### PR TITLE
feat: functional end-to-end testing environment

### DIFF
--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activity-apiserver
+  namespace: activity-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: activity-apiserver
+  template:
+    metadata:
+      labels:
+        app: activity-apiserver
+    spec:
+      serviceAccountName: activity-apiserver
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: apiserver
+        image: ghcr.io/datum-cloud/activity:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        command:
+        - /activity
+        - serve
+        args:
+        - --secure-port=$(SECURE_PORT)
+        - --tls-cert-file=$(TLS_CERT_FILE)
+        - --tls-private-key-file=$(TLS_PRIVATE_KEY_FILE)
+        - --clickhouse-address=$(CLICKHOUSE_ADDRESS)
+        - --clickhouse-database=$(CLICKHOUSE_DATABASE)
+        - --clickhouse-table=$(CLICKHOUSE_TABLE)
+        - --clickhouse-username=$(CLICKHOUSE_USERNAME)
+        - --clickhouse-password=$(CLICKHOUSE_PASSWORD)
+        - --authentication-tolerate-lookup-failure=$(AUTHENTICATION_TOLERATE_LOOKUP_FAILURE)
+        - --authorization-always-allow-paths=$(AUTHORIZATION_ALWAYS_ALLOW_PATHS)
+        - --logging-format=$(LOGGING_FORMAT)
+        - --tracing-config-file=$(TRACING_CONFIG_FILE)
+        env:
+        - name: SECURE_PORT
+          value: "8443"
+        - name: TLS_CERT_FILE
+          value: "/var/run/activity-apiserver/tls/tls.crt"
+        - name: TLS_PRIVATE_KEY_FILE
+          value: "/var/run/activity-apiserver/tls/tls.key"
+        - name: AUTHENTICATION_TOLERATE_LOOKUP_FAILURE
+          value: "false"
+        - name: AUTHORIZATION_ALWAYS_ALLOW_PATHS
+          value: "/healthz,/readyz,/livez"
+        - name: LOGGING_FORMAT
+          value: "json"
+        - name: TRACING_CONFIG_FILE
+          value: ""
+        - name: CLICKHOUSE_ADDRESS
+          value: "clickhouse.activity-system.svc.cluster.local:9000"
+        - name: CLICKHOUSE_DATABASE
+          value: "audit"
+        - name: CLICKHOUSE_TABLE
+          value: "events"
+        - name: CLICKHOUSE_USERNAME
+          value: "default"
+        - name: CLICKHOUSE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: clickhouse-credentials
+              key: password
+              optional: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - name: tls-certs
+          mountPath: /var/run/activity-apiserver/tls
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tls-certs
+        csi:
+          driver: csi.cert-manager.io
+          readOnly: true
+          volumeAttributes:
+            csi.cert-manager.io/issuer-name: selfsigned-cluster-issuer
+            csi.cert-manager.io/issuer-kind: ClusterIssuer
+            csi.cert-manager.io/common-name: activity-apiserver.activity-system.svc
+            csi.cert-manager.io/dns-names: "activity-apiserver,activity-apiserver.activity-system,activity-apiserver.activity-system.svc,activity-apiserver.activity-system.svc.cluster.local"
+            csi.cert-manager.io/duration: "8760h"
+            csi.cert-manager.io/renew-before: "720h"
+            csi.cert-manager.io/fs-group: "65532"
+      - name: tmp
+        emptyDir: {}

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: activity-system
+
+resources:
+  - serviceaccount.yaml
+  - deployment.yaml
+  - service.yaml
+  - secret.yaml
+  - rbac-auth-reader.yaml
+  - rbac-cluster.yaml
+
+labels:
+  - includeSelectors: true
+    includeTemplates: true
+    pairs:
+      app.kubernetes.io/name: activity
+      app.kubernetes.io/instance: activity-apiserver
+      app.kubernetes.io/component: apiserver
+      app.kubernetes.io/part-of: activity.miloapis.com
+      app.kubernetes.io/managed-by: kustomize
+
+# Images (will be replaced by overlays for different environments)
+images:
+  - name: ghcr.io/datum-cloud/activity
+    newTag: latest
+
+# JSON patches to ensure rbac-auth-reader stays in kube-system
+# These are applied AFTER all other transformations
+patches:
+  - target:
+      kind: RoleBinding
+      name: activity-apiserver-auth-reader
+    patch: |-
+      - op: replace
+        path: /metadata/namespace
+        value: kube-system
+      - op: replace
+        path: /subjects/0/namespace
+        value: activity-system

--- a/config/base/rbac-auth-reader.yaml
+++ b/config/base/rbac-auth-reader.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: activity-apiserver-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: activity-apiserver
+  namespace: activity-system

--- a/config/base/rbac-cluster.yaml
+++ b/config/base/rbac-cluster.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: activity-apiserver
+rules:
+# Allow reading extension-apiserver-authentication configmap for authentication
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["extension-apiserver-authentication"]
+  verbs: ["get", "list", "watch"]
+# Allow reading flow control resources for API Priority and Fairness
+- apiGroups: ["flowcontrol.apiserver.k8s.io"]
+  resources: ["flowschemas", "prioritylevelconfigurations"]
+  verbs: ["get", "list", "watch"]
+# Allow creating subjectaccessreviews for authorization checks
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: activity-apiserver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: activity-apiserver
+subjects:
+- kind: ServiceAccount
+  name: activity-apiserver
+  namespace: activity-system

--- a/config/base/secret.yaml
+++ b/config/base/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: clickhouse-credentials
+  namespace: activity-system
+  labels:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: activity.miloapis.com
+type: Opaque
+stringData:
+  password: ""

--- a/config/base/service.yaml
+++ b/config/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: activity-apiserver
+  namespace: activity-system
+spec:
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 443
+    targetPort: 8443
+    protocol: TCP
+  selector:
+    app: activity-apiserver

--- a/config/base/serviceaccount.yaml
+++ b/config/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: activity-apiserver
+  namespace: activity-system

--- a/config/components/README.md
+++ b/config/components/README.md
@@ -1,0 +1,28 @@
+# Kustomize Components
+
+Optional components that can be selectively included in overlays.
+
+## Available Components
+
+- **namespace** - Creates the activity-system namespace
+- **api-registration** - Kubernetes API aggregation (APIService registration)
+- **cert-manager-ca** - CA infrastructure for TLS certificates
+- **clickhouse-database** - ClickHouse database deployment
+- **clickhouse-migrations** - Database schema migrations
+- **grafana-clickhouse** - Grafana datasource configuration
+- **nats-streams** - NATS JetStream configuration
+- **observability** - ServiceMonitors, alerts, and dashboards
+- **rustfs-bucket** - S3-compatible object storage
+- **tracing** - OpenTelemetry distributed tracing
+- **vector-aggregator** - Vector aggregator for log processing
+- **vector-sidecar** - Vector sidecar for audit log collection
+
+## Usage
+
+Include components in your overlay's `kustomization.yaml`:
+
+```yaml
+components:
+  - ../../components/cert-manager-ca
+  - ../../components/clickhouse-database
+```

--- a/config/components/api-registration/apiservice.yaml
+++ b/config/components/api-registration/apiservice.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.activity.miloapis.com
+spec:
+  service:
+    name: activity-apiserver
+    namespace: activity-system
+    port: 443
+  group: activity.miloapis.com
+  version: v1alpha1
+  insecureSkipTLSVerify: false
+  groupPriorityMinimum: 1000
+  versionPriority: 15

--- a/config/components/api-registration/kustomization.yaml
+++ b/config/components/api-registration/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - apiservice.yaml

--- a/config/components/cert-manager-ca/ca-certificate.yaml
+++ b/config/components/cert-manager-ca/ca-certificate.yaml
@@ -1,0 +1,22 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: activity-ca
+  namespace: activity-system
+spec:
+  isCA: true
+  secretName: activity-ca-secret
+  duration: 87600h  # 10 years
+  renewBefore: 8760h  # 1 year before expiration
+  subject:
+    organizations:
+      - datum-technology
+  commonName: Activity Internal CA
+  # Use a self-signed issuer to bootstrap the CA
+  # This should reference an existing cluster-wide self-signed issuer
+  issuerRef:
+    name: selfsigned-cluster-issuer
+    kind: ClusterIssuer
+  privateKey:
+    algorithm: RSA
+    size: 4096

--- a/config/components/cert-manager-ca/issuer.yaml
+++ b/config/components/cert-manager-ca/issuer.yaml
@@ -1,0 +1,9 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: activity-ca-issuer
+  namespace: activity-system
+spec:
+  ca:
+    # Reference the secret created by the CA Certificate
+    secretName: activity-ca-secret

--- a/config/components/cert-manager-ca/kustomization.yaml
+++ b/config/components/cert-manager-ca/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ca-certificate.yaml
+  - issuer.yaml
+
+# Patches to update the deployment to use the namespaced CA issuer
+patches:
+  - target:
+      kind: Deployment
+      name: activity-apiserver
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/volumes/0/csi/volumeAttributes/csi.cert-manager.io~1issuer-name
+        value: activity-ca-issuer
+      - op: replace
+        path: /spec/template/spec/volumes/0/csi/volumeAttributes/csi.cert-manager.io~1issuer-kind
+        value: Issuer

--- a/config/components/grafana-clickhouse/clickhouse-datasource.yaml
+++ b/config/components/grafana-clickhouse/clickhouse-datasource.yaml
@@ -1,0 +1,38 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: clickhouse-datasource
+  labels:
+    dashboards: grafana
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasource:
+    name: ClickHouse
+    type: grafana-clickhouse-datasource
+    access: proxy
+    uid: clickhouse-datasource
+    editable: false
+    isDefault: false
+    jsonData:
+      # ClickHouse server configuration
+      server: clickhouse.activity-system.svc.cluster.local
+      port: 9000
+      protocol: native
+      secure: false
+      # Default database
+      defaultDatabase: audit
+      # Connection settings
+      dialTimeout: "10"
+      queryTimeout: 60
+      # Enable additional features
+      logs:
+        defaultDatabase: audit
+        defaultTable: events
+      traces:
+        enabled: false
+  plugins:
+    - name: grafana-clickhouse-datasource
+      version: 4.11.2

--- a/config/components/grafana-clickhouse/kustomization.yaml
+++ b/config/components/grafana-clickhouse/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - clickhouse-datasource.yaml

--- a/config/components/namespace/kustomization.yaml
+++ b/config/components/namespace/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - namespace.yaml

--- a/config/components/namespace/namespace.yaml
+++ b/config/components/namespace/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: activity-system

--- a/config/components/nats-streams/audit-stream.yaml
+++ b/config/components/nats-streams/audit-stream.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: audit-events
+  namespace: nats-system
+spec:
+  # Stream name in NATS
+  name: AUDIT_EVENTS
+
+  # Subjects to consume - wildcard for all Kubernetes audit events
+  subjects:
+    - audit.k8s.>
+
+  # Retention policy: limits-based (time + size)
+  retention: limits
+
+  # Storage: file-based for durability
+  storage: file
+
+  # Maximum age: 7 days retention as per architecture
+  maxAge: 168h  # 7 days = 168 hours
+
+  # Maximum bytes: 100GB as per architecture
+  maxBytes: 107374182400  # 100 * 1024 * 1024 * 1024
+
+  # Number of replicas for high availability
+  replicas: 1  # Can be increased to 3 for production HA
+
+  # Discard policy when limits are reached
+  discard: old
+
+  # Allow direct access for queries
+  allowDirect: true
+
+  # Deduplication window - prevents duplicate messages
+  duplicateWindow: 2m
+
+  # Maximum number of consumers
+  maxConsumers: 10
+
+  # Maximum message size (10MB - large enough for batch audit events)
+  maxMsgSize: 10485760  # 10 * 1024 * 1024
+
+  # No message limit - rely on age and size limits
+  maxMsgs: -1
+
+  # Performance tuning
+  noAck: false  # Require acknowledgments for durability

--- a/config/components/nats-streams/clickhouse-consumer.yaml
+++ b/config/components/nats-streams/clickhouse-consumer.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Consumer
+metadata:
+  name: clickhouse-ingest
+  namespace: nats-system
+spec:
+  # Link to the stream
+  streamName: AUDIT_EVENTS
+
+  # Durable consumer name
+  durableName: clickhouse-ingest
+
+  # Delivery policy: deliver all messages (including historical)
+  deliverPolicy: all
+
+  # Ack policy: explicit acknowledgments required
+  ackPolicy: explicit
+
+  # Replay policy: instant (process as fast as possible)
+  replayPolicy: instant
+
+  # Filter subject: all audit events
+  filterSubject: audit.k8s.>
+
+  # Max delivery attempts: unlimited (-1)
+  maxDeliver: -1
+
+  # Max ack pending: allow 10000 unacknowledged messages
+  # Vector pulls in batches of 1000, so this allows multiple batches in-flight
+  maxAckPending: 10000
+
+  # Ack wait: 60 seconds before redelivery
+  # Vector v0.50.0+ properly acknowledges messages after successful processing
+  # This timeout handles cases where Vector crashes during processing
+  ackWait: 60s
+
+  # PULL-based consumer (no deliverSubject)
+  # Vector will pull messages directly using JetStream pull consumer protocol
+  # Messages are acknowledged only after successful delivery to ClickHouse

--- a/config/components/nats-streams/kustomization.yaml
+++ b/config/components/nats-streams/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: nats-system
+
+resources:
+  - audit-stream.yaml
+  - clickhouse-consumer.yaml
+
+# Note: This contains application-specific NATS JetStream stream configurations.
+# The NATS infrastructure (server + NACK controller) is deployed from config/dependencies/nats/

--- a/config/components/tracing/configmap.yaml
+++ b/config/components/tracing/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: activity-tracing-config
+  namespace: activity-system
+data:
+  config.yaml: |
+    apiVersion: apiserver.config.k8s.io/v1beta1
+    kind: TracingConfiguration
+    # OTLP gRPC endpoint for trace export
+    endpoint: "telemetry-system-tempo.telemetry-system.svc.cluster.local:4317"
+    # Sampling rate: 100000 = 100% of traces (1,000,000 per million)
+    #
+    # Adjust based on environment:
+    # - Development: 1000000 (100%)
+    # - Staging: 100000 (10%)
+    # - Production: 10000 (1%)
+    samplingRatePerMillion: 1000000

--- a/config/components/tracing/deployment-patch.yaml
+++ b/config/components/tracing/deployment-patch.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activity-apiserver
+  namespace: activity-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: apiserver
+        # Mount the tracing configuration
+        volumeMounts:
+        - name: tracing-config
+          mountPath: /etc/kubernetes/tracing
+          readOnly: true
+        # Add tracing config file environment variable and pod metadata
+        env:
+        - name: TRACING_CONFIG_FILE
+          value: "/etc/kubernetes/tracing/config.yaml"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "k8s.cluster.name=test-infra,k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME)"
+      volumes:
+      - name: tracing-config
+        configMap:
+          name: activity-tracing-config

--- a/config/components/tracing/kustomization.yaml
+++ b/config/components/tracing/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - configmap.yaml
+
+patches:
+  - path: deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: activity-apiserver

--- a/config/components/vector-aggregator/helmrepository.yaml
+++ b/config/components/vector-aggregator/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: vector
+  namespace: activity-system
+spec:
+  interval: 1h
+  url: https://helm.vector.dev

--- a/config/components/vector-aggregator/kustomization.yaml
+++ b/config/components/vector-aggregator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - helmrepository.yaml
+  - vector-hr.yaml

--- a/config/components/vector-aggregator/vector-hr.yaml
+++ b/config/components/vector-aggregator/vector-hr.yaml
@@ -1,0 +1,176 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vector-aggregator
+  namespace: activity-system
+spec:
+  interval: 1h
+  timeout: 1m
+  chart:
+    spec:
+      chart: vector
+      version: 0.49.x
+      sourceRef:
+        kind: HelmRepository
+        name: vector
+        namespace: activity-system
+      interval: 1h
+  values:
+    # Role: Aggregator (stateless, can run as Deployment)
+    role: Stateless-Aggregator
+    replicas: 2
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: 80
+    service:
+      enabled: true
+      type: ClusterIP
+      ports:
+        - name: metrics
+          port: 9090
+          protocol: TCP
+    podMonitor:
+      enabled: true
+      port: internal-promet
+    customConfig:
+      data_dir: /vector-data-dir
+
+      # API for health checks
+      api:
+        enabled: true
+        address: 0.0.0.0:8686
+
+      sources:
+        # NATS JetStream consumer (pull-based with proper acknowledgements)
+        # Vector v0.50.0+ supports JetStream with automatic message acknowledgement
+        # Messages are only ACKed after successful processing through the entire pipeline
+        nats_consumer:
+          type: nats
+          connection_name: vector-aggregator
+          url: nats://nats.nats-system.svc.cluster.local:4222
+
+          # Subject filter (required even with JetStream)
+          # This filters which messages from the stream to consume
+          subject: audit.k8s.>
+
+          # JetStream configuration (enables pull-based consumption with ACKs)
+          jetstream:
+            # Name of the JetStream stream to consume from
+            stream: AUDIT_EVENTS
+            # Name of the durable consumer (must be pre-created)
+            consumer: clickhouse-ingest
+
+            batch_config:
+              batch: 1000
+              # Maximum 10MB per batch
+              max_bytes: 10485760
+          decoding:
+            codec: json
+        internal_metrics:
+          type: internal_metrics
+          namespace: vector
+      transforms:
+        # Filter to ResponseComplete stage only (recommended strategy for 75% data reduction)
+        # This reduces storage and query costs while keeping all necessary audit information
+        filter_response_complete:
+          type: filter
+          inputs:
+            - nats_consumer
+          condition:
+            type: vrl
+            source: |
+              .stage == "ResponseComplete"
+
+        # Prepare events for ClickHouse
+        prepare_for_clickhouse:
+          type: remap
+          inputs:
+            - filter_response_complete
+          source: |
+            # Wrap entire event as event_json for ClickHouse
+            .event_json = encode_json(.)
+            . = {
+              "event_json": .event_json
+            }
+
+      sinks:
+        # Export audit events to clickhouse
+        clickhouse:
+          type: clickhouse
+          inputs:
+            - prepare_for_clickhouse
+          endpoint: http://clickhouse.activity-system.svc.cluster.local:8123
+          database: audit
+          table: events
+          encoding:
+            only_fields:
+              - event_json
+          batch:
+            max_bytes: 10485760
+            max_events: 10000
+            timeout_secs: 10
+          buffer:
+            type: disk
+            max_size: 10737418240
+            when_full: block
+          request:
+            retry_attempts: 9999999
+            retry_initial_backoff_secs: 1
+            retry_max_duration_secs: 300
+            timeout_secs: 60
+          healthcheck:
+            enabled: true
+          compression: gzip
+
+        # Export metrics over prometheus
+        internal_prometheus:
+          type: prometheus_exporter
+          inputs:
+            - internal_metrics
+          address: 0.0.0.0:9091
+          default_namespace: vector_internal
+
+    env:
+      - name: CLICKHOUSE_USERNAME
+        value: "default"
+      - name: CLICKHOUSE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: clickhouse-credentials
+            key: password
+            optional: true
+      - name: VECTOR_LOG
+        value: "info"
+      - name: VECTOR_LOG_FORMAT
+        value: "json"
+
+    # Persistence for buffer
+    persistence:
+      enabled: true
+      storageClassName: ""  # Use default storage class
+      accessModes:
+        - ReadWriteOnce
+      size: 10Gi
+
+  install:
+    crds: Create
+    createNamespace: false
+
+  upgrade:
+    crds: CreateReplace
+
+  uninstall:
+    keepHistory: false

--- a/config/components/vector-sidecar/helmrepository.yaml
+++ b/config/components/vector-sidecar/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: vector-sidecar
+  namespace: activity-system
+spec:
+  interval: 1h
+  url: https://helm.vector.dev

--- a/config/components/vector-sidecar/kustomization.yaml
+++ b/config/components/vector-sidecar/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - helmrepository.yaml
+  - vector-sidecar-hr.yaml

--- a/config/components/vector-sidecar/vector-sidecar-hr.yaml
+++ b/config/components/vector-sidecar/vector-sidecar-hr.yaml
@@ -1,0 +1,158 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vector-sidecar
+  namespace: activity-system
+spec:
+  interval: 5m
+  timeout: 1m
+
+  chart:
+    spec:
+      chart: vector
+      version: 0.49.x
+      sourceRef:
+        kind: HelmRepository
+        name: vector-sidecar
+        namespace: activity-system
+      interval: 1h
+
+  values:
+    role: Agent
+    daemonset:
+      enabled: true
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+    podMonitor:
+      enabled: true
+      port: internal-promet
+
+    service:
+      enabled: true
+      type: ClusterIP
+      ports:
+        - name: metrics
+          port: 9090
+          protocol: TCP
+        - name: webhook
+          port: 8080
+          protocol: TCP
+
+    customConfig:
+      data_dir: /vector-data-dir
+
+      api:
+        enabled: true
+        address: 0.0.0.0:8686
+
+      sources:
+        # Webhook endpoint for receiving logs via HTTP
+        webhook:
+          type: http_server
+          address: 0.0.0.0:8080
+          path: /events
+          strict_path: true
+          decoding:
+            codec: json
+          framing:
+            method: bytes
+
+        internal_metrics:
+          type: internal_metrics
+          namespace: vector
+
+      transforms:
+        # Extract individual events from webhook EventList batch
+        # The Kubernetes API server webhook sends batches in this format:
+        # {
+        #   "kind": "EventList",
+        #   "apiVersion": "audit.k8s.io/v1",
+        #   "items": [
+        #     { "kind": "Event", ... },
+        #     { "kind": "Event", ... }
+        #   ]
+        # }
+        # This transform splits the items array into individual events
+        parse_webhook_batch:
+          type: remap
+          inputs:
+            - webhook
+          source: |
+            # Check if this is an EventList batch from Kubernetes webhook
+            if exists(.kind) && .kind == "EventList" && exists(.items) {
+              # Extract the items array and emit each item as a separate event
+              . = unnest!(.items)
+            }
+
+        # Add source metadata
+        add_source_metadata:
+          type: remap
+          inputs:
+            - parse_webhook_batch
+          source: |
+            .source = "webhook"
+            .cluster = get_env_var!("CLUSTER_NAME")
+
+      sinks:
+        # Publish to NATS JetStream
+        nats_jetstream:
+          type: nats
+          inputs:
+            - add_source_metadata
+          url: nats://nats.nats-system.svc.cluster.local:4222
+          connection_name: vector-sidecar
+          subject: audit.k8s.activity
+          encoding:
+            codec: json
+          healthcheck:
+            enabled: true
+
+          # Buffer for durability
+          # 10GB disk buffer to survive NATS outages
+          buffer:
+            type: disk
+            max_size: 10737418240
+            when_full: block
+
+        internal_prometheus:
+          type: prometheus_exporter
+          inputs:
+            - internal_metrics
+          address: 0.0.0.0:9091
+          default_namespace: vector_internal
+
+    env:
+      - name: CLUSTER_NAME
+        value: "default"
+      - name: VECTOR_LOG
+        value: "info"
+      - name: VECTOR_LOG_FORMAT
+        value: "json"
+
+    persistence:
+      enabled: true
+      storageClassName: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 15Gi
+
+    extraVolumes: []
+    extraVolumeMounts: []
+
+  install:
+    crds: Create
+    createNamespace: false
+
+  upgrade:
+    crds: CreateReplace
+
+  uninstall:
+    keepHistory: false

--- a/config/dependencies/nats/helmrepository.yaml
+++ b/config/dependencies/nats/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: nats
+  namespace: nats-system
+spec:
+  interval: 1h
+  url: https://nats-io.github.io/k8s/helm/charts/

--- a/config/dependencies/nats/kustomization.yaml
+++ b/config/dependencies/nats/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: nats-system
+
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - nats-hr.yaml         # NATS JetStream server
+  - nack-hr.yaml         # NACK controller for CRD-based stream management
+
+# Note: This deploys the NATS infrastructure (server + controller).
+# Application-specific stream configurations are in config/components/nats-streams/
+# The old Job-based approach (stream-audit-events.yaml and stream-setup-job.yaml)
+# is deprecated in favor of the CRD-based approach.

--- a/config/dependencies/nats/nack-hr.yaml
+++ b/config/dependencies/nats/nack-hr.yaml
@@ -1,0 +1,49 @@
+---
+# Note: HelmRepository is defined in helmrepository.yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nack
+  namespace: nats-system
+spec:
+  interval: 5m
+  timeout: 2m
+
+  chart:
+    spec:
+      chart: nack
+      version: 0.x  # Use latest 0.x version
+      sourceRef:
+        kind: HelmRepository
+        name: nats
+        namespace: nats-system
+      interval: 1h
+
+  # NACK values configuration
+  values:
+    # JetStream controller configuration
+    jetstream:
+      # NATS server connection URL
+      nats:
+        url: nats://nats.nats-system.svc.cluster.local:4222
+
+      # Enable control-loop mode for KV and Object store support
+      additionalArgs:
+        - --control-loop
+
+    # Resources for the controller
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
+    # RBAC settings
+    rbac:
+      create: true
+
+    serviceAccount:
+      create: true
+      name: nack-jetstream-controller

--- a/config/dependencies/nats/namespace.yaml
+++ b/config/dependencies/nats/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nats-system
+  labels:
+    app.kubernetes.io/name: nats
+    app.kubernetes.io/component: messaging

--- a/config/dependencies/nats/nats-hr.yaml
+++ b/config/dependencies/nats/nats-hr.yaml
@@ -1,0 +1,79 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nats
+  namespace: nats-system
+spec:
+  interval: 5m
+  timeout: 10m
+
+  chart:
+    spec:
+      chart: nats
+      version: 1.2.x  # Use latest 1.2.x version
+      sourceRef:
+        kind: HelmRepository
+        name: nats
+        namespace: nats-system
+      interval: 1h
+
+  # Helm values configuration
+  values:
+    # NATS configuration
+    config:
+      # JetStream configuration (CRITICAL)
+      jetstream:
+        enabled: true
+        fileStore:
+          dir: /data
+          pvc:
+            enabled: true
+            size: 100Gi
+            storageClassName: standard  # Adjust for your cluster
+
+        # Resource limits for JetStream
+        maxMemory: 1Gi
+        maxFile: 100Gi
+
+    # Cluster configuration
+    cluster:
+      enabled: false  # Single node for test-infra
+      replicas: 1
+
+    # Resource limits
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 2Gi
+
+    # Monitoring
+    promExporter:
+      enabled: true
+      port: 7777
+
+      # Enable PodMonitor for Prometheus Operator / Victoria Metrics Operator
+      podMonitor:
+        enabled: true
+        # Add labels to help with discovery
+        labels:
+          monitoring: "true"
+
+    # NATS Box for management
+    natsbox:
+      enabled: true  # Useful for testing/debugging
+
+  # Install CRDs if needed
+  install:
+    crds: Create
+    createNamespace: false
+
+  # Upgrade CRDs
+  upgrade:
+    crds: CreateReplace
+
+  # Uninstall configuration
+  uninstall:
+    keepHistory: false

--- a/config/overlays/test-infra/kustomization.yaml
+++ b/config/overlays/test-infra/kustomization.yaml
@@ -3,18 +3,43 @@ kind: Kustomization
 
 namespace: activity-system
 
-# Include components for test-infra (migrations only for now)
-components:
-  - ../../components/rustfs-bucket          # RustFS S3 bucket for ClickHouse cold storage
-  - ../../components/clickhouse-database    # ClickHouse database instance
-  - ../../components/clickhouse-migrations  # Database schema migrations
+# Base resources (API server, service, APIService, etc.)
+resources:
+  - ../../base
 
+components:
+  - ../../components/namespace
+  - ../../components/api-registration
+  - ../../components/cert-manager-ca
+  - ../../components/rustfs-bucket
+  - ../../components/clickhouse-database
+  - ../../components/clickhouse-migrations
+  - ../../components/grafana-clickhouse
+  - ../../components/vector-sidecar
+  - ../../components/vector-aggregator
+  - ../../components/observability
+  - ../../components/tracing
+
+# Note: NATS stream configuration (nats-streams) is in a different namespace (nats-system)
+# and must be applied separately. See dev:deploy task in Taskfile.yaml
+# Note: Vector sidecar is deployed to kube-system namespace
 # Note: RustFS bucket initialization job will create the S3 bucket on first deployment
+
+# Image overrides for test-infra environment
+images:
+  - name: ghcr.io/datum-cloud/activity
+    newName: ghcr.io/datum-cloud/activity
+    newTag: dev
 
 # Patches specific to test-infra environment
 patches:
-  - path: patches/clickhouse-storage-patch.yaml  # Configure ClickHouse to use RustFS
+  - path: patches/deployment-patch.yaml
+  - path: patches/apiservice-patch.yaml
+  - path: patches/vector-sidecar-patch.yaml
+  - path: patches/clickhouse-storage-patch.yaml
 
-# Additional labels for test-infra environment
-commonLabels:
-  environment: test-infra
+labels:
+  - includeSelectors: true
+    includeTemplates: true
+    pairs:
+      environment: test-infra

--- a/config/overlays/test-infra/patches/apiservice-patch.yaml
+++ b/config/overlays/test-infra/patches/apiservice-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.activity.miloapis.com
+spec:
+  # Skip TLS verification in test-infra environment
+  insecureSkipTLSVerify: true

--- a/config/overlays/test-infra/patches/deployment-patch.yaml
+++ b/config/overlays/test-infra/patches/deployment-patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activity-apiserver
+  namespace: activity-system
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: apiserver
+        # Test-infra specific configuration
+        imagePullPolicy: Never  # Use images loaded via kind load
+        env:
+        - name: LOG_LEVEL
+          value: "debug"
+        - name: ENABLE_DEBUG_ENDPOINTS
+          value: "true"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi

--- a/config/overlays/test-infra/patches/vector-sidecar-patch.yaml
+++ b/config/overlays/test-infra/patches/vector-sidecar-patch.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vector-sidecar
+  namespace: activity-system
+spec:
+  values:
+    env:
+      - name: CLUSTER_NAME
+        value: "test-infra"
+      - name: VECTOR_LOG
+        value: "info"
+      - name: VECTOR_LOG_FORMAT
+        value: "json"
+
+    extraVolumes:
+      - name: audit-logs
+        hostPath:
+          path: /var/log/kubernetes
+          type: DirectoryOrCreate
+
+    extraVolumeMounts:
+      - name: audit-logs
+        mountPath: /var/log/kubernetes
+        readOnly: true
+
+    customConfig:
+      sources:
+        # File-based audit log collection from kind cluster
+        apiserver_audit_logs:
+          type: file
+          include:
+            - /var/log/kubernetes/kube-apiserver-audit.log
+            - /var/log/kubernetes/kube-apiserver-audit.log.*
+          read_from: beginning
+          fingerprint:
+            strategy: device_and_inode
+          max_line_bytes: 1048576
+
+      transforms:
+        # Parse JSON from file lines
+        parse_json_from_file:
+          type: remap
+          inputs:
+            - apiserver_audit_logs
+          source: |
+            . = parse_json!(.message)
+
+        # Add source metadata to file events
+        add_file_source_metadata:
+          type: remap
+          inputs:
+            - parse_json_from_file
+          source: |
+            .source = "test-infra-apiserver"
+            .cluster = get_env_var!("CLUSTER_NAME")
+
+        # Update webhook metadata to merge both sources
+        add_source_metadata:
+          type: remap
+          inputs:
+            - parse_webhook_batch
+            - add_file_source_metadata
+          source: |
+            if !exists(.source) {
+              .source = "test-infra-webhook"
+            }
+            if !exists(.cluster) {
+              .cluster = get_env_var!("CLUSTER_NAME")
+            }


### PR DESCRIPTION
## Summary

This PR builds on datum-cloud/engineering#1 and datum-cloud/engineering#2 to introduce a complete and functional end-to-end testing environment for testing the new activity service in a [local kind cluster](https://kind.sigs.k8s.io). The test environment is built on top of a [test-infra] cluster that includes base services like flux, envoy gateway, and a telemetry stack. 

The test environment includes a [Vector](https://vector.dev), [NATS](https://nats.io), [Clickhouse](https://clickhouse.com) pipeline that automatically collects audit logs emitted from the test-infra kind cluster.

```mermaid
graph LR
    APIServer[Activity API Server<br/>Generates audit logs]
    Vector1[Vector Sidecar<br/>Publishes events]
    NATS[NATS JetStream<br/>Event storage & routing]
    Vector2[Vector Aggregator<br/>Batching & persistence]
    CH[ClickHouse<br/>Long-term storage]
    QueryAPI[Activity API Server<br/>Query interface]
    Client[Clients<br/>kubectl/API]

    APIServer -->|writes| Vector1
    Vector1 -->|publish| NATS
    NATS -->|push| Vector2
    Vector2 -->|insert| CH
    Client -->|query| QueryAPI
    QueryAPI -->|CEL → SQL| CH
    CH -->|results| QueryAPI

    style APIServer fill:#e1f5ff
    style NATS fill:#fff3e0
    style CH fill:#f3e5f5
    style QueryAPI fill:#e8f5e9
    style Vector1 fill:#fff9c4
    style Vector2 fill:#fff9c4
```

## Details

The apiserver deployment manifests are structured as a standard `base` kustomize deployment that includes the kubernetes Deployment, Service, and RBAC resources.

The following kustomize components have been introduced to provide optional functionality that can be enabled in environments when necessary.

- **api-registration**: Configures the APIService registration with the k8s apiserver to proxy requests to the activity apiserver
- **cert-manager-ca**: Configures a namespaced cert issuer to use with the activity apiserver
- **grafana-clickhouse**: Configures a new Grafana datasource to connect to the deployed clickhouse instance
- **namespace**: Creates a namespace to use for the system's deployment
- **nats-stream**: Creates a new nats JetStream to use for the audit log pipeline
- **tracing**: Configures the APIserver with a tracing configuration
- **vector-aggregator**: Deploys an aggregated version of Vector that ingests audit logs from NATS and writes them to Clickhouse
- **vector-sidecar**: Deployment of Vector that runs on every node in the cluster that's responsible for collecting audit logs from apiservers and writing them to NATS

Also included is deployment automation for deploying the system's dependencies:

- **[Clickhouse operator](https://github.com/Altinity/clickhouse-operator)**: Manages deployments of Clickhouse through CRDs
- **NATS**: Deploys an instance of NATS and [NACK](https://github.com/nats-io/nack) to configure NATS through CRDs

After deploying a fresh test environment, I used a [kubectl-plugin](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/) to query the activity API and retrieve audit logs that have been collected through the pipeline. 

```shell
▶ kubectl activity query --filter='objectRef.resource != "leases"' --limit 10
TIMESTAMP             VERB    USER                                                                                   NAMESPACE          RESOURCE             NAME                                     STATUS
2025-12-17 17:07:12   get     system:serviceaccount:kyverno:kyverno-background-controller                                                                                                             200
2025-12-17 17:07:11   get     system:anonymous                                                                                                                                                        200
2025-12-17 17:07:10   get     system:anonymous                                                                                                                                                        200
2025-12-17 17:07:10   get     system:serviceaccount:kyverno:kyverno-reports-controller                                                                                                                200
2025-12-17 17:07:10   get     system:serviceaccount:telemetry-system:telemetry-system-vm-victoria-metrics-operator   telemetry-system   secrets              tls-assets-vmalert-telemetry-system-vm   200
2025-12-17 17:07:10   get     system:serviceaccount:telemetry-system:telemetry-system-vm-victoria-metrics-operator   telemetry-system   secrets              vmalert-telemetry-system-vm              200
2025-12-17 17:07:10   get     system:serviceaccount:telemetry-system:telemetry-system-vm-victoria-metrics-operator   telemetry-system   configmaps           vm-telemetry-system-vm-rulefiles-0       200
2025-12-17 17:07:10   watch   system:serviceaccount:telemetry-system:telemetry-system-vm-victoria-metrics-operator                      daemonsets                                                    200
2025-12-17 17:07:10   watch   system:serviceaccount:kyverno:kyverno-admission-controller                                                generatingpolicies                                            200
2025-12-17 17:07:10   watch   system:serviceaccount:flux-system:image-reflector-controller                                              imagepolicies                                                 200

More results available. Use --continue-after 'eyJ0IjoiMjAyNS0xMi0xN1QyMzowNzoxMC4yNTA5NjhaIiwiYSI6IjJlZTJhMDgwLTAzYmMtNDk3Yi1hYjliLWU4ODQyZjBkMzY2NyIsImgiOiJDZ1FrUHh5S2NCT2NkTEUyNm9meDhBPT0iLCJpIjoiMjAyNS0xMi0xN1QyMzowNzoxNC4wNzYwOTU1NDRaIn0=' to get the next page.
Or use --all-pages to fetch all results automatically.
``` 

Here's a dashboard I'm working on that was loaded into the local environment to visualize the health and performance of the pipeline. The source for this dashboard will be included in a follow up PR. 

<img width="1385" height="1221" alt="image" src="https://github.com/user-attachments/assets/4328f182-d167-4565-a7e7-9703419c2b48" />


[test-infra]: https://github.com/datum-cloud/test-infra

## Up Next

- CI pipeline integration w/ end-to-end testing
- CLI package for interacting with the new activity audit log querying API w/ [kubectl plugin](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/)
- Operational dashboards & performance testing

--- 

Relates to https://github.com/datum-cloud/enhancements/issues/536