### PR TITLE
fix: use tagged test-infra repo for taskfile

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,7 +7,7 @@ vars:
   ACTIVITY_IMAGE_TAG: "dev"
   TEST_INFRA_CLUSTER_NAME: "test-infra"
   # Test infra repository configuration - can be overridden with environment variable
-  TEST_INFRA_REPO_REF: 'feat/global-grafana-watch'
+  TEST_INFRA_REPO_REF: 'v0.6.0'
   # ClickHouse configuration for testing
   CLICKHOUSE_DATABASE: "audit"
   CLICKHOUSE_TABLE: "events"


### PR DESCRIPTION
Adjusts the task file to use the new [v0.6.0 test-infra release](https://github.com/datum-cloud/test-infra/releases/tag/v0.6.0) that contains the audit log policy changes for the activity system to automatically ingest audit logs from the test-infra cluster. 