### PR TITLE
feat: securely connect apiserver to clickhouse

### DIFF
--- a/cmd/activity/main.go
+++ b/cmd/activity/main.go
@@ -129,6 +129,12 @@ type ActivityServerOptions struct {
 	ClickHousePassword string
 	ClickHouseTable    string
 
+	// TLS configuration for ClickHouse connection
+	ClickHouseTLSEnabled  bool
+	ClickHouseTLSCertFile string
+	ClickHouseTLSKeyFile  string
+	ClickHouseTLSCAFile   string
+
 	MaxQueryWindow time.Duration // Maximum time range allowed for queries
 	MaxPageSize    int32         // Maximum number of results per page
 }
@@ -172,6 +178,15 @@ func (o *ActivityServerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Password for ClickHouse authentication")
 	fs.StringVar(&o.ClickHouseTable, "clickhouse-table", o.ClickHouseTable,
 		"Table containing audit events")
+
+	fs.BoolVar(&o.ClickHouseTLSEnabled, "clickhouse-tls-enabled", o.ClickHouseTLSEnabled,
+		"Enable TLS for ClickHouse connection")
+	fs.StringVar(&o.ClickHouseTLSCertFile, "clickhouse-tls-cert-file", o.ClickHouseTLSCertFile,
+		"Path to client certificate file for ClickHouse TLS")
+	fs.StringVar(&o.ClickHouseTLSKeyFile, "clickhouse-tls-key-file", o.ClickHouseTLSKeyFile,
+		"Path to client private key file for ClickHouse TLS")
+	fs.StringVar(&o.ClickHouseTLSCAFile, "clickhouse-tls-ca-file", o.ClickHouseTLSCAFile,
+		"Path to CA certificate file for ClickHouse TLS")
 
 	fs.DurationVar(&o.MaxQueryWindow, "max-query-window", o.MaxQueryWindow,
 		"Maximum time range for a single query (e.g., 720h for 30 days)")
@@ -234,6 +249,10 @@ func (o *ActivityServerOptions) Config() (*activityapiserver.Config, error) {
 				Username:       o.ClickHouseUsername,
 				Password:       o.ClickHousePassword,
 				Table:          o.ClickHouseTable,
+				TLSEnabled:     o.ClickHouseTLSEnabled,
+				TLSCertFile:    o.ClickHouseTLSCertFile,
+				TLSKeyFile:     o.ClickHouseTLSKeyFile,
+				TLSCAFile:      o.ClickHouseTLSCAFile,
 				MaxQueryWindow: o.MaxQueryWindow,
 				MaxPageSize:    o.MaxPageSize,
 			},

--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -49,6 +49,10 @@ spec:
         - --clickhouse-table=$(CLICKHOUSE_TABLE)
         - --clickhouse-username=$(CLICKHOUSE_USERNAME)
         - --clickhouse-password=$(CLICKHOUSE_PASSWORD)
+        - --clickhouse-tls-enabled=$(CLICKHOUSE_TLS_ENABLED)
+        - --clickhouse-tls-cert-file=$(CLICKHOUSE_TLS_CERT_FILE)
+        - --clickhouse-tls-key-file=$(CLICKHOUSE_TLS_KEY_FILE)
+        - --clickhouse-tls-ca-file=$(CLICKHOUSE_TLS_CA_FILE)
         - --authentication-tolerate-lookup-failure=$(AUTHENTICATION_TOLERATE_LOOKUP_FAILURE)
         - --authorization-always-allow-paths=$(AUTHORIZATION_ALWAYS_ALLOW_PATHS)
         - --logging-format=$(LOGGING_FORMAT)
@@ -82,6 +86,14 @@ spec:
               name: clickhouse-credentials
               key: password
               optional: true
+        - name: CLICKHOUSE_TLS_ENABLED
+          value: "false"
+        - name: CLICKHOUSE_TLS_CERT_FILE
+          value: ""
+        - name: CLICKHOUSE_TLS_KEY_FILE
+          value: ""
+        - name: CLICKHOUSE_TLS_CA_FILE
+          value: ""
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
This change introduces the ability for the [activity-apiserver](https://github.com/datum-cloud/activity/blob/main/docs/components/apiserver-architecture.md) to connect to a clickhouse database using a secure connection. A client certificate is expected to be used to connect to clickhouse.

See [Clickhouse's Golang library docs](https://clickhouse.com/docs/integrations/go#using-tls) for more information. 

---

Relates to https://github.com/datum-cloud/enhancements/issues/536