### PR TITLE
feat: collect metrics from clickhouse databases

### DIFF
--- a/config/dependencies/clickhouse-operator/helmrelease.yaml
+++ b/config/dependencies/clickhouse-operator/helmrelease.yaml
@@ -55,6 +55,17 @@ spec:
           cpu: 200m
           memory: 256Mi
 
+    # ServiceMonitor for Prometheus Operator
+    serviceMonitor:
+      enabled: true
+      # Scrape interval for metrics
+      clickhouseMetrics:
+        interval: 30s
+        scrapeTimeout: 10s
+      operatorMetrics:
+        interval: 30s
+        scrapeTimeout: 10s
+
     # Configure operator watch namespaces directly in config.yaml
     configs:
       files:


### PR DESCRIPTION
This PR enables collecting clickhouse database metrics in the test environment. Confirmed I was able to query clickhouse metrics after this change was deployed.

<img width="1767" height="1175" alt="image" src="https://github.com/user-attachments/assets/916151d4-d88a-425b-88e3-90abd41167b0" />


---

Relates to https://github.com/datum-cloud/enhancements/issues/536