### PR TITLE
fix: adjust sidecar webhook processing

### DIFF
--- a/config/components/vector-sidecar/vector-sidecar-hr.yaml
+++ b/config/components/vector-sidecar/vector-sidecar-hr.yaml
@@ -89,24 +89,15 @@ spec:
             # Check if this is an EventList batch from Kubernetes webhook
             if exists(.kind) && .kind == "EventList" && exists(.items) {
               # Extract the items array and emit each item as a separate event
-              . = unnest!(.items)
+              . = .items
             }
-
-        # Add source metadata
-        add_source_metadata:
-          type: remap
-          inputs:
-            - parse_webhook_batch
-          source: |
-            .source = "webhook"
-            .cluster = get_env_var!("CLUSTER_NAME")
 
       sinks:
         # Publish to NATS JetStream
         nats_jetstream:
           type: nats
           inputs:
-            - add_source_metadata
+            - parse_webhook_batch
           url: nats://nats.nats-system.svc.cluster.local:4222
           connection_name: vector-sidecar
           subject: audit.k8s.activity


### PR DESCRIPTION
## Summary

This PR resolves an issue where a webhook batch wasn't being parsed correctly into individual audit log events that could be processed by the pipeline. This was resulting in clickhouse storing the entire batch of audit events in a single row. 

```json
{
  "kind": "EventList",
  "apiVersion": "audit.k8s.io/v1",
  "items": [
     { "kind": "Event", ... },
     { "kind": "Event", ... }
  ]
}
```

It's expected the pipeline will take the above batch of events sent to the webhook and convert it into individual logs:

```json
{ "kind": "Event", ... },
```

## Detail

The webhook processor should use the `.items` as the output from the stage because vector will automatically convert each array element into its own log entry. This will result in vector sending individual log events through the pipeline after this stage.

I also remove an unnecessary stage that was adding a source / cluster label to each log entry.


---

Relates to https://github.com/datum-cloud/enhancements/issues/536