### PR TITLE
feat: calculate pipeline delay

### DIFF
--- a/config/components/vector-aggregator/vector-hr.yaml
+++ b/config/components/vector-aggregator/vector-hr.yaml
@@ -83,12 +83,27 @@ spec:
           type: internal_metrics
           namespace: vector
       transforms:
+        # Ensure timestamp is set from stageTimestamp for accurate lag tracking
+        #
+        # Events from NATS should already have .timestamp set by the sidecar,
+        # but we ensure it here as a safety measure
+        set_event_timestamp:
+          type: remap
+          inputs:
+            - nats_consumer
+          source: |
+            # If timestamp wasn't set by sidecar, set it from stageTimestamp
+            # This is critical for vector_source_lag_time_seconds accuracy
+            if !exists(.timestamp) && exists(.stageTimestamp) {
+              .timestamp = parse_timestamp!(.stageTimestamp, format: "%+")
+            }
+
         # Filter to ResponseComplete stage only (recommended strategy for 75% data reduction)
         # This reduces storage and query costs while keeping all necessary audit information
         filter_response_complete:
           type: filter
           inputs:
-            - nats_consumer
+            - set_event_timestamp
           condition:
             type: vrl
             source: |

--- a/config/components/vector-sidecar/vector-sidecar-hr.yaml
+++ b/config/components/vector-sidecar/vector-sidecar-hr.yaml
@@ -92,12 +92,27 @@ spec:
               . = .items
             }
 
+        # Set event timestamp from audit log stageTimestamp
+        #
+        # This is critical for accurate lag metrics - Vector will use this timestamp
+        # to calculate source_lag_time_seconds
+        set_event_timestamp:
+          type: remap
+          inputs:
+            - parse_webhook_batch
+          source: |
+            # Parse stageTimestamp from the audit event and set as Vector's timestamp
+            # This allows Vector to calculate accurate lag metrics
+            if exists(.stageTimestamp) {
+              .timestamp = parse_timestamp!(.stageTimestamp, format: "%+")
+            }
+
       sinks:
         # Publish to NATS JetStream
         nats_jetstream:
           type: nats
           inputs:
-            - parse_webhook_batch
+            - set_event_timestamp
           url: nats://nats.nats-system.svc.cluster.local:4222
           connection_name: vector-sidecar
           subject: audit.k8s.activity

--- a/config/overlays/test-infra/patches/vector-sidecar-patch.yaml
+++ b/config/overlays/test-infra/patches/vector-sidecar-patch.yaml
@@ -47,11 +47,25 @@ spec:
           source: |
             . = parse_json!(.message)
 
+        # Set event timestamp from audit log stageTimestamp
+        # This is critical for accurate lag metrics - Vector will use this timestamp
+        # to calculate source_lag_time_seconds
+        set_event_timestamp:
+          type: remap
+          inputs:
+            - parse_json_from_file
+          source: |
+            # Parse stageTimestamp from the audit event and set as Vector's timestamp
+            # This allows Vector to calculate accurate lag metrics
+            if exists(.stageTimestamp) {
+              .timestamp = parse_timestamp!(.stageTimestamp, format: "%+")
+            }
+
         # Add source metadata to file events
         add_file_source_metadata:
           type: remap
           inputs:
-            - parse_json_from_file
+            - set_event_timestamp
           source: |
             .source = "test-infra-apiserver"
             .cluster = get_env_var!("CLUSTER_NAME")
@@ -68,4 +82,8 @@ spec:
             }
             if !exists(.cluster) {
               .cluster = get_env_var!("CLUSTER_NAME")
+            }
+            # Also set timestamp for webhook events
+            if !exists(.timestamp) && exists(.stageTimestamp) {
+              .timestamp = parse_timestamp!(.stageTimestamp, format: "%+")
             }


### PR DESCRIPTION
Configures the vector pipeline to use the audit log's `stageTimestamp` value for the event timestamp so vector can accurately calculate the delay of data moving through the pipeline.

---

Relates to https://github.com/datum-cloud/enhancements/issues/536