### PR TITLE
feat: add more validation for filtering

### DIFF
--- a/internal/cel/cel_test.go
+++ b/internal/cel/cel_test.go
@@ -193,6 +193,21 @@ func TestCELFilterCompilation(t *testing.T) {
 			filter:  "user.startsWith('system:')",
 			wantErr: true,
 		},
+		{
+			name:    "invalid field - objectRef.resources (should be resource singular)",
+			filter:  `objectRef.resources == "domains"`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid field - user.name (should be username)",
+			filter:  `user.name == "admin"`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid field - responseStatus.status (should be code)",
+			filter:  `responseStatus.status == 200`,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/registry/activity/auditlog/storage_test.go
+++ b/internal/registry/activity/auditlog/storage_test.go
@@ -444,6 +444,42 @@ func TestQueryStorage_Create_ValidationErrors(t *testing.T) {
 			},
 			wantError: "filter expression must return a boolean",
 		},
+		{
+			name: "invalid field name on objectRef (plural instead of singular)",
+			query: &v1alpha1.AuditLogQuery{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1alpha1.AuditLogQuerySpec{
+					StartTime: "now-1h",
+					EndTime:   "now",
+					Filter:    `objectRef.resources == "domains"`, // should be objectRef.resource (singular)
+				},
+			},
+			wantError: "field 'objectRef.resources' is not available for filtering",
+		},
+		{
+			name: "invalid field name on user",
+			query: &v1alpha1.AuditLogQuery{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1alpha1.AuditLogQuerySpec{
+					StartTime: "now-1h",
+					EndTime:   "now",
+					Filter:    `user.name == "admin"`, // should be user.username
+				},
+			},
+			wantError: "field 'user.name' is not available for filtering",
+		},
+		{
+			name: "invalid field name on responseStatus",
+			query: &v1alpha1.AuditLogQuery{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1alpha1.AuditLogQuerySpec{
+					StartTime: "now-1h",
+					EndTime:   "now",
+					Filter:    `responseStatus.status == 200`, // should be responseStatus.code
+				},
+			},
+			wantError: "field 'responseStatus.status' is not available for filtering",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Filtering with an unknown field on an object would lead to a "**503 Service Unavailable**" error instead of an "**Invalid request**" error.

This change adjusts the filter validation to confirm that all fields under an object are actually filterable fields so appropriate validation is returned.

**Current Behavior**:

> $ datumctl activity query --project datum-cloud --filter 'objectRef.resources == "test"' -v 6
...
I0120 12:36:20.074227   54523 round_trippers.go:632] "Response" verb="POST" url="https://api.staging.env.datum.net/apis/resourcemanager.miloapis.com/v1alpha1/projects/datum-cloud/control-plane/apis/activity.miloapis.com/v1alpha1/auditlogqueries" status="503 Service Unavailable" milliseconds=427
error: query failed: Failed to execute query. Please try again later or contact support for help.

**New Behavior**:

> $ datumctl activity query --project datum-cloud --filter 'objectRef.resources == "test"'     
error: query failed: AuditLogQuery.activity.miloapis.com "" is invalid: spec.filter: Invalid value: "objectRef.resources == \"test\"": Invalid filter: field 'objectRef.resources' is not available for filtering. Available fields for objectRef: [objectRef.resource objectRef.name objectRef.apiGroup objectRef.namespace]. Available fields: auditID, verb, requestReceivedTimestamp, objectRef.namespace, objectRef.resource, objectRef.name, user.username, user.groups, responseStatus.code. See https://cel.dev for CEL syntax

---

Relates to https://github.com/datum-cloud/enhancements/issues/536