### PR TITLE
feat: add CEL policy engine for activity filtering

### DIFF
--- a/internal/apierrors/validation.go
+++ b/internal/apierrors/validation.go
@@ -1,0 +1,81 @@
+package apierrors
+
+import (
+	"fmt"
+	"net/http"
+	"unicode"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// capitalizeFirst capitalizes the first letter of a string.
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	runes := []rune(s)
+	runes[0] = unicode.ToUpper(runes[0])
+	return string(runes)
+}
+
+// NewValidationError creates a user-friendly validation error that includes
+// structured field-level causes. The summary message provides a brief overview,
+// while clients should use the causes array for detailed field-level rendering.
+func NewValidationError(gk schema.GroupKind, name string, errs field.ErrorList) *metav1.Status {
+	causes := make([]metav1.StatusCause, 0, len(errs))
+	for _, err := range errs {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseType(err.Type),
+			Message: err.Detail,
+			Field:   err.Field,
+		})
+	}
+
+	// Summary message following error message best practices:
+	// 1. What went wrong
+	// 2. How to fix it
+	var message string
+	if len(errs) == 1 {
+		message = fmt.Sprintf("%s. Please correct this and try again.", capitalizeFirst(errs[0].Detail))
+	} else {
+		message = "Some fields are missing or invalid. See the error details for what needs to be corrected."
+	}
+
+	return &metav1.Status{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Status",
+		},
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusUnprocessableEntity,
+		Reason:  metav1.StatusReasonInvalid,
+		Message: message,
+		Details: &metav1.StatusDetails{
+			Group:  gk.Group,
+			Kind:   gk.Kind,
+			Name:   name,
+			Causes: causes,
+		},
+	}
+}
+
+// StatusError wraps a Status as an error.
+type StatusError struct {
+	ErrStatus metav1.Status
+}
+
+func (e *StatusError) Error() string {
+	return e.ErrStatus.Message
+}
+
+// Status returns the Status object.
+func (e *StatusError) Status() metav1.Status {
+	return e.ErrStatus
+}
+
+// NewValidationStatusError creates a StatusError with a user-friendly validation message.
+func NewValidationStatusError(gk schema.GroupKind, name string, errs field.ErrorList) *StatusError {
+	return &StatusError{ErrStatus: *NewValidationError(gk, name, errs)}
+}

--- a/internal/apierrors/validation_test.go
+++ b/internal/apierrors/validation_test.go
@@ -1,0 +1,94 @@
+package apierrors
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestNewValidationStatusError_MessageFormat(t *testing.T) {
+	gk := schema.GroupKind{Group: "activity.miloapis.com", Kind: "PolicyPreview"}
+
+	t.Run("single error includes detail and action in message", func(t *testing.T) {
+		errs := field.ErrorList{
+			field.Required(field.NewPath("spec", "inputs"),
+				"provide at least one audit log or event to test"),
+		}
+
+		statusErr := NewValidationStatusError(gk, "", errs)
+
+		expectedMsg := "Provide at least one audit log or event to test. Please correct this and try again."
+		if statusErr.Error() != expectedMsg {
+			t.Errorf("unexpected message:\ngot:  %s\nwant: %s", statusErr.Error(), expectedMsg)
+		}
+
+		// Single error should still have causes for field highlighting
+		status := statusErr.Status()
+		if len(status.Details.Causes) != 1 {
+			t.Errorf("expected 1 cause, got %d", len(status.Details.Causes))
+		}
+	})
+
+	t.Run("multiple errors directs to details", func(t *testing.T) {
+		errs := field.ErrorList{
+			field.Required(field.NewPath("spec", "policy", "resource", "apiGroup"),
+				"specify the API group of the resource this policy targets"),
+			field.Required(field.NewPath("spec", "policy", "resource", "kind"),
+				"specify the kind of resource this policy targets"),
+			field.Required(field.NewPath("spec", "inputs"),
+				"provide at least one audit log or event to test"),
+		}
+
+		statusErr := NewValidationStatusError(gk, "", errs)
+
+		// Message explains what's wrong and how to fix it
+		expectedMsg := "Some fields are missing or invalid. See the error details for what needs to be corrected."
+		if statusErr.Error() != expectedMsg {
+			t.Errorf("unexpected message:\ngot:  %s\nwant: %s", statusErr.Error(), expectedMsg)
+		}
+
+		// Verify causes contain the details for client rendering
+		status := statusErr.Status()
+		if len(status.Details.Causes) != 3 {
+			t.Errorf("expected 3 causes, got %d", len(status.Details.Causes))
+		}
+
+		// Verify each cause has field path and message
+		expectedCauses := []struct {
+			field   string
+			message string
+		}{
+			{"spec.policy.resource.apiGroup", "specify the API group of the resource this policy targets"},
+			{"spec.policy.resource.kind", "specify the kind of resource this policy targets"},
+			{"spec.inputs", "provide at least one audit log or event to test"},
+		}
+		for i, expected := range expectedCauses {
+			cause := status.Details.Causes[i]
+			if cause.Field != expected.field {
+				t.Errorf("cause[%d]: expected field %q, got %q", i, expected.field, cause.Field)
+			}
+			if cause.Message != expected.message {
+				t.Errorf("cause[%d]: expected message %q, got %q", i, expected.message, cause.Message)
+			}
+		}
+	})
+
+	t.Run("causes include error type for client categorization", func(t *testing.T) {
+		errs := field.ErrorList{
+			field.Required(field.NewPath("spec", "inputs"), "inputs required"),
+			field.Invalid(field.NewPath("spec", "policy", "match"), "bad expr", "invalid CEL"),
+			field.NotSupported(field.NewPath("spec", "type"), "foo", []string{"bar", "baz"}),
+		}
+
+		statusErr := NewValidationStatusError(gk, "", errs)
+		status := statusErr.Status()
+
+		expectedTypes := []string{"FieldValueRequired", "FieldValueInvalid", "FieldValueNotSupported"}
+		for i, expected := range expectedTypes {
+			if string(status.Details.Causes[i].Type) != expected {
+				t.Errorf("cause[%d]: expected type %q, got %q", i, expected, status.Details.Causes[i].Type)
+			}
+		}
+	})
+}

--- a/internal/cel/activity_filter.go
+++ b/internal/cel/activity_filter.go
@@ -1,0 +1,407 @@
+package cel
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+
+	"go.miloapis.com/activity/internal/metrics"
+	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
+)
+
+// ActivityFieldValidator implements FieldValidator for activity CEL expressions.
+type ActivityFieldValidator struct{}
+
+// ValidateSelectExpr validates field access for activity expressions.
+// Handles both single-level (spec.changeSource) and nested (spec.actor.name) field access.
+func (v *ActivityFieldValidator) ValidateSelectExpr(sel *expr.Expr_Select) error {
+	operand := sel.GetOperand()
+	if operand == nil {
+		return nil
+	}
+
+	// Handle nested field access like spec.actor.name
+	if nestedSel := operand.GetSelectExpr(); nestedSel != nil {
+		if baseIdent := nestedSel.GetOperand().GetIdentExpr(); baseIdent != nil {
+			baseName := baseIdent.GetName()
+			parentField := nestedSel.GetField()
+			field := sel.GetField()
+			fullPath := baseName + "." + parentField
+
+			if allowedFields, ok := activityValidFields[fullPath]; ok {
+				if !allowedFields[field] {
+					return fmt.Errorf("field '%s.%s' is not available for filtering", fullPath, field)
+				}
+			}
+		}
+		return nil
+	}
+
+	// Direct field access like spec.changeSource
+	if identExpr := operand.GetIdentExpr(); identExpr != nil {
+		baseObject := identExpr.GetName()
+		field := sel.GetField()
+
+		if allowedFields, ok := activityValidFields[baseObject]; ok {
+			if !allowedFields[field] {
+				return fmt.Errorf("field '%s.%s' is not available for filtering", baseObject, field)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ActivityFieldMapper implements FieldMapper for activity CEL expressions.
+type ActivityFieldMapper struct{}
+
+// MapIdentExpr maps bare identifiers to ClickHouse columns for activities.
+func (m *ActivityFieldMapper) MapIdentExpr(ident *expr.Expr_Ident) (string, error) {
+	switch ident.Name {
+	case "spec", "metadata":
+		return "", fmt.Errorf("field '%s' must be accessed with dot notation (e.g., spec.changeSource, metadata.namespace)", ident.Name)
+	default:
+		return "", fmt.Errorf("field '%s' is not available for filtering", ident.Name)
+	}
+}
+
+// MapSelectExpr maps field selectors to ClickHouse columns for activities.
+func (m *ActivityFieldMapper) MapSelectExpr(sel *expr.Expr_Select) (string, error) {
+	operand := sel.GetOperand()
+	if operand == nil {
+		return "", fmt.Errorf("select expression missing operand")
+	}
+
+	field := sel.GetField()
+
+	// Check for nested select (e.g., spec.actor.name)
+	if nestedSel := operand.GetSelectExpr(); nestedSel != nil {
+		if baseIdent := nestedSel.GetOperand().GetIdentExpr(); baseIdent != nil {
+			baseName := baseIdent.GetName()
+			parentField := nestedSel.GetField()
+			return m.mapNestedField(baseName, parentField, field)
+		}
+	}
+
+	// Direct field access (e.g., spec.changeSource)
+	if identExpr := operand.GetIdentExpr(); identExpr != nil {
+		baseName := identExpr.GetName()
+		return m.mapDirectField(baseName, field)
+	}
+
+	return "", fmt.Errorf("unsupported select expression structure")
+}
+
+// mapNestedField maps nested activity CEL field paths to ClickHouse columns.
+func (m *ActivityFieldMapper) mapNestedField(baseName, parentField, field string) (string, error) {
+	switch {
+	// spec.actor.*
+	case baseName == "spec" && parentField == "actor" && field == "name":
+		return "actor_name", nil
+	case baseName == "spec" && parentField == "actor" && field == "type":
+		return "actor_type", nil
+	case baseName == "spec" && parentField == "actor" && field == "uid":
+		return "actor_uid", nil
+
+	// spec.resource.*
+	case baseName == "spec" && parentField == "resource" && field == "apiGroup":
+		return "api_group", nil
+	case baseName == "spec" && parentField == "resource" && field == "kind":
+		return "resource_kind", nil
+	case baseName == "spec" && parentField == "resource" && field == "name":
+		return "resource_name", nil
+	case baseName == "spec" && parentField == "resource" && field == "namespace":
+		return "resource_namespace", nil
+	case baseName == "spec" && parentField == "resource" && field == "uid":
+		return "resource_uid", nil
+
+	// spec.origin.*
+	case baseName == "spec" && parentField == "origin" && field == "type":
+		return "origin_type", nil
+
+	default:
+		return "", fmt.Errorf("field '%s.%s.%s' is not available for filtering", baseName, parentField, field)
+	}
+}
+
+// mapDirectField maps direct activity CEL field paths to ClickHouse columns.
+func (m *ActivityFieldMapper) mapDirectField(baseName, field string) (string, error) {
+	switch {
+	case baseName == "spec" && field == "changeSource":
+		return "change_source", nil
+	case baseName == "spec" && field == "summary":
+		return "summary", nil
+	case baseName == "metadata" && field == "namespace":
+		return "activity_namespace", nil
+	case baseName == "metadata" && field == "name":
+		return "activity_name", nil
+
+	default:
+		return "", fmt.Errorf("field '%s.%s' is not available for filtering", baseName, field)
+	}
+}
+
+// ActivityEnvironment creates a CEL environment for activity filtering.
+//
+// Available fields:
+//   - spec.changeSource - "human" or "system"
+//   - spec.actor.name - actor display name
+//   - spec.actor.type - actor type
+//   - spec.actor.uid - actor UID
+//   - spec.resource.apiGroup - resource API group
+//   - spec.resource.kind - resource kind
+//   - spec.resource.name - resource name
+//   - spec.resource.namespace - resource namespace
+//   - spec.resource.uid - resource UID
+//   - spec.summary - activity summary text
+//   - spec.origin.type - origin type (audit/event)
+//   - metadata.namespace - activity namespace
+//
+// Supports standard CEL operators (==, !=, &&, ||, !, in) and string methods
+// (startsWith, endsWith, contains).
+func ActivityEnvironment() (*cel.Env, error) {
+	specType := cel.MapType(cel.StringType, cel.DynType)
+	metadataType := cel.MapType(cel.StringType, cel.DynType)
+
+	return cel.NewEnv(
+		cel.Variable("spec", specType),
+		cel.Variable("metadata", metadataType),
+	)
+}
+
+// activityValidFields defines the allowed fields for activity filtering
+var activityValidFields = map[string]map[string]bool{
+	"spec": {
+		"changeSource": true,
+		"summary":      true,
+		// Parent fields - these are intermediate paths to nested fields
+		"actor":    true,
+		"resource": true,
+		"origin":   true,
+	},
+	"spec.actor": {
+		"name": true,
+		"type": true,
+		"uid":  true,
+	},
+	"spec.resource": {
+		"apiGroup":  true,
+		"kind":      true,
+		"name":      true,
+		"namespace": true,
+		"uid":       true,
+	},
+	"spec.origin": {
+		"type": true,
+	},
+	"metadata": {
+		"namespace": true,
+		"name":      true,
+	},
+}
+
+// CompileActivityFilter compiles and validates a CEL filter expression for activities.
+// Returns user-friendly error messages with helpful context.
+func CompileActivityFilter(filterExpr string) (*cel.Ast, error) {
+	startTime := time.Now()
+
+	if filterExpr == "" {
+		metrics.CELFilterErrors.WithLabelValues("empty").Inc()
+		return nil, fmt.Errorf("filter expression cannot be empty")
+	}
+
+	env, err := ActivityEnvironment()
+	if err != nil {
+		metrics.CELFilterErrors.WithLabelValues("environment").Inc()
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+
+	ast, issues := env.Compile(filterExpr)
+	if issues != nil && issues.Err() != nil {
+		metrics.CELFilterErrors.WithLabelValues("compilation").Inc()
+		metrics.CELFilterParseDuration.Observe(time.Since(startTime).Seconds())
+		return nil, fmt.Errorf("%s", formatActivityFilterError(issues.Err()))
+	}
+
+	if !ast.OutputType().IsExactType(cel.BoolType) {
+		metrics.CELFilterErrors.WithLabelValues("type_mismatch").Inc()
+		metrics.CELFilterParseDuration.Observe(time.Since(startTime).Seconds())
+		typeErr := fmt.Errorf("filter expression must return a boolean, got %v", ast.OutputType())
+		return nil, fmt.Errorf("%s", formatActivityFilterError(typeErr))
+	}
+
+	// Validate that only allowed fields are accessed
+	if err := ValidateFieldAccess(ast.Expr(), &ActivityFieldValidator{}); err != nil {
+		metrics.CELFilterErrors.WithLabelValues("invalid_field").Inc()
+		metrics.CELFilterParseDuration.Observe(time.Since(startTime).Seconds())
+		return nil, fmt.Errorf("%s", formatActivityFilterError(err))
+	}
+
+	metrics.CELFilterParseDuration.Observe(time.Since(startTime).Seconds())
+	return ast, nil
+}
+
+// CompiledActivityFilter holds a pre-compiled CEL program for reuse in watch operations.
+type CompiledActivityFilter struct {
+	program cel.Program
+}
+
+// CompileActivityFilterProgram compiles a CEL filter for watch evaluation.
+// Unlike CompileActivityFilter which returns an AST for SQL conversion, this
+// returns a compiled program that can evaluate Activity objects directly.
+func CompileActivityFilterProgram(filterExpr string) (*CompiledActivityFilter, error) {
+	if filterExpr == "" {
+		return nil, fmt.Errorf("filter expression cannot be empty")
+	}
+
+	env, err := ActivityEnvironment()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+
+	ast, issues := env.Compile(filterExpr)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("%s", formatActivityFilterError(issues.Err()))
+	}
+
+	if !ast.OutputType().IsExactType(cel.BoolType) {
+		typeErr := fmt.Errorf("filter expression must return a boolean, got %v", ast.OutputType())
+		return nil, fmt.Errorf("%s", formatActivityFilterError(typeErr))
+	}
+
+	// Validate that only allowed fields are accessed
+	if err := ValidateFieldAccess(ast.Expr(), &ActivityFieldValidator{}); err != nil {
+		return nil, fmt.Errorf("%s", formatActivityFilterError(err))
+	}
+
+	// Create program from compiled AST
+	program, err := env.Program(ast)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL program: %w", err)
+	}
+
+	return &CompiledActivityFilter{program: program}, nil
+}
+
+// EvaluateActivity evaluates the filter against an Activity object.
+// Returns true if the activity matches the filter, false otherwise.
+func (f *CompiledActivityFilter) EvaluateActivity(activity *v1alpha1.Activity) (bool, error) {
+	if f == nil || f.program == nil {
+		return true, nil // No filter means match all
+	}
+
+	// Convert Activity to map format for CEL evaluation
+	input := ActivityToMap(activity)
+
+	// Evaluate the program
+	result, _, err := f.program.Eval(input)
+	if err != nil {
+		return false, fmt.Errorf("CEL evaluation error: %w", err)
+	}
+
+	// Extract boolean result
+	boolVal, ok := result.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("CEL result is not a boolean: %T", result.Value())
+	}
+
+	return boolVal, nil
+}
+
+// ActivityToMap converts an Activity struct to a map format for CEL evaluation.
+// The map structure matches the CEL variables defined in ActivityEnvironment.
+func ActivityToMap(activity *v1alpha1.Activity) map[string]interface{} {
+	return map[string]interface{}{
+		"spec": map[string]interface{}{
+			"changeSource": activity.Spec.ChangeSource,
+			"summary":      activity.Spec.Summary,
+			"actor": map[string]interface{}{
+				"name": activity.Spec.Actor.Name,
+				"type": activity.Spec.Actor.Type,
+				"uid":  activity.Spec.Actor.UID,
+			},
+			"resource": map[string]interface{}{
+				"apiGroup":  activity.Spec.Resource.APIGroup,
+				"kind":      activity.Spec.Resource.Kind,
+				"name":      activity.Spec.Resource.Name,
+				"namespace": activity.Spec.Resource.Namespace,
+				"uid":       activity.Spec.Resource.UID,
+			},
+			"origin": map[string]interface{}{
+				"type": activity.Spec.Origin.Type,
+			},
+		},
+		"metadata": map[string]interface{}{
+			"namespace": activity.Namespace,
+			"name":      activity.Name,
+		},
+	}
+}
+
+// formatActivityFilterError formats error messages for activity filter expressions
+func formatActivityFilterError(err error) string {
+	errMsg := err.Error()
+
+	// Provide helpful suggestions for common errors
+	if strings.Contains(errMsg, "undeclared reference") {
+		return fmt.Sprintf(`%s
+
+Available fields for activity filtering:
+  - spec.changeSource - "human" or "system"
+  - spec.actor.name, spec.actor.type, spec.actor.uid
+  - spec.resource.apiGroup, spec.resource.kind, spec.resource.name
+  - spec.resource.namespace, spec.resource.uid
+  - spec.summary, spec.origin.type
+  - metadata.namespace, metadata.name
+
+Example: spec.changeSource == "human" && spec.resource.kind == "Deployment"`, errMsg)
+	}
+
+	return errMsg
+}
+
+// ConvertActivityToClickHouseSQL converts a CEL expression for activities to a ClickHouse WHERE clause.
+func ConvertActivityToClickHouseSQL(ctx context.Context, filterExpr string) (string, []any, error) {
+	_, span := tracer.Start(ctx, "cel.activity_filter.convert",
+		trace.WithAttributes(attribute.String("cel.expression", filterExpr)),
+	)
+	defer span.End()
+
+	if filterExpr == "" {
+		span.SetStatus(codes.Ok, "empty filter")
+		return "", nil, nil
+	}
+
+	ast, err := CompileActivityFilter(filterExpr)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "compilation failed")
+		return "", nil, err
+	}
+
+	span.SetAttributes(attribute.Bool("cel.valid", true))
+
+	converter := NewBaseSQLConverter(&ActivityFieldMapper{})
+
+	sql, err := converter.ConvertExpr(ast.Expr())
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "conversion failed")
+		return "", nil, err
+	}
+
+	span.SetAttributes(
+		attribute.String("sql.where_clause", sql),
+		attribute.Int("sql.param_count", len(converter.Args())),
+	)
+	span.SetStatus(codes.Ok, "conversion successful")
+
+	return sql, converter.Args(), nil
+}

--- a/internal/cel/activity_filter_test.go
+++ b/internal/cel/activity_filter_test.go
@@ -1,0 +1,539 @@
+package cel
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
+)
+
+// TestCompileActivityFilterProgram tests the CEL filter compilation for watch evaluation.
+func TestCompileActivityFilterProgram(t *testing.T) {
+	tests := []struct {
+		name    string
+		filter  string
+		wantErr bool
+	}{
+		{
+			name:    "valid simple equality filter",
+			filter:  `spec.changeSource == "human"`,
+			wantErr: false,
+		},
+		{
+			name:    "valid resource kind filter",
+			filter:  `spec.resource.kind == "Deployment"`,
+			wantErr: false,
+		},
+		{
+			name:    "valid actor name filter",
+			filter:  `spec.actor.name == "admin@example.com"`,
+			wantErr: false,
+		},
+		{
+			name:    "valid string contains filter",
+			filter:  `spec.actor.name.contains("admin")`,
+			wantErr: false,
+		},
+		{
+			name:    "valid combined AND filter",
+			filter:  `spec.changeSource == "human" && spec.resource.kind == "HTTPProxy"`,
+			wantErr: false,
+		},
+		{
+			name:    "valid combined OR filter",
+			filter:  `spec.resource.kind == "Deployment" || spec.resource.kind == "StatefulSet"`,
+			wantErr: false,
+		},
+		{
+			name:    "valid NOT filter",
+			filter:  `!(spec.changeSource == "system")`,
+			wantErr: false,
+		},
+		{
+			name:    "valid metadata namespace filter",
+			filter:  `metadata.namespace == "production"`,
+			wantErr: false,
+		},
+		{
+			name:    "empty filter",
+			filter:  "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid syntax",
+			filter:  `spec.changeSource = "human"`,
+			wantErr: true,
+		},
+		{
+			name:    "undeclared field",
+			filter:  `spec.unknownField == "value"`,
+			wantErr: true,
+		},
+		{
+			name:    "non-boolean return type",
+			filter:  `spec.changeSource`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compiled, err := CompileActivityFilterProgram(tt.filter)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CompileActivityFilterProgram() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && compiled == nil {
+				t.Error("CompileActivityFilterProgram() returned nil for valid filter")
+			}
+		})
+	}
+}
+
+// TestActivityToMap tests the Activity to map conversion.
+func TestActivityToMap(t *testing.T) {
+	activity := &v1alpha1.Activity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-activity",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.ActivitySpec{
+			Summary:      "alice created deployment nginx",
+			ChangeSource: "human",
+			Actor: v1alpha1.ActivityActor{
+				Name: "alice@example.com",
+				Type: "user",
+				UID:  "user-uid-123",
+			},
+			Resource: v1alpha1.ActivityResource{
+				APIGroup:  "apps",
+				Kind:      "Deployment",
+				Name:      "nginx",
+				Namespace: "production",
+				UID:       "deployment-uid-456",
+			},
+			Origin: v1alpha1.ActivityOrigin{
+				Type: "audit",
+			},
+		},
+	}
+
+	m := ActivityToMap(activity)
+
+	// Verify spec fields
+	spec, ok := m["spec"].(map[string]interface{})
+	if !ok {
+		t.Fatal("spec is not a map")
+	}
+
+	if spec["changeSource"] != "human" {
+		t.Errorf("spec.changeSource = %v, want %v", spec["changeSource"], "human")
+	}
+
+	if spec["summary"] != "alice created deployment nginx" {
+		t.Errorf("spec.summary = %v, want %v", spec["summary"], "alice created deployment nginx")
+	}
+
+	// Verify actor fields
+	actor, ok := spec["actor"].(map[string]interface{})
+	if !ok {
+		t.Fatal("spec.actor is not a map")
+	}
+
+	if actor["name"] != "alice@example.com" {
+		t.Errorf("spec.actor.name = %v, want %v", actor["name"], "alice@example.com")
+	}
+
+	if actor["type"] != "user" {
+		t.Errorf("spec.actor.type = %v, want %v", actor["type"], "user")
+	}
+
+	// Verify resource fields
+	resource, ok := spec["resource"].(map[string]interface{})
+	if !ok {
+		t.Fatal("spec.resource is not a map")
+	}
+
+	if resource["kind"] != "Deployment" {
+		t.Errorf("spec.resource.kind = %v, want %v", resource["kind"], "Deployment")
+	}
+
+	if resource["apiGroup"] != "apps" {
+		t.Errorf("spec.resource.apiGroup = %v, want %v", resource["apiGroup"], "apps")
+	}
+
+	// Verify metadata fields
+	metadata, ok := m["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatal("metadata is not a map")
+	}
+
+	if metadata["name"] != "test-activity" {
+		t.Errorf("metadata.name = %v, want %v", metadata["name"], "test-activity")
+	}
+
+	if metadata["namespace"] != "default" {
+		t.Errorf("metadata.namespace = %v, want %v", metadata["namespace"], "default")
+	}
+}
+
+// TestEvaluateActivity tests the CEL filter evaluation against Activity objects.
+func TestEvaluateActivity(t *testing.T) {
+	humanDeploymentActivity := &v1alpha1.Activity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "human-deployment",
+			Namespace: "production",
+		},
+		Spec: v1alpha1.ActivitySpec{
+			Summary:      "alice created deployment nginx",
+			ChangeSource: "human",
+			Actor: v1alpha1.ActivityActor{
+				Name: "alice@example.com",
+				Type: "user",
+				UID:  "user-uid-123",
+			},
+			Resource: v1alpha1.ActivityResource{
+				APIGroup:  "apps",
+				Kind:      "Deployment",
+				Name:      "nginx",
+				Namespace: "production",
+				UID:       "deployment-uid-456",
+			},
+			Origin: v1alpha1.ActivityOrigin{
+				Type: "audit",
+			},
+		},
+	}
+
+	systemPodActivity := &v1alpha1.Activity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "system-pod",
+			Namespace: "kube-system",
+		},
+		Spec: v1alpha1.ActivitySpec{
+			Summary:      "kube-controller-manager updated pod coredns",
+			ChangeSource: "system",
+			Actor: v1alpha1.ActivityActor{
+				Name: "system:serviceaccount:kube-system:controller-manager",
+				Type: "serviceaccount",
+				UID:  "sa-uid-789",
+			},
+			Resource: v1alpha1.ActivityResource{
+				APIGroup:  "",
+				Kind:      "Pod",
+				Name:      "coredns",
+				Namespace: "kube-system",
+				UID:       "pod-uid-999",
+			},
+			Origin: v1alpha1.ActivityOrigin{
+				Type: "audit",
+			},
+		},
+	}
+
+	httpProxyActivity := &v1alpha1.Activity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "httpproxy-create",
+			Namespace: "ingress",
+		},
+		Spec: v1alpha1.ActivitySpec{
+			Summary:      "admin created HTTPProxy api-gateway",
+			ChangeSource: "human",
+			Actor: v1alpha1.ActivityActor{
+				Name: "admin@example.com",
+				Type: "user",
+				UID:  "admin-uid-111",
+			},
+			Resource: v1alpha1.ActivityResource{
+				APIGroup:  "projectcontour.io",
+				Kind:      "HTTPProxy",
+				Name:      "api-gateway",
+				Namespace: "ingress",
+				UID:       "httpproxy-uid-222",
+			},
+			Origin: v1alpha1.ActivityOrigin{
+				Type: "audit",
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		filter   string
+		activity *v1alpha1.Activity
+		want     bool
+	}{
+		{
+			name:     "human changeSource - matches",
+			filter:   `spec.changeSource == "human"`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+		{
+			name:     "human changeSource - does not match",
+			filter:   `spec.changeSource == "human"`,
+			activity: systemPodActivity,
+			want:     false,
+		},
+		{
+			name:     "system changeSource - matches",
+			filter:   `spec.changeSource == "system"`,
+			activity: systemPodActivity,
+			want:     true,
+		},
+		{
+			name:     "resource kind Deployment - matches",
+			filter:   `spec.resource.kind == "Deployment"`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+		{
+			name:     "resource kind Deployment - does not match Pod",
+			filter:   `spec.resource.kind == "Deployment"`,
+			activity: systemPodActivity,
+			want:     false,
+		},
+		{
+			name:     "actor name contains admin - matches",
+			filter:   `spec.actor.name.contains("admin")`,
+			activity: httpProxyActivity,
+			want:     true,
+		},
+		{
+			name:     "actor name contains admin - does not match",
+			filter:   `spec.actor.name.contains("admin")`,
+			activity: humanDeploymentActivity,
+			want:     false,
+		},
+		{
+			name:     "combined filter - human AND Deployment",
+			filter:   `spec.changeSource == "human" && spec.resource.kind == "Deployment"`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+		{
+			name:     "combined filter - human AND HTTPProxy",
+			filter:   `spec.changeSource == "human" && spec.resource.kind == "HTTPProxy"`,
+			activity: httpProxyActivity,
+			want:     true,
+		},
+		{
+			name:     "combined filter - human AND HTTPProxy on Deployment",
+			filter:   `spec.changeSource == "human" && spec.resource.kind == "HTTPProxy"`,
+			activity: humanDeploymentActivity,
+			want:     false,
+		},
+		{
+			name:     "OR filter - Deployment OR Pod",
+			filter:   `spec.resource.kind == "Deployment" || spec.resource.kind == "Pod"`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+		{
+			name:     "OR filter - Deployment OR Pod - matches Pod",
+			filter:   `spec.resource.kind == "Deployment" || spec.resource.kind == "Pod"`,
+			activity: systemPodActivity,
+			want:     true,
+		},
+		{
+			name:     "OR filter - does not match HTTPProxy",
+			filter:   `spec.resource.kind == "Deployment" || spec.resource.kind == "Pod"`,
+			activity: httpProxyActivity,
+			want:     false,
+		},
+		{
+			name:     "NOT filter - not system",
+			filter:   `!(spec.changeSource == "system")`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+		{
+			name:     "NOT filter - not system - does not match system activity",
+			filter:   `!(spec.changeSource == "system")`,
+			activity: systemPodActivity,
+			want:     false,
+		},
+		{
+			name:     "metadata namespace filter",
+			filter:   `metadata.namespace == "production"`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+		{
+			name:     "metadata namespace filter - does not match",
+			filter:   `metadata.namespace == "production"`,
+			activity: systemPodActivity,
+			want:     false,
+		},
+		{
+			name:     "apiGroup filter - apps",
+			filter:   `spec.resource.apiGroup == "apps"`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+		{
+			name:     "apiGroup filter - empty string for core",
+			filter:   `spec.resource.apiGroup == ""`,
+			activity: systemPodActivity,
+			want:     true,
+		},
+		{
+			name:     "apiGroup filter - projectcontour.io",
+			filter:   `spec.resource.apiGroup == "projectcontour.io"`,
+			activity: httpProxyActivity,
+			want:     true,
+		},
+		{
+			name:     "actor type filter - user",
+			filter:   `spec.actor.type == "user"`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+		{
+			name:     "actor type filter - serviceaccount",
+			filter:   `spec.actor.type == "serviceaccount"`,
+			activity: systemPodActivity,
+			want:     true,
+		},
+		{
+			name:     "origin type filter",
+			filter:   `spec.origin.type == "audit"`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+		{
+			name:     "summary contains filter",
+			filter:   `spec.summary.contains("created")`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+		{
+			name:     "summary startsWith filter",
+			filter:   `spec.summary.startsWith("alice")`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+		{
+			name:     "resource name filter",
+			filter:   `spec.resource.name == "nginx"`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+		{
+			name:     "complex combined filter",
+			filter:   `spec.changeSource == "human" && spec.resource.apiGroup == "apps" && spec.actor.name.contains("alice")`,
+			activity: humanDeploymentActivity,
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compiled, err := CompileActivityFilterProgram(tt.filter)
+			if err != nil {
+				t.Fatalf("CompileActivityFilterProgram() error = %v", err)
+			}
+
+			got, err := compiled.EvaluateActivity(tt.activity)
+			if err != nil {
+				t.Fatalf("EvaluateActivity() error = %v", err)
+			}
+
+			if got != tt.want {
+				t.Errorf("EvaluateActivity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEvaluateActivity_NilFilter tests that nil filter returns true for all activities.
+func TestEvaluateActivity_NilFilter(t *testing.T) {
+	activity := &v1alpha1.Activity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-activity",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.ActivitySpec{
+			ChangeSource: "human",
+		},
+	}
+
+	var compiled *CompiledActivityFilter = nil
+	got, err := compiled.EvaluateActivity(activity)
+	if err != nil {
+		t.Fatalf("EvaluateActivity() error = %v", err)
+	}
+
+	if !got {
+		t.Errorf("EvaluateActivity() with nil filter = %v, want true", got)
+	}
+}
+
+// TestConvertActivityToClickHouseSQL_ChangeSource tests the SQL conversion for changeSource filter.
+func TestConvertActivityToClickHouseSQL_ChangeSource(t *testing.T) {
+	tests := []struct {
+		name           string
+		filter         string
+		wantSQLContain string
+		wantArg        string
+	}{
+		{
+			name:           "changeSource equals human",
+			filter:         `spec.changeSource == "human"`,
+			wantSQLContain: "change_source = {arg",
+			wantArg:        "human",
+		},
+		{
+			name:           "changeSource equals system",
+			filter:         `spec.changeSource == "system"`,
+			wantSQLContain: "change_source = {arg",
+			wantArg:        "system",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, args, err := ConvertActivityToClickHouseSQL(context.Background(), tt.filter)
+			if err != nil {
+				t.Fatalf("ConvertActivityToClickHouseSQL() error = %v", err)
+			}
+
+			t.Logf("Generated SQL: %s", sql)
+			t.Logf("Args: %v", args)
+
+			if !contains(sql, tt.wantSQLContain) {
+				t.Errorf("SQL = %q, want to contain %q", sql, tt.wantSQLContain)
+			}
+
+			// Check that the argument value is correct
+			found := false
+			for _, arg := range args {
+				if arg == tt.wantArg {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("args = %v, want to contain %q", args, tt.wantArg)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cel/cel.go
+++ b/internal/cel/cel.go
@@ -1,0 +1,326 @@
+// Package cel provides CEL (Common Expression Language) utilities for filtering
+// audit logs and activities in ClickHouse queries.
+//
+// This package implements a shared infrastructure for:
+//   - Compiling CEL filter expressions with field validation
+//   - Converting CEL ASTs to ClickHouse SQL WHERE clauses
+//   - Domain-specific field mapping (audit logs, activities)
+//
+// The design uses interfaces to allow different domains (audit logs, activities)
+// to share the common CEL parsing and SQL generation logic while customizing
+// field validation and column mapping.
+package cel
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+// FieldValidator defines the interface for validating CEL field access.
+// Each domain implements this to define which fields are allowed in filter expressions.
+type FieldValidator interface {
+	// ValidateSelectExpr validates a field selection expression.
+	// Returns nil if the field access is valid, or an error describing the issue.
+	ValidateSelectExpr(sel *expr.Expr_Select) error
+}
+
+// FieldMapper defines the interface for mapping CEL fields to ClickHouse columns.
+// Each domain implements this to define how CEL expression fields map to their
+// ClickHouse table columns.
+type FieldMapper interface {
+	// MapSelectExpr converts a CEL select expression to a ClickHouse column name.
+	// It receives the full select expression to handle both simple (objectRef.namespace)
+	// and nested (spec.actor.name) field access patterns.
+	MapSelectExpr(sel *expr.Expr_Select) (string, error)
+
+	// MapIdentExpr handles bare identifiers (e.g., "auditID", "verb").
+	// Returns an error if the identifier requires dot notation access.
+	MapIdentExpr(ident *expr.Expr_Ident) (string, error)
+}
+
+// ValidateFieldAccess recursively validates that only allowed fields are accessed
+// in a CEL expression. It uses the provided FieldValidator for domain-specific
+// field validation.
+func ValidateFieldAccess(e *expr.Expr, validator FieldValidator) error {
+	if e == nil {
+		return nil
+	}
+
+	switch exprKind := e.ExprKind.(type) {
+	case *expr.Expr_SelectExpr:
+		sel := exprKind.SelectExpr
+		if err := validator.ValidateSelectExpr(sel); err != nil {
+			return err
+		}
+		// Recursively validate the operand
+		if operand := sel.GetOperand(); operand != nil {
+			if err := ValidateFieldAccess(operand, validator); err != nil {
+				return err
+			}
+		}
+
+	case *expr.Expr_CallExpr:
+		call := exprKind.CallExpr
+		if call.Target != nil {
+			if err := ValidateFieldAccess(call.Target, validator); err != nil {
+				return err
+			}
+		}
+		for _, arg := range call.Args {
+			if err := ValidateFieldAccess(arg, validator); err != nil {
+				return err
+			}
+		}
+
+	case *expr.Expr_ListExpr:
+		list := exprKind.ListExpr
+		for _, elem := range list.Elements {
+			if err := ValidateFieldAccess(elem, validator); err != nil {
+				return err
+			}
+		}
+
+	case *expr.Expr_StructExpr:
+		structExpr := exprKind.StructExpr
+		for _, entry := range structExpr.Entries {
+			if err := ValidateFieldAccess(entry.GetValue(), validator); err != nil {
+				return err
+			}
+		}
+
+	case *expr.Expr_ComprehensionExpr:
+		comp := exprKind.ComprehensionExpr
+		if err := ValidateFieldAccess(comp.IterRange, validator); err != nil {
+			return err
+		}
+		if err := ValidateFieldAccess(comp.AccuInit, validator); err != nil {
+			return err
+		}
+		if err := ValidateFieldAccess(comp.LoopCondition, validator); err != nil {
+			return err
+		}
+		if err := ValidateFieldAccess(comp.LoopStep, validator); err != nil {
+			return err
+		}
+		if err := ValidateFieldAccess(comp.Result, validator); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BaseSQLConverter contains shared CEL-to-ClickHouse SQL conversion logic.
+// It handles operator conversion, constant handling, and parameter management.
+// Domain-specific field mapping is delegated to the FieldMapper interface.
+type BaseSQLConverter struct {
+	args      []any
+	argIndex  int
+	paramName map[int]string
+	mapper    FieldMapper
+}
+
+// NewBaseSQLConverter creates a new BaseSQLConverter with the given field mapper.
+func NewBaseSQLConverter(mapper FieldMapper) *BaseSQLConverter {
+	return &BaseSQLConverter{
+		args:      make([]any, 0),
+		argIndex:  1,
+		paramName: make(map[int]string),
+		mapper:    mapper,
+	}
+}
+
+// Args returns the collected query arguments.
+func (c *BaseSQLConverter) Args() []any {
+	return c.args
+}
+
+// addArg adds a value to the argument list and returns a ClickHouse parameter placeholder.
+func (c *BaseSQLConverter) addArg(value any) string {
+	c.args = append(c.args, value)
+	paramName := fmt.Sprintf("arg%d", c.argIndex)
+	c.paramName[c.argIndex] = paramName
+	c.argIndex++
+	return fmt.Sprintf("{%s}", paramName)
+}
+
+// ConvertExpr converts a CEL expression to a ClickHouse SQL string.
+func (c *BaseSQLConverter) ConvertExpr(e *expr.Expr) (string, error) {
+	switch e.ExprKind.(type) {
+	case *expr.Expr_CallExpr:
+		return c.convertCallExpr(e.GetCallExpr())
+	case *expr.Expr_IdentExpr:
+		return c.mapper.MapIdentExpr(e.GetIdentExpr())
+	case *expr.Expr_ConstExpr:
+		return c.convertConstExpr(e.GetConstExpr())
+	case *expr.Expr_SelectExpr:
+		return c.mapper.MapSelectExpr(e.GetSelectExpr())
+	case *expr.Expr_ListExpr:
+		return c.convertListExpr(e.GetListExpr())
+	default:
+		return "", fmt.Errorf("unsupported expression type: %T", e.ExprKind)
+	}
+}
+
+func (c *BaseSQLConverter) convertCallExpr(call *expr.Expr_Call) (string, error) {
+	switch call.Function {
+	case "!_":
+		arg, err := c.ConvertExpr(call.Args[0])
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("NOT (%s)", arg), nil
+
+	case "_==_":
+		return c.convertBinaryOp(call, "=")
+
+	case "_!=_":
+		return c.convertBinaryOp(call, "!=")
+
+	case "_&&_":
+		left, err := c.ConvertExpr(call.Args[0])
+		if err != nil {
+			return "", err
+		}
+		right, err := c.ConvertExpr(call.Args[1])
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("(%s AND %s)", left, right), nil
+
+	case "_||_":
+		left, err := c.ConvertExpr(call.Args[0])
+		if err != nil {
+			return "", err
+		}
+		right, err := c.ConvertExpr(call.Args[1])
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("(%s OR %s)", left, right), nil
+
+	case "_>=_":
+		return c.convertBinaryOp(call, ">=")
+
+	case "_<=_":
+		return c.convertBinaryOp(call, "<=")
+
+	case "_>_":
+		return c.convertBinaryOp(call, ">")
+
+	case "_<_":
+		return c.convertBinaryOp(call, "<")
+
+	case "@in":
+		left, err := c.ConvertExpr(call.Args[0])
+		if err != nil {
+			return "", err
+		}
+		right, err := c.ConvertExpr(call.Args[1])
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s IN %s", left, right), nil
+
+	case "startsWith":
+		if call.Target != nil {
+			target, err := c.ConvertExpr(call.Target)
+			if err != nil {
+				return "", err
+			}
+			prefix, err := c.ConvertExpr(call.Args[0])
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("startsWith(%s, %s)", target, prefix), nil
+		}
+
+	case "endsWith":
+		if call.Target != nil {
+			target, err := c.ConvertExpr(call.Target)
+			if err != nil {
+				return "", err
+			}
+			suffix, err := c.ConvertExpr(call.Args[0])
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("endsWith(%s, %s)", target, suffix), nil
+		}
+
+	case "contains":
+		if call.Target != nil {
+			target, err := c.ConvertExpr(call.Target)
+			if err != nil {
+				return "", err
+			}
+			substring, err := c.ConvertExpr(call.Args[0])
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("position(%s, %s) > 0", target, substring), nil
+		}
+
+	case "timestamp":
+		if len(call.Args) == 1 {
+			if constExpr := call.Args[0].GetConstExpr(); constExpr != nil {
+				if strVal := constExpr.GetStringValue(); strVal != "" {
+					t, err := time.Parse(time.RFC3339, strVal)
+					if err != nil {
+						return "", fmt.Errorf("invalid timestamp format: %w", err)
+					}
+					return c.addArg(t), nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("unsupported CEL function: %s", call.Function)
+}
+
+func (c *BaseSQLConverter) convertBinaryOp(call *expr.Expr_Call, op string) (string, error) {
+	left, err := c.ConvertExpr(call.Args[0])
+	if err != nil {
+		return "", err
+	}
+	right, err := c.ConvertExpr(call.Args[1])
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s %s %s", left, op, right), nil
+}
+
+func (c *BaseSQLConverter) convertConstExpr(constant *expr.Constant) (string, error) {
+	switch constant.ConstantKind.(type) {
+	case *expr.Constant_StringValue:
+		return c.addArg(constant.GetStringValue()), nil
+	case *expr.Constant_Int64Value:
+		return c.addArg(constant.GetInt64Value()), nil
+	case *expr.Constant_Uint64Value:
+		return c.addArg(constant.GetUint64Value()), nil
+	case *expr.Constant_DoubleValue:
+		return c.addArg(constant.GetDoubleValue()), nil
+	case *expr.Constant_BoolValue:
+		if constant.GetBoolValue() {
+			return "1", nil
+		}
+		return "0", nil
+	default:
+		return "", fmt.Errorf("unsupported constant type: %T", constant.ConstantKind)
+	}
+}
+
+func (c *BaseSQLConverter) convertListExpr(list *expr.Expr_CreateList) (string, error) {
+	elements := make([]string, len(list.Elements))
+	for i, elem := range list.Elements {
+		val, err := c.ConvertExpr(elem)
+		if err != nil {
+			return "", err
+		}
+		elements[i] = val
+	}
+	return fmt.Sprintf("[%s]", strings.Join(elements, ", ")), nil
+}

--- a/internal/cel/policy.go
+++ b/internal/cel/policy.go
@@ -1,0 +1,505 @@
+package cel
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+// PolicyExpressionType indicates whether an expression is a match or summary expression.
+type PolicyExpressionType string
+
+const (
+	// MatchExpression is a CEL expression that returns a boolean.
+	MatchExpression PolicyExpressionType = "match"
+	// SummaryExpression is a CEL template expression with {{ }} delimiters.
+	SummaryExpression PolicyExpressionType = "summary"
+)
+
+// PolicyRuleType indicates whether a rule is for audit or event processing.
+type PolicyRuleType string
+
+const (
+	// AuditRule is a rule that processes audit log entries.
+	AuditRule PolicyRuleType = "audit"
+	// EventRule is a rule that processes Kubernetes events.
+	EventRule PolicyRuleType = "event"
+)
+
+// summaryTemplateRegex matches {{ expression }} patterns in summary templates.
+var summaryTemplateRegex = regexp.MustCompile(`\{\{\s*(.+?)\s*\}\}`)
+
+// auditEnvironment creates a CEL environment for audit rule expressions.
+// Available variables: audit (full audit event), kind, kindPlural, actor, actorRef
+// If collector is non-nil, link() calls will capture link information.
+func auditEnvironment(collector *linkCollector) (*cel.Env, error) {
+	// The audit variable is a map containing the full Kubernetes audit event
+	auditType := cel.MapType(cel.StringType, cel.DynType)
+	// The actorRef variable is a map with {type, name} for linking
+	actorRefType := cel.MapType(cel.StringType, cel.DynType)
+
+	return cel.NewEnv(
+		cel.Variable("audit", auditType),
+		cel.Variable("kind", cel.StringType),
+		cel.Variable("kindPlural", cel.StringType),
+		cel.Variable("actor", cel.StringType),
+		cel.Variable("actorRef", actorRefType),
+
+		// link function declaration with implementation: link(displayText string, resourceRef map) -> string
+		// Returns the display text and optionally captures link info in the collector.
+		cel.Function("link",
+			cel.Overload("link_string_dyn",
+				[]*cel.Type{cel.StringType, cel.DynType},
+				cel.StringType,
+				cel.BinaryBinding(func(displayText, resourceRef ref.Val) ref.Val {
+					text := fmt.Sprintf("%v", displayText.Value())
+					if collector != nil {
+						collector.addLink(text, resourceRef.Value())
+					}
+					return types.String(text)
+				}),
+			),
+		),
+	)
+}
+
+// eventEnvironment creates a CEL environment for event rule expressions.
+// Available variables: event (full Kubernetes event), kind, kindPlural, actor, actorRef
+// If collector is non-nil, link() calls will capture link information.
+func eventEnvironment(collector *linkCollector) (*cel.Env, error) {
+	// The event variable is a map containing the full Kubernetes Event
+	eventType := cel.MapType(cel.StringType, cel.DynType)
+	// The actorRef variable is a map with {type, name} for linking
+	actorRefType := cel.MapType(cel.StringType, cel.DynType)
+
+	return cel.NewEnv(
+		cel.Variable("event", eventType),
+		cel.Variable("kind", cel.StringType),
+		cel.Variable("kindPlural", cel.StringType),
+		cel.Variable("actor", cel.StringType),
+		cel.Variable("actorRef", actorRefType),
+
+		// link function declaration with implementation: link(displayText string, resourceRef map) -> string
+		// Returns the display text and optionally captures link info in the collector.
+		cel.Function("link",
+			cel.Overload("link_string_dyn",
+				[]*cel.Type{cel.StringType, cel.DynType},
+				cel.StringType,
+				cel.BinaryBinding(func(displayText, resourceRef ref.Val) ref.Val {
+					text := fmt.Sprintf("%v", displayText.Value())
+					if collector != nil {
+						collector.addLink(text, resourceRef.Value())
+					}
+					return types.String(text)
+				}),
+			),
+		),
+	)
+}
+
+// ValidatePolicyExpression validates a CEL expression used in an ActivityPolicy rule.
+// It checks for syntax errors and type correctness based on the expression and rule types.
+func ValidatePolicyExpression(expression string, exprType PolicyExpressionType, ruleType PolicyRuleType) error {
+	if expression == "" {
+		return fmt.Errorf("expression cannot be empty")
+	}
+
+	// Get the appropriate environment based on rule type
+	// Pass nil collector since we're just validating, not collecting links
+	var env *cel.Env
+	var err error
+
+	switch ruleType {
+	case AuditRule:
+		env, err = auditEnvironment(nil)
+	case EventRule:
+		env, err = eventEnvironment(nil)
+	default:
+		return fmt.Errorf("unknown rule type: %s", ruleType)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+
+	switch exprType {
+	case MatchExpression:
+		return validateMatchExpression(env, expression)
+	case SummaryExpression:
+		return validateSummaryExpression(env, expression)
+	default:
+		return fmt.Errorf("unknown expression type: %s", exprType)
+	}
+}
+
+// validateMatchExpression validates a match expression that should return a boolean.
+func validateMatchExpression(env *cel.Env, expression string) error {
+	ast, issues := env.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		return formatPolicyError(issues.Err(), "match")
+	}
+
+	// Match expressions must return boolean
+	if !ast.OutputType().IsExactType(cel.BoolType) {
+		return fmt.Errorf("match expression must return a boolean, got %v", ast.OutputType())
+	}
+
+	return nil
+}
+
+// validateSummaryExpression validates a summary template expression with {{ }} delimiters.
+func validateSummaryExpression(env *cel.Env, expression string) error {
+	// Extract all {{ expression }} blocks from the template
+	matches := summaryTemplateRegex.FindAllStringSubmatch(expression, -1)
+
+	if len(matches) == 0 {
+		// No template expressions found - this is valid but probably unintended
+		// We allow it as the user might want a static summary
+		return nil
+	}
+
+	// Validate each embedded CEL expression
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+
+		embeddedExpr := strings.TrimSpace(match[1])
+		if embeddedExpr == "" {
+			return fmt.Errorf("empty expression in template: %s", match[0])
+		}
+
+		// Compile the embedded expression
+		ast, issues := env.Compile(embeddedExpr)
+		if issues != nil && issues.Err() != nil {
+			return formatPolicyError(issues.Err(), "summary")
+		}
+
+		// Summary template expressions should return a string
+		// The link() function returns a string, so check for string type
+		if !ast.OutputType().IsExactType(cel.StringType) && !ast.OutputType().IsExactType(cel.DynType) {
+			return fmt.Errorf("expression '{{ %s }}' in summary must return a string, got %v", embeddedExpr, ast.OutputType())
+		}
+	}
+
+	return nil
+}
+
+// formatPolicyError formats a CEL error into a user-friendly message.
+func formatPolicyError(err error, context string) error {
+	errStr := err.Error()
+
+	// Check for common error patterns and provide helpful messages
+	if strings.Contains(errStr, "undeclared reference") {
+		return fmt.Errorf("invalid %s expression: %s. "+
+			"For audit rules, use 'audit' variable (e.g., audit.verb, audit.objectRef.name). "+
+			"For event rules, use 'event' variable (e.g., event.reason, event.regarding.name). "+
+			"Also available: kind, kindPlural, actor", context, errStr)
+	}
+
+	if strings.Contains(errStr, "found no matching overload") {
+		return fmt.Errorf("invalid %s expression: function call error - %s. "+
+			"Available function: link(displayText, resourceRef)", context, errStr)
+	}
+
+	return fmt.Errorf("invalid %s expression: %s", context, errStr)
+}
+
+// Link represents a link extracted from a summary template.
+type Link struct {
+	Marker   string
+	Resource map[string]interface{}
+}
+
+// linkCollector collects links during CEL evaluation.
+type linkCollector struct {
+	links []Link
+}
+
+func (c *linkCollector) addLink(displayText string, resource interface{}) {
+	if resourceMap, ok := resource.(map[string]interface{}); ok {
+		c.links = append(c.links, Link{
+			Marker:   displayText,
+			Resource: resourceMap,
+		})
+	} else if resourceRef, ok := resource.(map[ref.Val]ref.Val); ok {
+		// Convert CEL map to Go map
+		goMap := make(map[string]interface{})
+		for k, v := range resourceRef {
+			if keyStr, ok := k.Value().(string); ok {
+				goMap[keyStr] = v.Value()
+			}
+		}
+		c.links = append(c.links, Link{
+			Marker:   displayText,
+			Resource: goMap,
+		})
+	}
+}
+
+// EvaluateAuditMatch evaluates a match expression against an audit log entry.
+func EvaluateAuditMatch(expression string, audit interface{}) (bool, error) {
+	auditMap, err := toMap(audit)
+	if err != nil {
+		return false, fmt.Errorf("failed to convert audit to map: %w", err)
+	}
+	return EvaluateAuditMatchWithKind(expression, auditMap,
+		extractString(auditMap, "objectRef", "resource"),
+		extractString(auditMap, "objectRef", "resource"))
+}
+
+// EvaluateAuditMatchWithKind evaluates a match expression against an audit log entry
+// with explicit kind labels.
+func EvaluateAuditMatchWithKind(expression string, auditMap map[string]interface{}, kindLabel, kindLabelPlural string) (bool, error) {
+	env, err := auditEnvironment(nil) // No link collection for match expressions
+	if err != nil {
+		return false, fmt.Errorf("failed to create audit environment: %w", err)
+	}
+
+	ast, issues := env.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		return false, fmt.Errorf("failed to compile match expression: %w", issues.Err())
+	}
+
+	prg, err := env.Program(ast)
+	if err != nil {
+		return false, fmt.Errorf("failed to create program: %w", err)
+	}
+
+	out, _, err := prg.Eval(map[string]interface{}{
+		"audit":      auditMap,
+		"kind":       kindLabel,
+		"kindPlural": kindLabelPlural,
+		"actor":      extractString(auditMap, "user", "username"),
+		"actorRef":   buildActorRef(auditMap),
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to evaluate match expression: %w", err)
+	}
+
+	result, ok := out.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("match expression did not return a boolean")
+	}
+
+	return result, nil
+}
+
+// EvaluateAuditSummary evaluates a summary template against an audit log entry.
+func EvaluateAuditSummary(template string, audit interface{}) (string, []Link, error) {
+	auditMap, err := toMap(audit)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to convert audit to map: %w", err)
+	}
+	return EvaluateAuditSummaryWithKind(template, auditMap,
+		extractString(auditMap, "objectRef", "resource"),
+		extractString(auditMap, "objectRef", "resource"))
+}
+
+// EvaluateAuditSummaryWithKind evaluates a summary template against an audit log entry
+// with explicit kind labels.
+func EvaluateAuditSummaryWithKind(template string, auditMap map[string]interface{}, kindLabel, kindLabelPlural string) (string, []Link, error) {
+	collector := &linkCollector{}
+	env, err := auditEnvironment(collector)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create audit environment: %w", err)
+	}
+
+	vars := map[string]interface{}{
+		"audit":      auditMap,
+		"kind":       kindLabel,
+		"kindPlural": kindLabelPlural,
+		"actor":      extractString(auditMap, "user", "username"),
+		"actorRef":   buildActorRef(auditMap),
+	}
+
+	result, err := evaluateSummaryTemplate(env, template, vars)
+	if err != nil {
+		return "", nil, err
+	}
+	return result, collector.links, nil
+}
+
+// EvaluateEventMatch evaluates a match expression against a Kubernetes event.
+func EvaluateEventMatch(expression string, event map[string]interface{}) (bool, error) {
+	return EvaluateEventMatchWithKind(expression, event,
+		extractString(event, "regarding", "kind"),
+		extractString(event, "regarding", "kind"))
+}
+
+// EvaluateEventMatchWithKind evaluates a match expression against a Kubernetes event
+// with explicit kind labels.
+func EvaluateEventMatchWithKind(expression string, event map[string]interface{}, kindLabel, kindLabelPlural string) (bool, error) {
+	env, err := eventEnvironment(nil) // No link collection for match expressions
+	if err != nil {
+		return false, fmt.Errorf("failed to create event environment: %w", err)
+	}
+
+	ast, issues := env.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		return false, fmt.Errorf("failed to compile match expression: %w", issues.Err())
+	}
+
+	prg, err := env.Program(ast)
+	if err != nil {
+		return false, fmt.Errorf("failed to create program: %w", err)
+	}
+
+	out, _, err := prg.Eval(map[string]interface{}{
+		"event":      event,
+		"kind":       kindLabel,
+		"kindPlural": kindLabelPlural,
+		"actor":      extractString(event, "reportingController"),
+		"actorRef":   buildEventActorRef(event),
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to evaluate match expression: %w", err)
+	}
+
+	result, ok := out.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("match expression did not return a boolean")
+	}
+
+	return result, nil
+}
+
+// EvaluateEventSummary evaluates a summary template against a Kubernetes event.
+func EvaluateEventSummary(template string, event map[string]interface{}) (string, []Link, error) {
+	return EvaluateEventSummaryWithKind(template, event,
+		extractString(event, "regarding", "kind"),
+		extractString(event, "regarding", "kind"))
+}
+
+// EvaluateEventSummaryWithKind evaluates a summary template against a Kubernetes event
+// with explicit kind labels.
+func EvaluateEventSummaryWithKind(template string, event map[string]interface{}, kindLabel, kindLabelPlural string) (string, []Link, error) {
+	collector := &linkCollector{}
+	env, err := eventEnvironment(collector)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create event environment: %w", err)
+	}
+
+	vars := map[string]interface{}{
+		"event":      event,
+		"kind":       kindLabel,
+		"kindPlural": kindLabelPlural,
+		"actor":      extractString(event, "reportingController"),
+		"actorRef":   buildEventActorRef(event),
+	}
+
+	result, err := evaluateSummaryTemplate(env, template, vars)
+	if err != nil {
+		return "", nil, err
+	}
+	return result, collector.links, nil
+}
+
+// evaluateSummaryTemplate evaluates a summary template with the given variables.
+// Links are captured by the linkCollector in the CEL environment during evaluation.
+func evaluateSummaryTemplate(env *cel.Env, template string, vars map[string]interface{}) (string, error) {
+	result := summaryTemplateRegex.ReplaceAllStringFunc(template, func(match string) string {
+		// Extract the expression from {{ expression }}
+		submatches := summaryTemplateRegex.FindStringSubmatch(match)
+		if len(submatches) < 2 {
+			return match
+		}
+
+		expr := strings.TrimSpace(submatches[1])
+
+		// Compile and evaluate the expression
+		// The link() function in the environment will capture links automatically
+		ast, issues := env.Compile(expr)
+		if issues != nil && issues.Err() != nil {
+			return fmt.Sprintf("[ERROR: %v]", issues.Err())
+		}
+
+		prg, err := env.Program(ast)
+		if err != nil {
+			return fmt.Sprintf("[ERROR: %v]", err)
+		}
+
+		out, _, err := prg.Eval(vars)
+		if err != nil {
+			return fmt.Sprintf("[ERROR: %v]", err)
+		}
+
+		return fmt.Sprintf("%v", out.Value())
+	})
+
+	return result, nil
+}
+
+// toMap converts an interface to a map[string]interface{}.
+func toMap(v interface{}) (map[string]interface{}, error) {
+	if m, ok := v.(map[string]interface{}); ok {
+		return m, nil
+	}
+
+	// For structured types, we'd need to use reflection or JSON marshaling
+	// For now, return an error for unsupported types
+	return nil, fmt.Errorf("unsupported type for map conversion: %T", v)
+}
+
+// extractString extracts a nested string value from a map.
+func extractString(m map[string]interface{}, keys ...string) string {
+	current := m
+	for i, key := range keys {
+		if i == len(keys)-1 {
+			// Last key - expect string
+			if v, ok := current[key].(string); ok {
+				return v
+			}
+			return ""
+		}
+		// Not last key - expect nested map
+		if nested, ok := current[key].(map[string]interface{}); ok {
+			current = nested
+		} else {
+			return ""
+		}
+	}
+	return ""
+}
+
+// buildActorRef builds an actor reference map from audit user info.
+// Returns a map with {type, name} structure matching the Activity actor format.
+func buildActorRef(auditMap map[string]interface{}) map[string]interface{} {
+	username := extractString(auditMap, "user", "username")
+	if username == "" {
+		return map[string]interface{}{
+			"type": "unknown",
+			"name": "",
+		}
+	}
+
+	// Determine actor type based on username pattern
+	actorType := "user"
+	if strings.HasPrefix(username, "system:serviceaccount:") {
+		actorType = "serviceaccount"
+	} else if strings.HasPrefix(username, "system:") {
+		actorType = "system"
+	}
+
+	return map[string]interface{}{
+		"type": actorType,
+		"name": username,
+	}
+}
+
+// buildEventActorRef builds an actor reference map from a Kubernetes event.
+func buildEventActorRef(event map[string]interface{}) map[string]interface{} {
+	controller := extractString(event, "reportingController")
+	if controller == "" {
+		controller = extractString(event, "source", "component")
+	}
+
+	return map[string]interface{}{
+		"type": "controller",
+		"name": controller,
+	}
+}

--- a/internal/cel/policy_test.go
+++ b/internal/cel/policy_test.go
@@ -1,0 +1,257 @@
+package cel
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePolicyExpression_MatchExpressions(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		ruleType   PolicyRuleType
+		wantErr    bool
+		errContains string
+	}{
+		{
+			name:       "valid audit verb match",
+			expression: "audit.verb == 'create'",
+			ruleType:   AuditRule,
+			wantErr:    false,
+		},
+		{
+			name:       "valid audit verb in list",
+			expression: "audit.verb in ['update', 'patch']",
+			ruleType:   AuditRule,
+			wantErr:    false,
+		},
+		{
+			name:       "valid audit subresource check",
+			expression: "audit.objectRef.subresource == 'status'",
+			ruleType:   AuditRule,
+			wantErr:    false,
+		},
+		{
+			name:       "valid true fallback",
+			expression: "true",
+			ruleType:   AuditRule,
+			wantErr:    false,
+		},
+		{
+			name:       "valid event reason match",
+			expression: "event.reason == 'Programmed'",
+			ruleType:   EventRule,
+			wantErr:    false,
+		},
+		{
+			name:       "valid event startsWith",
+			expression: "event.reason.startsWith('Failed')",
+			ruleType:   EventRule,
+			wantErr:    false,
+		},
+		{
+			name:       "invalid - non-boolean return",
+			expression: "audit.verb",
+			ruleType:   AuditRule,
+			wantErr:    true,
+			errContains: "must return a boolean",
+		},
+		{
+			name:       "invalid - undefined variable",
+			expression: "foo.bar == 'test'",
+			ruleType:   AuditRule,
+			wantErr:    true,
+			errContains: "undeclared reference",
+		},
+		{
+			name:       "invalid - empty expression",
+			expression: "",
+			ruleType:   AuditRule,
+			wantErr:    true,
+			errContains: "cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePolicyExpression(tt.expression, MatchExpression, tt.ruleType)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errContains)
+				} else if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidatePolicyExpression_SummaryExpressions(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		ruleType   PolicyRuleType
+		wantErr    bool
+		errContains string
+	}{
+		{
+			name:       "valid actor template",
+			expression: "{{ actor }} created something",
+			ruleType:   AuditRule,
+			wantErr:    false,
+		},
+		{
+			name:       "valid link function",
+			expression: "{{ actor }} created {{ link(kind + ' ' + audit.objectRef.name, audit.responseObject) }}",
+			ruleType:   AuditRule,
+			wantErr:    false,
+		},
+		{
+			name:       "valid link in ternary expression",
+			expression: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified {{ audit.objectRef.name }}",
+			ruleType:   AuditRule,
+			wantErr:    false,
+		},
+		{
+			name:       "valid event summary",
+			expression: "{{ link(kind + ' ' + event.regarding.name, event.regarding) }} is now programmed",
+			ruleType:   EventRule,
+			wantErr:    false,
+		},
+		{
+			name:       "valid multiple templates",
+			expression: "{{ actor }} updated {{ kind }} {{ audit.objectRef.name }}",
+			ruleType:   AuditRule,
+			wantErr:    false,
+		},
+		{
+			name:       "valid static summary (no templates)",
+			expression: "Something happened",
+			ruleType:   AuditRule,
+			wantErr:    false,
+		},
+		{
+			name:       "invalid - empty template expression",
+			expression: "{{ }}",
+			ruleType:   AuditRule,
+			wantErr:    true,
+			errContains: "empty expression",
+		},
+		{
+			name:       "invalid - undefined variable in template",
+			expression: "{{ foo.bar }}",
+			ruleType:   AuditRule,
+			wantErr:    true,
+			errContains: "undeclared reference",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePolicyExpression(tt.expression, SummaryExpression, tt.ruleType)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errContains)
+				} else if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestEvaluateAuditSummary_TernaryWithLink(t *testing.T) {
+	tests := []struct {
+		name           string
+		template       string
+		auditMap       map[string]interface{}
+		wantSummary    string
+		wantLinkCount  int
+		wantErr        bool
+	}{
+		{
+			name:     "ternary evaluates to system (no link)",
+			template: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified pod",
+			auditMap: map[string]interface{}{
+				"user": map[string]interface{}{
+					"username": "system:serviceaccount:kube-system:default",
+				},
+				"objectRef": map[string]interface{}{
+					"resource": "pods",
+					"name":     "test-pod",
+				},
+			},
+			wantSummary:   "System modified pod",
+			wantLinkCount: 0,
+			wantErr:       false,
+		},
+		{
+			name:     "ternary evaluates to link (user actor)",
+			template: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified pod",
+			auditMap: map[string]interface{}{
+				"user": map[string]interface{}{
+					"username": "kubernetes-admin",
+				},
+				"objectRef": map[string]interface{}{
+					"resource": "pods",
+					"name":     "test-pod",
+				},
+			},
+			wantSummary:   "kubernetes-admin modified pod",
+			wantLinkCount: 1, // Link is captured even inside ternary
+			wantErr:       false,
+		},
+		{
+			name:     "standalone link function",
+			template: "{{ link(audit.objectRef.name, audit.objectRef) }} was modified",
+			auditMap: map[string]interface{}{
+				"user": map[string]interface{}{
+					"username": "admin",
+				},
+				"objectRef": map[string]interface{}{
+					"resource": "pods",
+					"name":     "my-pod",
+				},
+			},
+			wantSummary:   "my-pod was modified",
+			wantLinkCount: 1,
+			wantErr:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary, links, err := EvaluateAuditSummary(tt.template, tt.auditMap)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if summary != tt.wantSummary {
+				t.Errorf("got summary %q, want %q", summary, tt.wantSummary)
+			}
+
+			if len(links) != tt.wantLinkCount {
+				t.Errorf("got %d links, want %d", len(links), tt.wantLinkCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds the expression engine that powers ActivityPolicy rules and Activity filtering:

- **Policy matching**: Define rules like `audit.verb == "delete"` to capture specific actions
- **Activity filtering**: Query activities with expressions like `changeSource == "human" && resource.kind == "Deployment"`
- **Template rendering**: Generate human-readable summaries like "alice deleted Deployment nginx"

## Context

This is the foundation for letting service providers customize how their resources appear in activity feeds. For example, a networking team can create policies that translate low-level audit events into meaningful messages like "api-gateway proxy route updated" instead of raw API operations.

## What's supported

**For policy rules:**
- Match on audit fields: `audit.verb`, `audit.user.username`, `audit.objectRef.name`
- Match on event fields: `event.reason`, `event.message`, `event.regarding.name`

**For activity filters:**
- Filter by change source: `changeSource == "human"` (exclude system noise)
- Filter by resource: `resource.kind == "HTTPProxy" && resource.apiGroup == "networking.datumapis.com"`
- Filter by actor: `actor.name.contains("admin")`
- Combine with AND/OR/NOT: `changeSource == "human" && !(resource.kind == "Event")`

## Dependencies

- #35 

---

Relates to https://github.com/datum-cloud/enhancements/issues/469