### PR TITLE
feat: add controller manager for ActivityPolicy reconciliation

### DIFF
--- a/cmd/activity/controller_manager.go
+++ b/cmd/activity/controller_manager.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"go.miloapis.com/activity/internal/controller"
+)
+
+// ControllerManagerOptions contains configuration for the controller manager.
+type ControllerManagerOptions struct {
+	Kubeconfig      string
+	MasterURL       string
+	Workers         int
+	MetricsAddr     string
+	HealthProbeAddr string
+}
+
+// NewControllerManagerOptions creates options with default values.
+func NewControllerManagerOptions() *ControllerManagerOptions {
+	return &ControllerManagerOptions{
+		Workers:         2,
+		MetricsAddr:     ":8080",
+		HealthProbeAddr: ":8081",
+	}
+}
+
+// AddFlags adds controller manager flags to the command.
+func (o *ControllerManagerOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig,
+		"Path to a kubeconfig file. Only required if out-of-cluster.")
+	fs.StringVar(&o.MasterURL, "master", o.MasterURL,
+		"The address of the Kubernetes API server. Overrides any value in kubeconfig.")
+	fs.IntVar(&o.Workers, "workers", o.Workers,
+		"Number of worker threads for the controller.")
+	fs.StringVar(&o.MetricsAddr, "metrics-addr", o.MetricsAddr,
+		"The address to bind the metrics endpoint.")
+	fs.StringVar(&o.HealthProbeAddr, "health-probe-addr", o.HealthProbeAddr,
+		"The address to bind the health probe endpoint.")
+}
+
+// NewControllerManagerCommand creates the controller-manager subcommand.
+func NewControllerManagerCommand() *cobra.Command {
+	options := NewControllerManagerOptions()
+
+	cmd := &cobra.Command{
+		Use:   "controller-manager",
+		Short: "Run the controller manager",
+		Long: `Run the controller manager that watches for changes to Activity resources
+and reconciles the desired state. This includes managing ActivityPolicy resources
+and ensuring consistent state across the cluster.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Set up controller-runtime logging
+			ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+			return RunControllerManager(options)
+		},
+	}
+
+	options.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// RunControllerManager starts the controller manager.
+func RunControllerManager(options *ControllerManagerOptions) error {
+	klog.Info("Starting Activity Controller Manager")
+
+	// Build the client configuration
+	var config *rest.Config
+	var err error
+
+	if options.Kubeconfig != "" {
+		config, err = clientcmd.BuildConfigFromFlags(options.MasterURL, options.Kubeconfig)
+	} else {
+		config, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		return err
+	}
+
+	// Create the controller manager
+	mgr, err := controller.NewManager(config, controller.ManagerOptions{
+		Workers:         options.Workers,
+		MetricsAddr:     options.MetricsAddr,
+		HealthProbeAddr: options.HealthProbeAddr,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Use controller-runtime's signal handler for graceful shutdown
+	ctx := ctrl.SetupSignalHandler()
+
+	// Run the controller manager
+	if err := controller.Run(ctx, mgr); err != nil {
+		return err
+	}
+
+	klog.Info("Controller manager shutdown complete")
+	return nil
+}

--- a/cmd/activity/main.go
+++ b/cmd/activity/main.go
@@ -51,6 +51,7 @@ AuditLogQuery resources accessible through kubectl or any Kubernetes client.`,
 	}
 
 	cmd.AddCommand(NewServeCommand())
+	cmd.AddCommand(NewControllerManagerCommand())
 	cmd.AddCommand(NewVersionCommand())
 	cmd.AddCommand(NewMCPCommand())
 

--- a/config/base/controller-manager.yaml
+++ b/config/base/controller-manager.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activity-controller-manager
+  namespace: activity-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: activity-controller-manager
+  template:
+    metadata:
+      labels:
+        app: activity-controller-manager
+    spec:
+      serviceAccountName: activity-controller-manager
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: manager
+        image: ghcr.io/datum-cloud/activity:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        - containerPort: 8081
+          name: health
+          protocol: TCP
+        command:
+        - /activity
+        - controller-manager
+        args:
+        - --workers=$(WORKERS)
+        - --resync-period=$(RESYNC_PERIOD)
+        - --metrics-addr=$(METRICS_ADDR)
+        - --health-probe-addr=$(HEALTH_PROBE_ADDR)
+        - -v=$(LOG_LEVEL)
+        env:
+        - name: WORKERS
+          value: "2"
+        - name: RESYNC_PERIOD
+          value: "30"
+        - name: METRICS_ADDR
+          value: ":8080"
+        - name: HEALTH_PROBE_ADDR
+          value: ":8081"
+        - name: LOG_LEVEL
+          value: "2"
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: health
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/config/overlays/dev/patches/controller-manager-patch.yaml
+++ b/config/overlays/dev/patches/controller-manager-patch.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activity-controller-manager
+  namespace: activity-system
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: manager
+        # Dev-specific configuration
+        imagePullPolicy: Never  # Use images loaded via kind load
+        env:
+        - name: LOG_LEVEL
+          value: "4"  # Verbosity level: 0=info, 2=debug, 4=trace
+        resources:
+          # Reduced resources for dev environments
+          requests:
+            cpu: 25m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4
 	k8s.io/kubectl v0.34.3
+	sigs.k8s.io/controller-runtime v0.23.1
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482
 )
 
 require (
@@ -44,6 +46,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
+	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
@@ -124,6 +127,7 @@ require (
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.77.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
@@ -131,6 +135,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apiextensions-apiserver v0.35.0 // indirect
 	k8s.io/code-generator v0.35.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/kms v0.35.0 // indirect
@@ -140,7 +145,6 @@ require (
 	sigs.k8s.io/kustomize/api v0.20.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,10 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8P3k=
+github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
+github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
+github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -96,6 +100,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/jsonschema-go v0.2.0 h1:Uh19091iHC56//WOsAd1oRg6yy1P9BpSvpjOL6RcjLQ=
 github.com/google/jsonschema-go v0.2.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
@@ -178,6 +184,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+v
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4/v4 v4.1.23 h1:oJE7T90aYBGtFNrI8+KbETnPymobAhzRrR8Mu8n1yfU=
 github.com/pierrec/lz4/v4 v4.1.23/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -350,6 +357,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
+gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
 google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 h1:fCvbg86sFXwdrl5LgVcTEvNC+2txB5mgROGmRL5mrls=
@@ -377,6 +386,8 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.0 h1:iBAU5LTyBI9vw3L5glmat1njFK34srdLmktWwLTprlY=
 k8s.io/api v0.35.0/go.mod h1:AQ0SNTzm4ZAczM03QH42c7l3bih1TbAXYo0DkF8ktnA=
+k8s.io/apiextensions-apiserver v0.35.0 h1:3xHk2rTOdWXXJM+RDQZJvdx0yEOgC0FgQ1PlJatA5T4=
+k8s.io/apiextensions-apiserver v0.35.0/go.mod h1:E1Ahk9SADaLQ4qtzYFkwUqusXTcaV2uw3l14aqpL2LU=
 k8s.io/apimachinery v0.35.0 h1:Z2L3IHvPVv/MJ7xRxHEtk6GoJElaAqDCCU0S6ncYok8=
 k8s.io/apimachinery v0.35.0/go.mod h1:jQCgFZFR1F4Ik7hvr2g84RTJSZegBc8yHgFWKn//hns=
 k8s.io/apiserver v0.35.0 h1:CUGo5o+7hW9GcAEF3x3usT3fX4f9r8xmgQeCBDaOgX4=
@@ -403,6 +414,8 @@ k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzk
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
+sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
+sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kustomize/api v0.20.1 h1:iWP1Ydh3/lmldBnH/S5RXgT98vWYMaTUL1ADcr+Sv7I=
@@ -411,7 +424,7 @@ sigs.k8s.io/kustomize/kyaml v0.20.1 h1:PCMnA2mrVbRP3NIB6v9kYCAc38uvFLVs8j/CD567A
 sigs.k8s.io/kustomize/kyaml v0.20.1/go.mod h1:0EmkQHRUsJxY8Ug9Niig1pUMSCGHxQ5RklbpV/Ri6po=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.3.0 h1:jTijUJbW353oVOd9oTlifJqOGEkUw2jB/fXCbTiQEco=
-sigs.k8s.io/structured-merge-diff/v6 v6.3.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
+sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 h1:2WOzJpHUBVrrkDjU4KBT8n5LDcj824eX0I5UKcgeRUs=
+sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/internal/controller/activitypolicy_controller.go
+++ b/internal/controller/activitypolicy_controller.go
@@ -1,0 +1,183 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"go.miloapis.com/activity/internal/cel"
+	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
+)
+
+// ActivityPolicyReconciler reconciles ActivityPolicy resources.
+type ActivityPolicyReconciler struct {
+	client.Client
+	Scheme     *runtime.Scheme
+	RESTMapper meta.RESTMapper
+}
+
+// +kubebuilder:rbac:groups=activity.milo.io,resources=activitypolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=activity.milo.io,resources=activitypolicies/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=activity.milo.io,resources=activitypolicies/finalizers,verbs=update
+
+// Reconcile handles the reconciliation of an ActivityPolicy resource.
+func (r *ActivityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Fetch the ActivityPolicy
+	var policy v1alpha1.ActivityPolicy
+	if err := r.Get(ctx, req.NamespacedName, &policy); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			logger.Error(err, "unable to fetch ActivityPolicy")
+			return ctrl.Result{}, err
+		}
+		// Object was deleted, nothing to do
+		return ctrl.Result{}, nil
+	}
+
+	// Determine Ready condition
+	condition := metav1.Condition{
+		Type:               "Ready",
+		ObservedGeneration: policy.Generation,
+		LastTransitionTime: metav1.Now(),
+	}
+
+	// Validate that the target resource type exists in the cluster
+	if validationErr := r.validateResourceExists(policy.Spec.Resource.APIGroup, policy.Spec.Resource.Kind); validationErr != nil {
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = "ResourceNotFound"
+		condition.Message = validationErr.Error()
+		logger.V(2).Info("ActivityPolicy targets non-existent resource", "error", validationErr)
+
+		if err := r.updatePolicyStatus(ctx, &policy, condition); err != nil {
+			return ctrl.Result{}, fmt.Errorf("error updating policy status: %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Validate all CEL expressions in the policy
+	if validationErr := r.validatePolicy(&policy); validationErr != nil {
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = "ValidationFailed"
+		condition.Message = validationErr.Error()
+		logger.V(2).Info("ActivityPolicy failed validation", "error", validationErr)
+	} else {
+		condition.Status = metav1.ConditionTrue
+		condition.Reason = "Valid"
+		condition.Message = "All rules validated successfully"
+		logger.V(2).Info("ActivityPolicy validated successfully")
+	}
+
+	// Update status
+	if err := r.updatePolicyStatus(ctx, &policy, condition); err != nil {
+		return ctrl.Result{}, fmt.Errorf("error updating policy status: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ActivityPolicyReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.ActivityPolicy{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+		}).
+		Complete(r)
+}
+
+// updatePolicyStatus updates the status of an ActivityPolicy.
+func (r *ActivityPolicyReconciler) updatePolicyStatus(ctx context.Context, policy *v1alpha1.ActivityPolicy, condition metav1.Condition) error {
+	logger := log.FromContext(ctx)
+
+	// Check if status already has the same condition to avoid unnecessary updates
+	for _, c := range policy.Status.Conditions {
+		if c.Type == condition.Type &&
+			c.Status == condition.Status &&
+			c.Reason == condition.Reason &&
+			c.Message == condition.Message {
+			// Condition already matches, no update needed
+			return nil
+		}
+	}
+
+	// Update the conditions
+	found := false
+	for i, c := range policy.Status.Conditions {
+		if c.Type == condition.Type {
+			policy.Status.Conditions[i] = condition
+			found = true
+			break
+		}
+	}
+	if !found {
+		policy.Status.Conditions = append(policy.Status.Conditions, condition)
+	}
+
+	// Set observed generation
+	policy.Status.ObservedGeneration = policy.Generation
+
+	// Update via the status subresource
+	if err := r.Status().Update(ctx, policy); err != nil {
+		return fmt.Errorf("failed to update status: %w", err)
+	}
+
+	logger.V(4).Info("Updated ActivityPolicy status", "ready", condition.Status)
+	return nil
+}
+
+// validatePolicy validates all CEL expressions in the policy.
+func (r *ActivityPolicyReconciler) validatePolicy(policy *v1alpha1.ActivityPolicy) error {
+	// Validate audit rules
+	for i, rule := range policy.Spec.AuditRules {
+		if err := cel.ValidatePolicyExpression(rule.Match, cel.MatchExpression, cel.AuditRule); err != nil {
+			return fmt.Errorf("audit rule %d match: %w", i, err)
+		}
+		if err := cel.ValidatePolicyExpression(rule.Summary, cel.SummaryExpression, cel.AuditRule); err != nil {
+			return fmt.Errorf("audit rule %d summary: %w", i, err)
+		}
+	}
+
+	// Validate event rules
+	for i, rule := range policy.Spec.EventRules {
+		if err := cel.ValidatePolicyExpression(rule.Match, cel.MatchExpression, cel.EventRule); err != nil {
+			return fmt.Errorf("event rule %d match: %w", i, err)
+		}
+		if err := cel.ValidatePolicyExpression(rule.Summary, cel.SummaryExpression, cel.EventRule); err != nil {
+			return fmt.Errorf("event rule %d summary: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// validateResourceExists checks if the specified apiGroup/kind exists in the cluster.
+func (r *ActivityPolicyReconciler) validateResourceExists(apiGroup, kind string) error {
+	if r.RESTMapper == nil {
+		return nil // Skip validation if no RESTMapper available
+	}
+
+	gk := schema.GroupKind{Group: apiGroup, Kind: kind}
+	mapping, err := r.RESTMapper.RESTMapping(gk)
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			return fmt.Errorf("resource %q not found in API group %q - verify the Kind is spelled correctly (case-sensitive) and the CRD is installed", kind, apiGroup)
+		}
+		return fmt.Errorf("failed to validate resource %s/%s: %w", apiGroup, kind, err)
+	}
+
+	// Verify the kind matches exactly (case-sensitive)
+	if mapping.GroupVersionKind.Kind != kind {
+		return fmt.Errorf("kind mismatch: specified %q but API server has %q", kind, mapping.GroupVersionKind.Kind)
+	}
+
+	return nil
+}

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -1,0 +1,86 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
+)
+
+var (
+	// Scheme defines the runtime type system for API object serialization.
+	Scheme = runtime.NewScheme()
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(Scheme))
+}
+
+// ManagerOptions contains configuration for the controller manager.
+type ManagerOptions struct {
+	// Workers is the number of worker threads for processing items.
+	Workers int
+	// MetricsAddr is the address to bind the metrics endpoint.
+	MetricsAddr string
+	// HealthProbeAddr is the address to bind the health probe endpoint.
+	HealthProbeAddr string
+}
+
+// ActivityPolicyGVR is the GroupVersionResource for ActivityPolicy.
+var ActivityPolicyGVR = schema.GroupVersionResource{
+	Group:    v1alpha1.GroupName,
+	Version:  "v1alpha1",
+	Resource: "activitypolicies",
+}
+
+// NewManager creates a new controller manager using controller-runtime.
+func NewManager(config *rest.Config, options ManagerOptions) (ctrl.Manager, error) {
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
+		Scheme:                 Scheme,
+		HealthProbeBindAddress: options.HealthProbeAddr,
+		Metrics: metricsserver.Options{
+			BindAddress: options.MetricsAddr,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create manager: %w", err)
+	}
+
+	// Add health and readiness checks
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return nil, fmt.Errorf("failed to add healthz check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		return nil, fmt.Errorf("failed to add readyz check: %w", err)
+	}
+
+	// Create and register the ActivityPolicy reconciler
+	reconciler := &ActivityPolicyReconciler{
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		RESTMapper: mgr.GetRESTMapper(),
+	}
+
+	if err := reconciler.SetupWithManager(mgr, options.Workers); err != nil {
+		return nil, fmt.Errorf("failed to create ActivityPolicy controller: %w", err)
+	}
+
+	return mgr, nil
+}
+
+// Run starts the controller manager and blocks until the context is cancelled.
+func Run(ctx context.Context, mgr ctrl.Manager) error {
+	klog.Info("Starting controller manager")
+	return mgr.Start(ctx)
+}


### PR DESCRIPTION
Watch ActivityPolicy resources and keep a synchronized cache of compiled rules for the activity processor. Includes health checks and metrics endpoints for operational visibility.

---

Relates to https://github.com/datum-cloud/enhancements/issues/469