### PR TITLE
feat: add lightweight dev environment for local development

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -132,20 +132,180 @@ tasks:
         kind load docker-image "{{.ACTIVITY_IMAGE_NAME}}:{{.ACTIVITY_IMAGE_TAG}}" --name "{{.TEST_INFRA_CLUSTER_NAME}}"
         echo "Successfully loaded image into kind cluster"
 
+  # ============================================================
+  # Lightweight Dev Environment (single-replica, minimal resources)
+  # ============================================================
   dev:setup:
-    desc: Complete setup of test-infra cluster with Activity server and all dependencies
+    desc: Setup lightweight dev environment (single-replica ClickHouse, minimal resources)
     silent: true
     cmds:
       - task: test-infra:cluster-up
       - task: test-infra:install-observability
-      - task: dev:install-dependencies
+      - task: dev:install-dependencies-minimal
       - task: dev:build
       - task: dev:load
       - task: dev:deploy
       - task: observability:deploy
 
-  dev:install-dependencies:
-    desc: Install all infrastructure dependencies (ClickHouse operator, NATS)
+  dev:install-dependencies-minimal:
+    desc: Install minimal infrastructure dependencies for dev (no RustFS)
+    silent: true
+    cmds:
+      - |
+        set -e
+        echo "📦 Installing minimal infrastructure dependencies for dev..."
+        echo ""
+
+        # ============================================================
+        # Install ClickHouse Operator
+        # ============================================================
+        echo "📦 Installing ClickHouse operator via Flux HelmRelease..."
+
+        echo "Applying Flux HelmRelease for ClickHouse operator..."
+        task test-infra:kubectl -- apply -k config/dependencies/clickhouse-operator
+
+        echo "Waiting for operator HelmRelease to be ready..."
+        task test-infra:kubectl -- wait --for=condition=ready helmrelease/clickhouse-operator -n clickhouse-system --timeout=300s 2>/dev/null || echo "⚠️  HelmRelease not ready yet (may need Flux installed)"
+
+        echo "Waiting for operator deployment to be ready..."
+        task test-infra:kubectl -- wait --for=condition=available deployment/clickhouse-operator -n clickhouse-system --timeout=120s 2>/dev/null || echo "⚠️  Operator deployment not ready yet"
+
+        echo "✅ ClickHouse operator installed"
+        echo ""
+
+        # ============================================================
+        # Install NATS
+        # ============================================================
+        echo "📦 Installing NATS for event streaming..."
+
+        echo "Applying NATS resources..."
+        task test-infra:kubectl -- apply -k config/dependencies/nats
+
+        echo "Waiting for NATS namespace to be created..."
+        task test-infra:kubectl -- wait --for=jsonpath='{.status.phase}'=Active namespace/nats-system --timeout=30s 2>/dev/null || echo "⚠️  Namespace not ready yet"
+
+        echo "Waiting for NATS HelmRelease to be ready..."
+        task test-infra:kubectl -- wait --for=condition=ready helmrelease/nats -n nats-system --timeout=300s 2>/dev/null || echo "⚠️  NATS HelmRelease not ready yet (may need Flux installed)"
+
+        echo "Waiting for NATS pods to be ready..."
+        task test-infra:kubectl -- wait --for=condition=ready pod -l app.kubernetes.io/name=nats -n nats-system --timeout=120s 2>/dev/null || echo "⚠️  NATS pods not ready yet"
+
+        echo "✅ NATS installed"
+        echo ""
+
+        # Note: RustFS is NOT installed for dev - we use local disk for storage
+        # Note: etcd is deployed as part of the dev overlay (not as a dependency)
+        echo "ℹ️  Skipping RustFS (dev uses local disk for ClickHouse storage)"
+        echo ""
+
+        echo "✅ Minimal infrastructure dependencies installed!"
+        echo ""
+
+  dev:deploy:
+    desc: Deploy Activity server using dev overlay (lightweight, non-HA)
+    silent: true
+    cmds:
+      - |
+        set -e
+        echo "🚀 Deploying Activity server (dev overlay - lightweight)..."
+
+        # Check if deployment manifests exist
+        if [ ! -d "config" ]; then
+          echo "⚠️  Warning: config directory not found"
+          exit 1
+        fi
+
+        echo "📋 Deploying Activity server (dev overlay)..."
+        task test-infra:kubectl -- apply -k config/overlays/dev
+
+        echo "⏳ Waiting for etcd to be ready..."
+        task test-infra:kubectl -- wait --for=condition=ready helmrelease/etcd -n activity-system --timeout=300s 2>/dev/null || echo "⚠️  etcd HelmRelease not ready yet"
+        task test-infra:kubectl -- wait --for=condition=ready pod -l app.kubernetes.io/name=etcd -n activity-system --timeout=120s 2>/dev/null || echo "⚠️  etcd pods not ready yet"
+
+        echo "⏳ Waiting for NATS streams to be ready..."
+        task test-infra:kubectl -- wait --for=condition=ready stream/audit-events -n activity-system --timeout=60s 2>/dev/null || echo "⚠️  audit-events stream not ready yet"
+        task test-infra:kubectl -- wait --for=condition=ready stream/activities -n activity-system --timeout=60s 2>/dev/null || echo "⚠️  activities stream not ready yet"
+
+        echo ""
+        echo "⏳ Waiting for ClickHouse Keeper to be ready..."
+        task test-infra:kubectl -- wait --for=condition=ready pod -l clickhouse-keeper.altinity.com/chk=activity-keeper -n activity-system --timeout=180s || echo "⚠️  ClickHouse Keeper pods not ready yet"
+
+        echo "⏳ Waiting for ClickHouse to be ready..."
+        task test-infra:kubectl -- wait --for=jsonpath='{.status.status}'=Completed clickhouseinstallation -n activity-system activity-clickhouse --timeout=180s 2>/dev/null || echo "⚠️  ClickHouse Installation not completed"
+        task test-infra:kubectl -- wait --for=condition=ready pod -l clickhouse.altinity.com/chi=activity-clickhouse -n activity-system --timeout=180s || echo "⚠️  ClickHouse pods not ready yet"
+
+        echo "⏳ Waiting for ClickHouse migrations to complete..."
+        task test-infra:kubectl -- wait --for=condition=complete job/clickhouse-migrate -n activity-system --timeout=120s 2>/dev/null || echo "⚠️  Migration job not complete yet"
+
+        echo "⏳ Waiting for Activity server to be ready..."
+        task test-infra:kubectl -- wait --for=condition=ready pod -l app=activity-apiserver -n activity-system --timeout=120s || echo "⚠️  API server pods not ready yet"
+
+        echo "⏳ Waiting for Activity APIService to be available..."
+        task test-infra:kubectl -- wait --for=condition=Available apiservice/v1alpha1.activity.datum.net --timeout=120s || echo "⚠️  APIService not available yet"
+
+        echo "⏳ Waiting for Vector aggregator to be ready..."
+        task test-infra:kubectl -- wait --for=condition=ready pod -l app.kubernetes.io/instance=vector-aggregator -n activity-system --timeout=120s 2>/dev/null || echo "⚠️  Vector aggregator pods not ready yet"
+
+        echo ""
+        echo "📋 Installing example ActivityPolicies for basic Kubernetes resources..."
+        task test-infra:kubectl -- apply -k examples/basic-kubernetes/
+
+        echo ""
+        echo "✅ Activity server deployed (dev overlay)!"
+        echo ""
+        echo "📊 Check status:"
+        echo "  All resources:     task test-infra:kubectl -- get all -n activity-system"
+        echo "  API server pods:   task test-infra:kubectl -- get pods -l app=activity-apiserver -n activity-system"
+        echo "  ClickHouse pods:   task test-infra:kubectl -- get pods -l clickhouse.altinity.com/chi=activity-clickhouse -n activity-system"
+        echo "  ActivityPolicies:  task test-infra:kubectl -- get activitypolicies"
+        echo ""
+        echo "📋 View logs:"
+        echo "  API server:        task test-infra:kubectl -- logs -l app=activity-apiserver -n activity-system -f"
+        echo "  ClickHouse:        task test-infra:kubectl -- logs -l clickhouse.altinity.com/chi=activity-clickhouse -n activity-system -f"
+        echo ""
+
+  dev:redeploy:
+    desc: Quick rebuild and redeploy for dev environment
+    deps:
+      - dev:build
+      - dev:load
+    cmds:
+      - |
+        set -e
+        echo "Redeploying Activity server (dev)..."
+
+        # Restart all activity deployments to pick up new image
+        task test-infra:kubectl -- rollout restart -n activity-system deployment/activity-apiserver || echo "⚠️  Deployment not found, run 'task dev:deploy' first"
+        task test-infra:kubectl -- rollout restart -n activity-system deployment/activity-processor || echo "⚠️  activity-processor deployment not found"
+        task test-infra:kubectl -- rollout restart -n activity-system deployment/activity-controller-manager || echo "⚠️  activity-controller-manager deployment not found"
+
+        # Wait for rollouts to complete
+        echo "Waiting for rollouts to complete..."
+        task test-infra:kubectl -- rollout status -n activity-system deployment/activity-apiserver --timeout=120s || true
+        task test-infra:kubectl -- rollout status -n activity-system deployment/activity-processor --timeout=120s || true
+        task test-infra:kubectl -- rollout status -n activity-system deployment/activity-controller-manager --timeout=120s || true
+
+        echo "✅ Redeployment complete!"
+        echo "Check logs with: task test-infra:kubectl -- logs -l app=activity-apiserver -n activity-system -f"
+    silent: true
+
+  # ============================================================
+  # Test Environment (full HA setup with RustFS)
+  # ============================================================
+  test:setup:
+    desc: Setup full test environment with HA ClickHouse (3 replicas), S3 storage, and all components
+    silent: true
+    cmds:
+      - task: test-infra:cluster-up
+      - task: test-infra:install-observability
+      - task: test:install-dependencies
+      - task: dev:build
+      - task: dev:load
+      - task: test:deploy
+      - task: observability:deploy
+
+  test:install-dependencies:
+    desc: Install all infrastructure dependencies for test environment (includes RustFS)
     silent: true
     cmds:
       - |
@@ -191,7 +351,7 @@ tasks:
         echo ""
 
         # Note: NACK controller is now installed as part of NATS dependencies kustomization above
-        # Stream configurations will be deployed as part of dev:deploy step
+        # Stream configurations will be deployed as part of test:deploy step
 
         # ============================================================
         # Install RustFS for S3-compatible object storage
@@ -212,8 +372,6 @@ tasks:
 
         echo "✅ RustFS storage installed"
         echo ""
-        # echo "📝 Note: S3 bucket will be created when deploying ClickHouse (task dev:deploy)"
-        # echo ""
 
         # ============================================================
         # Summary
@@ -234,13 +392,13 @@ tasks:
         echo "Note: JetStream stream configurations and S3 bucket will be deployed with the Activity server."
         echo ""
 
-  dev:deploy:
-    desc: Deploy Activity server to test-infra cluster
+  test:deploy:
+    desc: Deploy Activity server using test-infra overlay (full HA with 3 replicas)
     silent: true
     cmds:
       - |
         set -e
-        echo "🚀 Deploying Activity server to test-infra cluster..."
+        echo "🚀 Deploying Activity server (test-infra overlay - full HA)..."
 
         # Check if deployment manifests exist
         if [ ! -d "config" ]; then
@@ -248,22 +406,22 @@ tasks:
           exit 1
         fi
 
-        echo "📋 Deploying NATS stream configuration..."
-        task test-infra:kubectl -- apply -k config/components/nats-streams
-
-        echo "⏳ Waiting for NATS stream to be ready..."
-        task test-infra:kubectl -- wait --for=condition=ready stream/audit-events -n nats-system --timeout=60s 2>/dev/null || echo "⚠️  Stream not ready yet"
-
-        echo ""
-        echo "📋 Deploying Activity server and components..."
+        echo "📋 Deploying Activity server and components (test-infra overlay)..."
         task test-infra:kubectl -- apply -k config/overlays/test-infra
+
+        echo "⏳ Waiting for NATS streams to be ready..."
+        task test-infra:kubectl -- wait --for=condition=ready stream/audit-events -n activity-system --timeout=60s 2>/dev/null || echo "⚠️  audit-events stream not ready yet"
+        task test-infra:kubectl -- wait --for=condition=ready stream/activities -n activity-system --timeout=60s 2>/dev/null || echo "⚠️  activities stream not ready yet"
 
         echo ""
         echo "⏳ Waiting for RustFS bucket initialization..."
         task test-infra:kubectl -- wait --for=condition=complete job/rustfs-bucket-init -n activity-system --timeout=120s 2>/dev/null || echo "⚠️  Bucket initialization not complete yet"
 
+        echo "⏳ Waiting for ClickHouse Keeper to be ready..."
+        task test-infra:kubectl -- wait --for=condition=ready pod -l clickhouse-keeper.altinity.com/chk=activity-keeper -n activity-system --timeout=180s || echo "⚠️  ClickHouse Keeper pods not ready yet"
+
         echo "⏳ Waiting for ClickHouse to be ready..."
-        task test-infra:kubectl -- wait --for=jsonpath='{.status.status}'=Completed clickhouseinstallation -n activity-system activity-clickhouse --timeout=180s 2>/dev/null || echo "⚠️  Clickhouse Installation not completed"
+        task test-infra:kubectl -- wait --for=jsonpath='{.status.status}'=Completed clickhouseinstallation -n activity-system activity-clickhouse --timeout=180s 2>/dev/null || echo "⚠️  ClickHouse Installation not completed"
         task test-infra:kubectl -- wait --for=condition=ready pod -l clickhouse.altinity.com/chi=activity-clickhouse -n activity-system --timeout=180s || echo "⚠️  ClickHouse pods not ready yet"
 
         echo "⏳ Waiting for ClickHouse migrations to complete..."
@@ -281,7 +439,11 @@ tasks:
         task test-infra:kubectl -- wait --for=condition=DatasourceSynchronized grafanadatasource/clickhouse-datasource -n activity-system --timeout=60s 2>/dev/null || echo "⚠️  Datasource not synced yet (may need to restart Grafana pod for plugin to load)"
 
         echo ""
-        echo "✅ Activity server and all dependencies deployed successfully!"
+        echo "📋 Installing example ActivityPolicies for basic Kubernetes resources..."
+        task test-infra:kubectl -- apply -k examples/basic-kubernetes/
+
+        echo ""
+        echo "✅ Activity server deployed (test-infra overlay - full HA)!"
         echo ""
         echo "📊 Check status:"
         echo "  All resources:     task test-infra:kubectl -- get all -n activity-system"
@@ -289,10 +451,11 @@ tasks:
         echo "  ClickHouse pods:   task test-infra:kubectl -- get pods -l clickhouse.altinity.com/chi=activity-clickhouse -n activity-system"
         echo "  Vector pods:       task test-infra:kubectl -- get pods -l app.kubernetes.io/instance=vector-aggregator -n activity-system"
         echo "  NATS pods:         task test-infra:kubectl -- get pods -n nats-system"
-        echo "  NATS streams:      task test-infra:kubectl -- get streams -n nats-system"
+        echo "  NATS streams:      task test-infra:kubectl -- get streams -n activity-system"
         echo "  S3 bucket:         task test-infra:kubectl -- get objectbucketclaim -n activity-system"
         echo "  API service:       kubectl get apiservice v1alpha1.activity.datum.net"
         echo "  Grafana datasrc:   task test-infra:kubectl -- get grafanadatasource clickhouse-datasource -n activity-system"
+        echo "  ActivityPolicies:  task test-infra:kubectl -- get activitypolicies"
         echo ""
         echo "📋 View logs:"
         echo "  API server:        task test-infra:kubectl -- logs -l app=activity-apiserver -n activity-system -f"
@@ -305,30 +468,30 @@ tasks:
         echo "  Grafana URL:       http://localhost:3000 (admin / datum123)"
         echo "  Verify datasource: task test-infra:kubectl -- get grafanadatasource -n activity-system"
         echo ""
-        echo "🔗 Milo Integration:"
-        echo "  If you have Milo deployed, integrate its audit logs:"
-        echo "    task dev:integrate-milo"
-        echo ""
 
-  dev:redeploy:
-    desc: Quick rebuild and redeploy for development iterations
+  test:redeploy:
+    desc: Quick rebuild and redeploy for test environment
     deps:
       - dev:build
       - dev:load
     cmds:
       - |
         set -e
-        echo "Redeploying Activity server..."
+        echo "Redeploying Activity server (test)..."
 
-        # Restart the deployment to pick up new image
-        task test-infra:kubectl -- rollout restart -n activity-system deployment/activity-apiserver || echo "⚠️  Deployment not found, run 'task dev:deploy' first"
+        # Restart all activity deployments to pick up new image
+        task test-infra:kubectl -- rollout restart -n activity-system deployment/activity-apiserver || echo "⚠️  Deployment not found, run 'task test:deploy' first"
+        task test-infra:kubectl -- rollout restart -n activity-system deployment/activity-processor || echo "⚠️  activity-processor deployment not found"
+        task test-infra:kubectl -- rollout restart -n activity-system deployment/activity-controller-manager || echo "⚠️  activity-controller-manager deployment not found"
 
-        # Wait for rollout to complete
-        echo "Waiting for rollout to complete..."
+        # Wait for rollouts to complete
+        echo "Waiting for rollouts to complete..."
         task test-infra:kubectl -- rollout status -n activity-system deployment/activity-apiserver --timeout=120s || true
+        task test-infra:kubectl -- rollout status -n activity-system deployment/activity-processor --timeout=120s || true
+        task test-infra:kubectl -- rollout status -n activity-system deployment/activity-controller-manager --timeout=120s || true
 
         echo "✅ Redeployment complete!"
-        echo "Check logs with: task test-infra:kubectl -- logs -l app=activity-apiserver"
+        echo "Check logs with: task test-infra:kubectl -- logs -l app=activity-apiserver -n activity-system -f"
     silent: true
 
   # OpenAPI code generation

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -6,6 +6,8 @@ namespace: activity-system
 resources:
   - serviceaccount.yaml
   - deployment.yaml
+  - processor.yaml             # Activity processor deployment + RBAC
+  - controller-manager.yaml    # Controller manager deployment + RBAC
   - service.yaml
   - secret.yaml
   - rbac-auth-reader.yaml

--- a/config/base/processor.yaml
+++ b/config/base/processor.yaml
@@ -85,7 +85,7 @@ spec:
         - name: NATS_STREAM
           value: "AUDIT_EVENTS"
         - name: CONSUMER_NAME
-          value: "activity-processor@activity.miloapis.com"
+          value: "activity-processor"
         - name: OUTPUT_STREAM
           value: "ACTIVITIES"
         - name: OUTPUT_SUBJECT_PREFIX

--- a/config/components/clickhouse-keeper-standalone/keeper-installation.yaml
+++ b/config/components/clickhouse-keeper-standalone/keeper-installation.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: clickhouse-keeper.altinity.com/v1
+kind: ClickHouseKeeperInstallation
+metadata:
+  name: activity-keeper
+  namespace: activity-system
+spec:
+  configuration:
+    settings:
+      prometheus/endpoint: /metrics
+      prometheus/port: 7000
+      prometheus/metrics: true
+      prometheus/events: true
+      prometheus/asynchronous_metrics: true
+
+    clusters:
+      - name: activity-keeper
+        layout:
+          # Single replica for dev environments (no HA)
+          replicasCount: 1
+
+  defaults:
+    templates:
+      podTemplate: clickhouse-keeper
+      dataVolumeClaimTemplate: clickhouse-keeper
+
+  templates:
+    podTemplates:
+      - name: clickhouse-keeper
+        spec:
+          containers:
+            - name: clickhouse-keeper
+              imagePullPolicy: IfNotPresent
+              image: clickhouse/clickhouse-keeper:25.12.3-alpine
+              resources:
+                # Reduced resources for dev environments
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+              ports:
+                - name: chk-metrics
+                  containerPort: 7000
+    volumeClaimTemplates:
+      - name: clickhouse-keeper
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi  # Reduced storage for dev

--- a/config/components/clickhouse-keeper-standalone/kustomization.yaml
+++ b/config/components/clickhouse-keeper-standalone/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - keeper-installation.yaml
+
+# Component metadata
+metadata:
+  name: clickhouse-keeper-standalone
+  annotations:
+    config.kubernetes.io/local-config: "true"

--- a/config/components/clickhouse-migrations/configmap.yaml
+++ b/config/components/clickhouse-migrations/configmap.yaml
@@ -96,10 +96,9 @@ data:
     # Wait for all replicas in the cluster to be healthy and ready
     # This function will wait indefinitely until all replicas are online and healthy
     wait_for_cluster_ready() {
-        log_info "Waiting for all 3 replicas in the 'activity' cluster to be ready..."
+        local expected_replicas="${EXPECTED_REPLICAS:-3}"
+        log_info "Waiting for all ${expected_replicas} replicas in the 'activity' cluster to be ready..."
         log_info "This will wait indefinitely until the cluster is healthy."
-
-        local expected_replicas=3
         local attempt=1
 
         while true; do

--- a/config/components/clickhouse-standalone/clickhouse-installation.yaml
+++ b/config/components/clickhouse-standalone/clickhouse-installation.yaml
@@ -1,0 +1,128 @@
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: activity-clickhouse
+  namespace: activity-system
+spec:
+  configuration:
+    # Single-replica mode with Keeper for coordination
+    # Uses Replicated database engine for migration compatibility
+    zookeeper:
+      nodes:
+        - host: chk-activity-keeper-activity-keeper-0-0.activity-system.svc.cluster.local
+          port: 2181
+      session_timeout_ms: 30000
+      operation_timeout_ms: 10000
+    clusters:
+      - name: activity
+        layout:
+          shardsCount: 1
+          replicasCount: 1  # Single replica for dev environments
+
+    users:
+      default/password: ""  # Empty password for dev environments
+      default/networks/ip:
+        - "0.0.0.0/0"
+    settings:
+      # Default settings for ClickHouse
+      default/default_database: audit
+
+      # No quorum settings needed for single replica
+      # Disabled: insert_quorum, select_sequential_consistency
+
+    profiles:
+      default/max_memory_usage: 10000000000  # 10GB max memory usage for dev
+    files:
+      config.d/log_rotation.xml: |-
+        <clickhouse>
+            <logger>
+                <level>information</level>
+                <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+                <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+                <size>100M</size>
+                <count>3</count>
+                <console>1</console>
+            </logger>
+        </clickhouse>
+      # Storage configuration compatible with migrations (hot_cold policy)
+      # Uses local disk for both hot and cold (no S3 in dev)
+      # This allows the same migrations to work in dev and production
+      config.d/storage.xml: |
+        <clickhouse>
+          <storage_configuration>
+            <disks>
+              <default>
+                <keep_free_space_bytes>536870912</keep_free_space_bytes>
+              </default>
+              <!-- Separate disk for cold data (same physical storage in dev) -->
+              <cold_disk>
+                <path>/var/lib/clickhouse/cold/</path>
+                <keep_free_space_bytes>536870912</keep_free_space_bytes>
+              </cold_disk>
+            </disks>
+            <policies>
+              <!-- hot_cold policy required by migrations -->
+              <!-- In production, 'cold' volume would use S3-backed storage -->
+              <hot_cold>
+                <volumes>
+                  <hot>
+                    <disk>default</disk>
+                  </hot>
+                  <cold>
+                    <disk>cold_disk</disk>
+                  </cold>
+                </volumes>
+                <move_factor>0</move_factor>
+              </hot_cold>
+            </policies>
+          </storage_configuration>
+        </clickhouse>
+  defaults:
+    templates:
+      dataVolumeClaimTemplate: data-volume
+      podTemplate: clickhouse-pod
+  templates:
+    podTemplates:
+      - name: clickhouse-pod
+        spec:
+          containers:
+            - name: clickhouse
+              image: clickhouse/clickhouse-server:latest
+              resources:
+                # Resources for dev environments
+                requests:
+                  cpu: 100m
+                  memory: 2Gi
+                limits:
+                  cpu: 2000m
+                  memory: 10Gi
+    volumeClaimTemplates:
+      - name: data-volume
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 2Gi  # Reduced storage for dev
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+  namespace: activity-system
+  labels:
+    app: clickhouse
+    app.kubernetes.io/component: database
+spec:
+  type: ClusterIP
+  ports:
+  - name: native
+    port: 9000
+    targetPort: 9000
+    protocol: TCP
+  - name: http
+    port: 8123
+    targetPort: 8123
+    protocol: TCP
+  selector:
+    clickhouse.altinity.com/chi: activity-clickhouse

--- a/config/components/clickhouse-standalone/kustomization.yaml
+++ b/config/components/clickhouse-standalone/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - clickhouse-installation.yaml
+
+# Component metadata
+metadata:
+  name: clickhouse-standalone
+  annotations:
+    config.kubernetes.io/local-config: "true"

--- a/config/components/etcd/helmrelease.yaml
+++ b/config/components/etcd/helmrelease.yaml
@@ -1,0 +1,74 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: etcd
+  namespace: activity-system
+spec:
+  interval: 5m
+  timeout: 10m
+
+  chart:
+    spec:
+      chart: etcd
+      version: 12.x
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: activity-system
+      interval: 1h
+
+  values:
+    # Allow legacy Bitnami images
+    global:
+      security:
+        allowInsecureImages: true
+
+    # Use bitnamilegacy registry (avoids Docker Hub rate limits)
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/etcd
+      tag: 3.6.4-debian-12-r4
+
+    # Single replica for dev environment
+    replicaCount: 1
+
+    # Authentication disabled for simplicity in dev
+    auth:
+      rbac:
+        create: false
+      token:
+        enabled: false
+
+    # Resource limits appropriate for dev
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
+    # Persistence configuration
+    persistence:
+      enabled: true
+      size: 1Gi
+
+    # Service configuration to match expected DNS name
+    service:
+      type: ClusterIP
+      ports:
+        client: 2379
+        peer: 2380
+
+  # Install configuration
+  install:
+    crds: CreateReplace
+    createNamespace: false
+
+  # Upgrade configuration
+  upgrade:
+    crds: CreateReplace
+
+  # Uninstall configuration
+  uninstall:
+    keepHistory: false

--- a/config/components/etcd/helmrepository.yaml
+++ b/config/components/etcd/helmrepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: bitnami
+  namespace: activity-system
+spec:
+  type: oci
+  interval: 1h
+  url: oci://registry-1.docker.io/bitnamicharts
+  timeout: 3m

--- a/config/components/etcd/kustomization.yaml
+++ b/config/components/etcd/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/config/components/nats-streams/activities-stream.yaml
+++ b/config/components/nats-streams/activities-stream.yaml
@@ -3,7 +3,6 @@ apiVersion: jetstream.nats.io/v1beta2
 kind: Stream
 metadata:
   name: activities
-  namespace: nats-system
 spec:
   # Stream name in NATS
   name: ACTIVITIES
@@ -22,8 +21,8 @@ spec:
   # Maximum age: 7 days retention
   maxAge: 168h  # 7 days = 168 hours
 
-  # Maximum bytes: 10GB
-  maxBytes: 10737418240  # 10 * 1024 * 1024 * 1024
+  # Maximum bytes: 1GB (sufficient for dev/test environments)
+  maxBytes: 1073741824  # 1 * 1024 * 1024 * 1024
 
   # Number of replicas for high availability
   replicas: 1  # Can be increased to 3 for production HA

--- a/config/components/nats-streams/activity-processor-consumer.yaml
+++ b/config/components/nats-streams/activity-processor-consumer.yaml
@@ -3,13 +3,12 @@ apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:
   name: activity-processor
-  namespace: nats-system
 spec:
   # Link to the audit events stream
   streamName: AUDIT_EVENTS
 
-  # Durable consumer name - fully qualified to identify the owning service
-  durableName: activity-processor@activity.miloapis.com
+  # Durable consumer name
+  durableName: activity-processor
 
   # Delivery policy: deliver all messages (including historical)
   # This allows the processor to catch up on missed events after restart

--- a/config/components/nats-streams/audit-stream.yaml
+++ b/config/components/nats-streams/audit-stream.yaml
@@ -3,7 +3,6 @@ apiVersion: jetstream.nats.io/v1beta2
 kind: Stream
 metadata:
   name: audit-events
-  namespace: nats-system
 spec:
   # Stream name in NATS
   name: AUDIT_EVENTS
@@ -21,8 +20,8 @@ spec:
   # Maximum age: 7 days retention as per architecture
   maxAge: 168h  # 7 days = 168 hours
 
-  # Maximum bytes: 100GB as per architecture
-  maxBytes: 107374182400  # 100 * 1024 * 1024 * 1024
+  # Maximum bytes: 1GB (sufficient for dev/test environments)
+  maxBytes: 1073741824  # 1 * 1024 * 1024 * 1024
 
   # Number of replicas for high availability
   replicas: 1  # Can be increased to 3 for production HA

--- a/config/components/nats-streams/clickhouse-activities-consumer.yaml
+++ b/config/components/nats-streams/clickhouse-activities-consumer.yaml
@@ -3,7 +3,6 @@ apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:
   name: clickhouse-ingest-activities
-  namespace: nats-system
 spec:
   # Link to the activities stream
   streamName: ACTIVITIES

--- a/config/components/nats-streams/clickhouse-consumer.yaml
+++ b/config/components/nats-streams/clickhouse-consumer.yaml
@@ -3,7 +3,6 @@ apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:
   name: clickhouse-ingest
-  namespace: nats-system
 spec:
   # Link to the stream
   streamName: AUDIT_EVENTS

--- a/config/components/nats-streams/kustomization.yaml
+++ b/config/components/nats-streams/kustomization.yaml
@@ -1,7 +1,5 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-namespace: nats-system
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
 
 resources:
   - audit-stream.yaml

--- a/config/overlays/dev/anonymous-rbac.yaml
+++ b/config/overlays/dev/anonymous-rbac.yaml
@@ -1,0 +1,18 @@
+---
+# Dev-only: Allow anonymous users to read Activity resources
+# This is required because the Gateway doesn't have requestheader auth configured
+# In production, proper authentication should be configured
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: activity-anonymous-reader
+  annotations:
+    description: "DEV ONLY - Allows anonymous access to Activity API for Gateway routing"
+subjects:
+  - kind: User
+    name: system:anonymous
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: activity-ui-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/config/overlays/dev/kustomization.yaml
+++ b/config/overlays/dev/kustomization.yaml
@@ -1,0 +1,51 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: activity-system
+
+# Base resources (API server, service, APIService, etc.)
+resources:
+  - ../../base
+  - anonymous-rbac.yaml     # Dev-only: anonymous access for Gateway
+
+components:
+  - ../../components/namespace
+  - ../../components/api-registration
+  - ../../components/cert-manager-ca
+  - ../../components/etcd                          # Single-node etcd for ActivityPolicy storage
+  - ../../components/clickhouse-keeper-standalone  # Single-node Keeper for coordination
+  - ../../components/clickhouse-standalone         # Single-replica ClickHouse
+  - ../../components/clickhouse-migrations
+  - ../../components/nats-streams                  # NATS JetStream streams and consumers
+  - ../../components/grafana-clickhouse
+  - ../../components/vector-sidecar
+  - ../../components/vector-aggregator
+  - ../../components/tracing
+  - ../../components/observability            # ServiceMonitors, alerts, dashboards
+
+# Note: The following HA components are excluded for dev environments:
+# - clickhouse-keeper       # Replaced by clickhouse-keeper-standalone (1 replica)
+# - clickhouse-database     # Replaced by clickhouse-standalone (1 replica)
+# - rustfs-bucket           # No S3 cold storage in dev (uses local disk for both hot/cold)
+
+# Image overrides for dev environment
+images:
+  - name: ghcr.io/datum-cloud/activity
+    newName: ghcr.io/datum-cloud/activity
+    newTag: dev
+
+# Patches specific to dev environment
+patches:
+  - path: patches/deployment-patch.yaml
+  - path: patches/activity-processor-patch.yaml
+  - path: patches/controller-manager-patch.yaml
+  - path: patches/apiservice-patch.yaml
+  - path: patches/migration-job-patch.yaml
+  - path: patches/vector-sidecar-patch.yaml
+  - path: patches/vector-aggregator-patch.yaml
+
+labels:
+  - includeSelectors: true
+    includeTemplates: true
+    pairs:
+      environment: dev

--- a/config/overlays/dev/patches/activity-processor-patch.yaml
+++ b/config/overlays/dev/patches/activity-processor-patch.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activity-processor
+  namespace: activity-system
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: processor
+        # Dev-specific configuration
+        imagePullPolicy: Never  # Use images loaded via kind load
+        env:
+        - name: LOG_LEVEL
+          value: "4"  # Verbosity level: 0=info, 2=debug, 4=trace
+        resources:
+          # Reduced resources for dev environments
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi

--- a/config/overlays/dev/patches/apiservice-patch.yaml
+++ b/config/overlays/dev/patches/apiservice-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.activity.miloapis.com
+spec:
+  # Skip TLS verification in dev environment
+  insecureSkipTLSVerify: true

--- a/config/overlays/dev/patches/deployment-patch.yaml
+++ b/config/overlays/dev/patches/deployment-patch.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activity-apiserver
+  namespace: activity-system
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: apiserver
+        # Dev-specific configuration
+        imagePullPolicy: Never  # Use images loaded via kind load
+        env:
+        - name: LOG_LEVEL
+          value: "4"  # Verbosity level: 0=info, 2=debug, 4=trace
+        - name: ENABLE_DEBUG_ENDPOINTS
+          value: "true"
+        resources:
+          # Reduced resources for dev environments
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi

--- a/config/overlays/dev/patches/migration-job-patch.yaml
+++ b/config/overlays/dev/patches/migration-job-patch.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: clickhouse-migrate
+  namespace: activity-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: migrate
+        env:
+        # Override expected replicas for dev environment (single replica)
+        - name: EXPECTED_REPLICAS
+          value: "1"
+        - name: CLICKHOUSE_HOST
+          value: "chi-activity-clickhouse-activity-0-0.activity-system.svc.cluster.local"
+        - name: CLICKHOUSE_PORT
+          value: "9000"
+        - name: CLICKHOUSE_USER
+          value: "default"
+        - name: CLICKHOUSE_PASSWORD
+          value: ""
+        - name: CLICKHOUSE_DATABASE
+          value: "audit"
+        - name: MIGRATIONS_DIR
+          value: "/migrations"

--- a/config/overlays/dev/patches/vector-aggregator-patch.yaml
+++ b/config/overlays/dev/patches/vector-aggregator-patch.yaml
@@ -1,0 +1,15 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vector-aggregator
+  namespace: activity-system
+spec:
+  values:
+    # Single replica for dev environments
+    replicas: 1
+    # Disable autoscaling for dev
+    autoscaling:
+      enabled: false
+    # Disable PDB for single replica
+    podDisruptionBudget:
+      enabled: false

--- a/config/overlays/dev/patches/vector-sidecar-patch.yaml
+++ b/config/overlays/dev/patches/vector-sidecar-patch.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vector-sidecar
+  namespace: activity-system
+spec:
+  values:
+    env:
+      - name: CLUSTER_NAME
+        value: "dev"
+      - name: VECTOR_LOG
+        value: "info"
+      - name: VECTOR_LOG_FORMAT
+        value: "json"
+
+    extraVolumes:
+      - name: audit-logs
+        hostPath:
+          path: /var/log/kubernetes
+          type: DirectoryOrCreate
+
+    extraVolumeMounts:
+      - name: audit-logs
+        mountPath: /var/log/kubernetes
+        readOnly: true
+
+    customConfig:
+      sources:
+        # File-based audit log collection from kind cluster
+        apiserver_audit_logs:
+          type: file
+          include:
+            - /var/log/kubernetes/kube-apiserver-audit.log
+            - /var/log/kubernetes/kube-apiserver-audit.log.*
+          read_from: beginning
+          fingerprint:
+            strategy: device_and_inode
+          max_line_bytes: 1048576
+
+      transforms:
+        # Parse JSON from file lines
+        parse_json_from_file:
+          type: remap
+          inputs:
+            - apiserver_audit_logs
+          source: |
+            . = parse_json!(.message)
+
+        # Set event timestamp from audit log stageTimestamp
+        # This is critical for accurate lag metrics - Vector will use this timestamp
+        # to calculate source_lag_time_seconds
+        set_event_timestamp:
+          type: remap
+          inputs:
+            - parse_json_from_file
+          source: |
+            # Parse stageTimestamp from the audit event and set as Vector's timestamp
+            # This allows Vector to calculate accurate lag metrics
+            if exists(.stageTimestamp) {
+              .timestamp = parse_timestamp!(.stageTimestamp, format: "%+")
+            }
+
+        # Add source metadata to file events
+        add_file_source_metadata:
+          type: remap
+          inputs:
+            - set_event_timestamp
+          source: |
+            .source = "dev-apiserver"
+            .cluster = get_env_var!("CLUSTER_NAME")
+
+        # Update webhook metadata to merge both sources
+        add_source_metadata:
+          type: remap
+          inputs:
+            - parse_webhook_batch
+            - add_file_source_metadata
+          source: |
+            if !exists(.source) {
+              .source = "dev-webhook"
+            }
+            if !exists(.cluster) {
+              .cluster = get_env_var!("CLUSTER_NAME")
+            }
+            # Also set timestamp for webhook events
+            if !exists(.timestamp) && exists(.stageTimestamp) {
+              .timestamp = parse_timestamp!(.stageTimestamp, format: "%+")
+            }

--- a/examples/basic-kubernetes/apps.yaml
+++ b/examples/basic-kubernetes/apps.yaml
@@ -1,0 +1,86 @@
+# ActivityPolicies for apps Kubernetes API group
+# Resources: Deployment, ReplicaSet, StatefulSet, DaemonSet
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: apps-deployments
+spec:
+  resource:
+    apiGroup: apps
+    kind: Deployment
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} deployed {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed deployment {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch'] && audit.objectRef.subresource == 'scale'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} scaled {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch'] && audit.objectRef.subresource == 'status'"
+      summary: "{{ link(audit.objectRef.name, audit.objectRef) }} status changed"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified deployment {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: apps-replicasets
+spec:
+  resource:
+    apiGroup: apps
+    kind: ReplicaSet
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created replica set {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed replica set {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch'] && audit.objectRef.subresource == 'scale'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} scaled {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated replica set {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified replica set {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: apps-statefulsets
+spec:
+  resource:
+    apiGroup: apps
+    kind: StatefulSet
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created stateful set {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed stateful set {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch'] && audit.objectRef.subresource == 'scale'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} scaled {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated stateful set {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified stateful set {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: apps-daemonsets
+spec:
+  resource:
+    apiGroup: apps
+    kind: DaemonSet
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created daemon set {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed daemon set {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated daemon set {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified daemon set {{ link(audit.objectRef.name, audit.objectRef) }}"

--- a/examples/basic-kubernetes/batch.yaml
+++ b/examples/basic-kubernetes/batch.yaml
@@ -1,0 +1,42 @@
+# ActivityPolicies for batch Kubernetes API group
+# Resources: Job, CronJob
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: batch-jobs
+spec:
+  resource:
+    apiGroup: batch
+    kind: Job
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} started job {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed job {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch'] && audit.objectRef.subresource == 'status'"
+      summary: "Job {{ link(audit.objectRef.name, audit.objectRef) }} status changed"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated job {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified job {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: batch-cronjobs
+spec:
+  resource:
+    apiGroup: batch
+    kind: CronJob
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created scheduled job {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed scheduled job {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated scheduled job {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified scheduled job {{ link(audit.objectRef.name, audit.objectRef) }}"

--- a/examples/basic-kubernetes/core.yaml
+++ b/examples/basic-kubernetes/core.yaml
@@ -1,0 +1,158 @@
+# ActivityPolicies for core Kubernetes API group
+# Resources: Pod, Service, ConfigMap, Secret, Namespace, ServiceAccount, PersistentVolumeClaim, PersistentVolume
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: core-pods
+spec:
+  resource:
+    apiGroup: ""
+    kind: Pod
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} started {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} stopped pod {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch'] && audit.objectRef.subresource == 'status'"
+      summary: "{{ link(audit.objectRef.name, audit.objectRef) }} status changed"
+    - match: "audit.verb == 'create' && audit.objectRef.subresource == 'eviction'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} evicted {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified pod {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: core-services
+spec:
+  resource:
+    apiGroup: ""
+    kind: Service
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created service {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed service {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated service {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified service {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: core-configmaps
+spec:
+  resource:
+    apiGroup: ""
+    kind: ConfigMap
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created config {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed config {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated config {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified config {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: core-secrets
+spec:
+  resource:
+    apiGroup: ""
+    kind: Secret
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created secret {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed secret {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated secret {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified secret {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: core-namespaces
+spec:
+  resource:
+    apiGroup: ""
+    kind: Namespace
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created namespace {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed namespace {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated namespace {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified namespace {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: core-serviceaccounts
+spec:
+  resource:
+    apiGroup: ""
+    kind: ServiceAccount
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created service account {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed service account {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated service account {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified service account {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: core-persistentvolumeclaims
+spec:
+  resource:
+    apiGroup: ""
+    kind: PersistentVolumeClaim
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} requested storage {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} released storage {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated storage claim {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified storage claim {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: core-persistentvolumes
+spec:
+  resource:
+    apiGroup: ""
+    kind: PersistentVolume
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} provisioned storage {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed storage {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated storage {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified storage {{ link(audit.objectRef.name, audit.objectRef) }}"

--- a/examples/basic-kubernetes/kustomization.yaml
+++ b/examples/basic-kubernetes/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Example ActivityPolicies for basic Kubernetes resources
+# These policies translate audit logs into human-readable activity summaries
+
+resources:
+  - core.yaml       # Pod, Service, ConfigMap, Secret, Namespace, ServiceAccount, PersistentVolumeClaim, PersistentVolume
+  - apps.yaml       # Deployment, ReplicaSet, StatefulSet, DaemonSet
+  - batch.yaml      # Job, CronJob
+  - networking.yaml # Ingress
+  - rbac.yaml       # ClusterRole, ClusterRoleBinding, Role, RoleBinding

--- a/examples/basic-kubernetes/networking.yaml
+++ b/examples/basic-kubernetes/networking.yaml
@@ -1,0 +1,21 @@
+# ActivityPolicies for networking.k8s.io Kubernetes API group
+# Resources: Ingress
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: networking-ingresses
+spec:
+  resource:
+    apiGroup: networking.k8s.io
+    kind: Ingress
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created ingress {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed ingress {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated ingress {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified ingress {{ link(audit.objectRef.name, audit.objectRef) }}"

--- a/examples/basic-kubernetes/rbac.yaml
+++ b/examples/basic-kubernetes/rbac.yaml
@@ -1,0 +1,78 @@
+# ActivityPolicies for rbac.authorization.k8s.io Kubernetes API group
+# Resources: ClusterRole, ClusterRoleBinding, Role, RoleBinding
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: rbac-clusterroles
+spec:
+  resource:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created cluster role {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed cluster role {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated cluster role {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified cluster role {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: rbac-clusterrolebindings
+spec:
+  resource:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRoleBinding
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} granted cluster permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} revoked cluster permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated cluster permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified cluster permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: rbac-roles
+spec:
+  resource:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created role {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed role {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated role {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified role {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: rbac-rolebindings
+spec:
+  resource:
+    apiGroup: rbac.authorization.k8s.io
+    kind: RoleBinding
+  auditRules:
+    - match: "audit.verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} granted permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} revoked permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - match: "true"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified permissions {{ link(audit.objectRef.name, audit.objectRef) }}"

--- a/migrations/migrate.sh
+++ b/migrations/migrate.sh
@@ -75,10 +75,9 @@ wait_for_clickhouse() {
 # Wait for all replicas in the cluster to be healthy and ready
 # This function will wait indefinitely until all replicas are online and healthy
 wait_for_cluster_ready() {
-    log_info "Waiting for all 3 replicas in the 'activity' cluster to be ready..."
+    local expected_replicas="${EXPECTED_REPLICAS:-3}"
+    log_info "Waiting for all ${expected_replicas} replicas in the 'activity' cluster to be ready..."
     log_info "This will wait indefinitely until the cluster is healthy."
-
-    local expected_replicas=3
     local attempt=1
 
     while true; do


### PR DESCRIPTION
### Summary

Sets up a minimal dev environment that's faster to spin up and easier on resources. Uses single-replica ClickHouse and etcd instead of the full HA setup, skips RustFS entirely (just uses local disk), and dials down resource requests across the board.

### New tasks:

- `task dev:setup` spins up the lightweight environment
- `task test:setup` is the old behavior (full HA with RustFS)

Also adds example ActivityPolicies for common Kubernetes resources so there's something to work with out of the box.

---

Relates to https://github.com/datum-cloud/enhancements/issues/469