### PR TITLE
feat: add MCP tools for AI assistants

### DIFF
--- a/cmd/activity/mcp.go
+++ b/cmd/activity/mcp.go
@@ -46,7 +46,7 @@ func NewMCPCommand() *cobra.Command {
 		Use:   "mcp",
 		Short: "Start the MCP server for AI tool integration",
 		Long: `Start an MCP (Model Context Protocol) server that exposes audit log
-query tools for AI assistants.
+and activity query tools for AI assistants.
 
 The server communicates via stdio and can be connected to Claude Desktop,
 VS Code extensions, or other MCP-compatible clients.
@@ -55,8 +55,28 @@ The server uses the Activity API via a Kubernetes client, so it requires
 a valid kubeconfig with access to the Activity API resources.
 
 Available tools:
-  - query_audit_logs: Search audit logs with CEL filters
-  - get_audit_log_facets: Get distinct values for audit log fields
+
+  Audit Log Tools:
+    - query_audit_logs: Search audit logs with CEL filters
+    - get_audit_log_facets: Get distinct values for audit log fields
+
+  Activity Tools (human-readable summaries):
+    - query_activities: Search human-readable activity summaries
+    - get_activity_facets: Get distinct values for activity fields
+
+  Investigation Tools:
+    - find_failed_operations: Find operations that failed (4xx/5xx)
+    - get_resource_history: Get change history for a specific resource
+    - get_user_activity_summary: Get a user's recent actions
+
+  Analytics Tools:
+    - get_activity_timeline: Activity counts grouped by time buckets
+    - summarize_recent_activity: Summary with top actors and resources
+    - compare_activity_periods: Compare activity between time periods
+
+  Policy Tools:
+    - list_activity_policies: List configured ActivityPolicies
+    - preview_activity_policy: Test a policy against sample inputs
 
 Example configuration for Claude Desktop (claude_desktop_config.json):
   {

--- a/pkg/mcp/tools/integration_test.go
+++ b/pkg/mcp/tools/integration_test.go
@@ -1,0 +1,474 @@
+//go:build integration
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	authnv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
+	activityclient "go.miloapis.com/activity/pkg/client/clientset/versioned/typed/activity/v1alpha1"
+)
+
+// Integration tests for MCP tools against a live cluster.
+// Run with: go test -tags=integration -v ./pkg/mcp/tools/...
+//
+// Requires:
+// - KUBECONFIG environment variable set to a valid kubeconfig
+// - Activity API server running in the cluster
+
+func getTestClient(t *testing.T) activityclient.ActivityV1alpha1Interface {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		t.Skip("KUBECONFIG not set, skipping integration test")
+	}
+
+	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
+	restConfig, err := kubeConfig.ClientConfig()
+	if err != nil {
+		t.Fatalf("Failed to load kubeconfig: %v", err)
+	}
+
+	client, err := activityclient.NewForConfig(restConfig)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	return client
+}
+
+func TestIntegration_AuditLogQuery(t *testing.T) {
+	client := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	query := &v1alpha1.AuditLogQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "integration-test-",
+		},
+		Spec: v1alpha1.AuditLogQuerySpec{
+			StartTime: "now-1h",
+			EndTime:   "now",
+			Limit:     10,
+		},
+	}
+
+	result, err := client.AuditLogQueries().Create(ctx, query, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("AuditLogQuery failed: %v", err)
+	}
+
+	t.Logf("AuditLogQuery succeeded:")
+	t.Logf("  Count: %d events", len(result.Status.Results))
+	t.Logf("  Effective time range: %s to %s", result.Status.EffectiveStartTime, result.Status.EffectiveEndTime)
+
+	if len(result.Status.Results) > 0 {
+		event := result.Status.Results[0]
+		t.Logf("  First event: %s %s/%s by %s", event.Verb, event.ObjectRef.Resource, event.ObjectRef.Name, event.User.Username)
+	}
+}
+
+func TestIntegration_AuditLogFacetsQuery(t *testing.T) {
+	client := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	query := &v1alpha1.AuditLogFacetsQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "integration-test-",
+		},
+		Spec: v1alpha1.AuditLogFacetsQuerySpec{
+			TimeRange: v1alpha1.FacetTimeRange{
+				Start: "now-1h",
+				End:   "now",
+			},
+			Facets: []v1alpha1.FacetSpec{
+				{Field: "verb", Limit: 10},
+				{Field: "objectRef.resource", Limit: 10},
+			},
+		},
+	}
+
+	result, err := client.AuditLogFacetsQueries().Create(ctx, query, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("AuditLogFacetsQuery failed: %v", err)
+	}
+
+	t.Logf("AuditLogFacetsQuery succeeded:")
+	for _, facet := range result.Status.Facets {
+		t.Logf("  Field %s:", facet.Field)
+		for _, v := range facet.Values {
+			t.Logf("    %s: %d", v.Value, v.Count)
+		}
+	}
+}
+
+func TestIntegration_ActivityQuery(t *testing.T) {
+	client := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	query := &v1alpha1.ActivityQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "integration-test-",
+		},
+		Spec: v1alpha1.ActivityQuerySpec{
+			StartTime: "now-1h",
+			EndTime:   "now",
+			Limit:     10,
+		},
+	}
+
+	result, err := client.ActivityQueries().Create(ctx, query, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("ActivityQuery failed: %v", err)
+	}
+
+	t.Logf("ActivityQuery succeeded:")
+	t.Logf("  Count: %d activities", len(result.Status.Results))
+	t.Logf("  Effective time range: %s to %s", result.Status.EffectiveStartTime, result.Status.EffectiveEndTime)
+
+	for i, activity := range result.Status.Results {
+		if i >= 3 {
+			break
+		}
+		t.Logf("  Activity: %s", activity.Spec.Summary)
+	}
+}
+
+func TestIntegration_ActivityFacetQuery(t *testing.T) {
+	client := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	query := &v1alpha1.ActivityFacetQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "integration-test-",
+		},
+		Spec: v1alpha1.ActivityFacetQuerySpec{
+			TimeRange: v1alpha1.FacetTimeRange{
+				Start: "now-1h",
+				End:   "now",
+			},
+			Facets: []v1alpha1.FacetSpec{
+				{Field: "spec.actor.name", Limit: 10},
+				{Field: "spec.resource.kind", Limit: 10},
+			},
+		},
+	}
+
+	result, err := client.ActivityFacetQueries().Create(ctx, query, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("ActivityFacetQuery failed: %v", err)
+	}
+
+	t.Logf("ActivityFacetQuery succeeded:")
+	for _, facet := range result.Status.Facets {
+		t.Logf("  Field %s:", facet.Field)
+		for _, v := range facet.Values {
+			t.Logf("    %s: %d", v.Value, v.Count)
+		}
+	}
+}
+
+func TestIntegration_ListActivityPolicies(t *testing.T) {
+	client := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := client.ActivityPolicies().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("ListActivityPolicies failed: %v", err)
+	}
+
+	t.Logf("ListActivityPolicies succeeded:")
+	t.Logf("  Count: %d policies", len(result.Items))
+
+	for _, policy := range result.Items {
+		t.Logf("  Policy: %s (resource: %s/%s)", policy.Name, policy.Spec.Resource.APIGroup, policy.Spec.Resource.Kind)
+	}
+}
+
+func TestIntegration_PolicyPreview(t *testing.T) {
+	client := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	preview := &v1alpha1.PolicyPreview{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "integration-test-",
+		},
+		Spec: v1alpha1.PolicyPreviewSpec{
+			Policy: v1alpha1.ActivityPolicySpec{
+				Resource: v1alpha1.ActivityPolicyResource{
+					APIGroup: "",
+					Kind:     "Pod",
+				},
+				AuditRules: []v1alpha1.ActivityPolicyRule{
+					{
+						Match:   `audit.verb == "create"`,
+						Summary: "{{ actor }} created pod {{ audit.objectRef.name }}",
+					},
+				},
+			},
+			Inputs: []v1alpha1.PolicyPreviewInput{
+				{
+					Type: "audit",
+					Audit: &auditv1.Event{
+						Verb: "create",
+						User: authnv1.UserInfo{
+							Username: "test-user",
+						},
+						ObjectRef: &auditv1.ObjectReference{
+							Name:     "test-pod",
+							Resource: "pods",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := client.PolicyPreviews().Create(ctx, preview, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("PolicyPreview failed: %v", err)
+	}
+
+	t.Logf("PolicyPreview succeeded:")
+	if result.Status.Error != "" {
+		t.Logf("  Error: %s", result.Status.Error)
+	}
+
+	for _, r := range result.Status.Results {
+		t.Logf("  Input %d: matched=%v", r.InputIndex, r.Matched)
+		if r.Error != "" {
+			t.Logf("    Error: %s", r.Error)
+		}
+	}
+
+	for _, a := range result.Status.Activities {
+		t.Logf("  Generated activity: %s", a.Spec.Summary)
+	}
+}
+
+func TestIntegration_ToolProvider(t *testing.T) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		t.Skip("KUBECONFIG not set, skipping integration test")
+	}
+
+	cfg := Config{
+		Kubeconfig: kubeconfig,
+		Namespace:  "default",
+	}
+
+	provider, err := NewToolProvider(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create ToolProvider: %v", err)
+	}
+	defer provider.Close()
+
+	t.Logf("ToolProvider created successfully")
+
+	// Verify it can create an MCP server
+	server := provider.NewMCPServer(ServerConfig{
+		Name:    "test",
+		Version: "1.0.0",
+	})
+
+	if server == nil {
+		t.Fatal("NewMCPServer returned nil")
+	}
+
+	t.Logf("MCP server created successfully")
+}
+
+func TestIntegration_AllAPIsAvailable(t *testing.T) {
+	client := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Test each API to verify the cluster has all required CRDs installed
+	apis := []struct {
+		name string
+		test func() error
+	}{
+		{
+			name: "AuditLogQuery",
+			test: func() error {
+				query := &v1alpha1.AuditLogQuery{
+					ObjectMeta: metav1.ObjectMeta{GenerateName: "api-test-"},
+					Spec:       v1alpha1.AuditLogQuerySpec{StartTime: "now-1m", EndTime: "now", Limit: 1},
+				}
+				_, err := client.AuditLogQueries().Create(ctx, query, metav1.CreateOptions{})
+				return err
+			},
+		},
+		{
+			name: "AuditLogFacetsQuery",
+			test: func() error {
+				query := &v1alpha1.AuditLogFacetsQuery{
+					ObjectMeta: metav1.ObjectMeta{GenerateName: "api-test-"},
+					Spec: v1alpha1.AuditLogFacetsQuerySpec{
+						TimeRange: v1alpha1.FacetTimeRange{Start: "now-1m", End: "now"},
+						Facets:    []v1alpha1.FacetSpec{{Field: "verb", Limit: 1}},
+					},
+				}
+				_, err := client.AuditLogFacetsQueries().Create(ctx, query, metav1.CreateOptions{})
+				return err
+			},
+		},
+		{
+			name: "ActivityQuery",
+			test: func() error {
+				query := &v1alpha1.ActivityQuery{
+					ObjectMeta: metav1.ObjectMeta{GenerateName: "api-test-"},
+					Spec:       v1alpha1.ActivityQuerySpec{StartTime: "now-1m", EndTime: "now", Limit: 1},
+				}
+				_, err := client.ActivityQueries().Create(ctx, query, metav1.CreateOptions{})
+				return err
+			},
+		},
+		{
+			name: "ActivityFacetQuery",
+			test: func() error {
+				query := &v1alpha1.ActivityFacetQuery{
+					ObjectMeta: metav1.ObjectMeta{GenerateName: "api-test-"},
+					Spec: v1alpha1.ActivityFacetQuerySpec{
+						TimeRange: v1alpha1.FacetTimeRange{Start: "now-1m", End: "now"},
+						Facets:    []v1alpha1.FacetSpec{{Field: "spec.actor.name", Limit: 1}},
+					},
+				}
+				_, err := client.ActivityFacetQueries().Create(ctx, query, metav1.CreateOptions{})
+				return err
+			},
+		},
+		{
+			name: "ActivityPolicy (list)",
+			test: func() error {
+				_, err := client.ActivityPolicies().List(ctx, metav1.ListOptions{})
+				return err
+			},
+		},
+		{
+			name: "PolicyPreview",
+			test: func() error {
+				preview := &v1alpha1.PolicyPreview{
+					ObjectMeta: metav1.ObjectMeta{GenerateName: "api-test-"},
+					Spec: v1alpha1.PolicyPreviewSpec{
+						Policy: v1alpha1.ActivityPolicySpec{
+							Resource:   v1alpha1.ActivityPolicyResource{Kind: "Test"},
+							AuditRules: []v1alpha1.ActivityPolicyRule{{Match: "true", Summary: "test"}},
+						},
+						Inputs: []v1alpha1.PolicyPreviewInput{},
+					},
+				}
+				_, err := client.PolicyPreviews().Create(ctx, preview, metav1.CreateOptions{})
+				return err
+			},
+		},
+	}
+
+	allPassed := true
+	for _, api := range apis {
+		err := api.test()
+		if err != nil {
+			t.Errorf("API %s: FAILED - %v", api.name, err)
+			allPassed = false
+		} else {
+			t.Logf("API %s: OK", api.name)
+		}
+	}
+
+	if allPassed {
+		t.Logf("All Activity APIs are available and working!")
+	}
+}
+
+func TestIntegration_QueryWithCELFilter(t *testing.T) {
+	client := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Test CEL filtering
+	filters := []struct {
+		name   string
+		filter string
+	}{
+		{"verb filter", `verb == "get"`},
+		{"resource filter", `objectRef.resource == "pods"`},
+		{"namespace filter", `objectRef.namespace != ""`},
+		{"combined filter", `verb == "get" && objectRef.resource == "pods"`},
+	}
+
+	for _, f := range filters {
+		query := &v1alpha1.AuditLogQuery{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "cel-test-"},
+			Spec: v1alpha1.AuditLogQuerySpec{
+				StartTime: "now-1h",
+				EndTime:   "now",
+				Filter:    f.filter,
+				Limit:     5,
+			},
+		}
+
+		result, err := client.AuditLogQueries().Create(ctx, query, metav1.CreateOptions{})
+		if err != nil {
+			t.Errorf("CEL filter '%s' failed: %v", f.name, err)
+			continue
+		}
+
+		t.Logf("CEL filter '%s': %d results", f.name, len(result.Status.Results))
+	}
+}
+
+func TestIntegration_FailedOperations(t *testing.T) {
+	client := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Query for failed operations (4xx/5xx)
+	query := &v1alpha1.AuditLogQuery{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "failed-ops-"},
+		Spec: v1alpha1.AuditLogQuerySpec{
+			StartTime: "now-24h",
+			EndTime:   "now",
+			Filter:    "responseStatus.code >= 400",
+			Limit:     20,
+		},
+	}
+
+	result, err := client.AuditLogQueries().Create(ctx, query, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed operations query failed: %v", err)
+	}
+
+	t.Logf("Found %d failed operations in last 24h", len(result.Status.Results))
+
+	// Group by status code
+	byCode := make(map[int32]int)
+	for _, event := range result.Status.Results {
+		byCode[event.ResponseStatus.Code]++
+	}
+
+	resultJSON, _ := json.MarshalIndent(byCode, "", "  ")
+	t.Logf("By status code: %s", resultJSON)
+}

--- a/pkg/mcp/tools/tools.go
+++ b/pkg/mcp/tools/tools.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -107,37 +108,91 @@ func (p *ToolProvider) Close() error {
 
 // RegisterTools registers all activity tools with an MCP server.
 func (p *ToolProvider) RegisterTools(server *mcp.Server) {
-	// Register query_audit_logs tool
+	// Audit log tools
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "query_audit_logs",
 		Description: "Search audit logs from the Kubernetes control plane. Use this to investigate incidents, track resource changes, or analyze user activity. Results are returned newest-first.",
 	}, p.handleQueryAuditLogs)
 
-	// Register get_audit_log_facets tool
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_audit_log_facets",
 		Description: "Get distinct values and counts for audit log fields. Use this to discover what verbs, users, resources, and namespaces appear in the audit logs. Useful for building filters or understanding activity patterns.",
 	}, p.handleGetAuditLogFacets)
+
+	// Activity tools (human-readable summaries)
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "query_activities",
+		Description: "Search human-readable activity summaries. Activities are translated from audit logs into friendly descriptions like 'alice created HTTP proxy api-gateway'. Use this to understand what changed in plain language.",
+	}, p.handleQueryActivities)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_activity_facets",
+		Description: "Get distinct values and counts for activity fields. Discover who's active, what resources are changing, and whether changes are human or automated. Valid fields: spec.changeSource, spec.actor.name, spec.actor.type, spec.resource.apiGroup, spec.resource.kind, spec.resource.namespace.",
+	}, p.handleGetActivityFacets)
+
+	// Investigation tools
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "find_failed_operations",
+		Description: "Find operations that failed (HTTP 4xx/5xx responses). Use this to debug permission issues, find failed deployments, or investigate security events.",
+	}, p.handleFindFailedOperations)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_resource_history",
+		Description: "Get the change history for a specific resource. See who changed what, when, with field-level diffs where available. Use this to understand how a resource evolved over time.",
+	}, p.handleGetResourceHistory)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_user_activity_summary",
+		Description: "Get a summary of a specific user's recent actions. See what resources they modified, when, and how often. Useful for security reviews and understanding user behavior.",
+	}, p.handleGetUserActivitySummary)
+
+	// Analytics tools
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_activity_timeline",
+		Description: "Get activity counts grouped by time buckets (hourly/daily). Use this to visualize activity patterns, identify peak periods, and correlate with incidents.",
+	}, p.handleGetActivityTimeline)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "summarize_recent_activity",
+		Description: "Generate a summary of recent activity including top actors, most changed resources, and key highlights. Perfect for status updates and handoffs.",
+	}, p.handleSummarizeRecentActivity)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "compare_activity_periods",
+		Description: "Compare activity between two time periods. Identify what changed, new actors, increased/decreased activity. Use this for incident investigation and trend analysis.",
+	}, p.handleCompareActivityPeriods)
+
+	// Policy tools
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_activity_policies",
+		Description: "List configured ActivityPolicies that translate audit logs into human-readable summaries. See what resource types have translation rules and their status.",
+	}, p.handleListActivityPolicies)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "preview_activity_policy",
+		Description: "Test an ActivityPolicy against sample audit events to see what activities would be generated. Use this to develop and debug policies before deployment.",
+	}, p.handlePreviewActivityPolicy)
 }
+
+// =============================================================================
+// Query Audit Logs
+// =============================================================================
 
 // QueryAuditLogsArgs contains the arguments for the query_audit_logs tool.
 type QueryAuditLogsArgs struct {
 	// StartTime is the beginning of the search window.
-	// Supports relative times (e.g., 'now-7d', 'now-2h') or RFC3339 timestamps.
-	StartTime string `json:"startTime" jsonschema:"description=Start of search window. Supports relative times (e.g. 'now-7d') or RFC3339 timestamps. Required."`
+	StartTime string `json:"startTime"`
 
 	// EndTime is the end of the search window.
-	// Supports relative times (e.g., 'now') or RFC3339 timestamps.
-	EndTime string `json:"endTime" jsonschema:"description=End of search window. Supports relative times (e.g. 'now') or RFC3339 timestamps. Required."`
+	EndTime string `json:"endTime"`
 
 	// Filter is a CEL filter expression to narrow results.
-	Filter string `json:"filter,omitempty" jsonschema:"description=CEL filter expression. Available fields: verb, user.username, user.uid, responseStatus.code, objectRef.namespace, objectRef.resource, objectRef.name, objectRef.apiGroup. Examples: verb == 'delete', objectRef.namespace == 'production'"`
+	Filter string `json:"filter,omitempty"`
 
 	// Limit is the maximum number of results to return.
-	Limit int `json:"limit,omitempty" jsonschema:"description=Maximum results to return (default: 100, max: 1000)"`
+	Limit int `json:"limit,omitempty"`
 }
 
-// handleQueryAuditLogs handles the query_audit_logs tool invocation.
 func (p *ToolProvider) handleQueryAuditLogs(ctx context.Context, req *mcp.CallToolRequest, args QueryAuditLogsArgs) (*mcp.CallToolResult, any, error) {
 	limit := int32(args.Limit)
 	if limit == 0 {
@@ -161,7 +216,6 @@ func (p *ToolProvider) handleQueryAuditLogs(ctx context.Context, req *mcp.CallTo
 		return errorResult(fmt.Sprintf("Query failed: %v", err)), nil, nil
 	}
 
-	// Format results
 	output := map[string]any{
 		"count":              len(result.Status.Results),
 		"continue":           result.Status.Continue,
@@ -170,33 +224,31 @@ func (p *ToolProvider) handleQueryAuditLogs(ctx context.Context, req *mcp.CallTo
 		"events":             result.Status.Results,
 	}
 
-	jsonBytes, err := json.MarshalIndent(output, "", "  ")
-	if err != nil {
-		return errorResult(fmt.Sprintf("Failed to format results: %v", err)), nil, nil
-	}
-
-	return textResult(string(jsonBytes)), nil, nil
+	return jsonResult(output)
 }
+
+// =============================================================================
+// Get Audit Log Facets
+// =============================================================================
 
 // GetAuditLogFacetsArgs contains the arguments for the get_audit_log_facets tool.
 type GetAuditLogFacetsArgs struct {
 	// Fields to get facets for.
-	Fields []string `json:"fields" jsonschema:"description=Fields to get facets for. Supported: verb, user.username, user.uid, responseStatus.code, objectRef.namespace, objectRef.resource, objectRef.apiGroup"`
+	Fields []string `json:"fields"`
 
-	// StartTime is the beginning of the time window for facet aggregation.
-	StartTime string `json:"startTime,omitempty" jsonschema:"description=Start of time window for facet aggregation (e.g. 'now-7d')"`
+	// StartTime is the beginning of the time window.
+	StartTime string `json:"startTime,omitempty"`
 
-	// EndTime is the end of the time window for facet aggregation.
-	EndTime string `json:"endTime,omitempty" jsonschema:"description=End of time window for facet aggregation (e.g. 'now')"`
+	// EndTime is the end of the time window.
+	EndTime string `json:"endTime,omitempty"`
 
 	// Filter is a CEL filter to narrow down audit logs before computing facets.
-	Filter string `json:"filter,omitempty" jsonschema:"description=CEL filter to narrow down audit logs before computing facets"`
+	Filter string `json:"filter,omitempty"`
 
 	// Limit is the maximum number of distinct values per field.
-	Limit int `json:"limit,omitempty" jsonschema:"description=Maximum distinct values per field (default: 20, max: 100)"`
+	Limit int `json:"limit,omitempty"`
 }
 
-// handleGetAuditLogFacets handles the get_audit_log_facets tool invocation.
 func (p *ToolProvider) handleGetAuditLogFacets(ctx context.Context, req *mcp.CallToolRequest, args GetAuditLogFacetsArgs) (*mcp.CallToolResult, any, error) {
 	limit := int32(args.Limit)
 	if limit == 0 {
@@ -240,7 +292,6 @@ func (p *ToolProvider) handleGetAuditLogFacets(ctx context.Context, req *mcp.Cal
 		return errorResult(fmt.Sprintf("Query failed: %v", err)), nil, nil
 	}
 
-	// Convert to output format
 	output := make(map[string]any)
 	for _, facet := range result.Status.Facets {
 		values := make([]map[string]any, 0, len(facet.Values))
@@ -253,15 +304,994 @@ func (p *ToolProvider) handleGetAuditLogFacets(ctx context.Context, req *mcp.Cal
 		output[facet.Field] = values
 	}
 
-	jsonBytes, err := json.MarshalIndent(output, "", "  ")
-	if err != nil {
-		return errorResult(fmt.Sprintf("Failed to format results: %v", err)), nil, nil
-	}
-
-	return textResult(string(jsonBytes)), nil, nil
+	return jsonResult(output)
 }
 
-// Helper functions
+// =============================================================================
+// Query Activities
+// =============================================================================
+
+// QueryActivitiesArgs contains the arguments for the query_activities tool.
+type QueryActivitiesArgs struct {
+	// StartTime is the beginning of the search window.
+	StartTime string `json:"startTime"`
+
+	// EndTime is the end of the search window.
+	EndTime string `json:"endTime"`
+
+	// ChangeSource filters by change source.
+	ChangeSource string `json:"changeSource,omitempty"`
+
+	// ActorName filters by actor name.
+	ActorName string `json:"actorName,omitempty"`
+
+	// ResourceKind filters by resource kind.
+	ResourceKind string `json:"resourceKind,omitempty"`
+
+	// APIGroup filters by API group.
+	APIGroup string `json:"apiGroup,omitempty"`
+
+	// Search performs full-text search on summary.
+	Search string `json:"search,omitempty"`
+
+	// Limit is the maximum number of results to return.
+	Limit int `json:"limit,omitempty"`
+}
+
+func (p *ToolProvider) handleQueryActivities(ctx context.Context, req *mcp.CallToolRequest, args QueryActivitiesArgs) (*mcp.CallToolResult, any, error) {
+	limit := int32(args.Limit)
+	if limit == 0 {
+		limit = 100
+	}
+
+	query := &v1alpha1.ActivityQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "mcp-activity-query-",
+		},
+		Spec: v1alpha1.ActivityQuerySpec{
+			StartTime:    args.StartTime,
+			EndTime:      args.EndTime,
+			ChangeSource: args.ChangeSource,
+			ActorName:    args.ActorName,
+			ResourceKind: args.ResourceKind,
+			APIGroup:     args.APIGroup,
+			Search:       args.Search,
+			Limit:        limit,
+		},
+	}
+
+	result, err := p.client.ActivityQueries().Create(ctx, query, metav1.CreateOptions{})
+	if err != nil {
+		return errorResult(fmt.Sprintf("Query failed: %v", err)), nil, nil
+	}
+
+	// Format results for readability
+	activities := make([]map[string]any, 0, len(result.Status.Results))
+	for _, activity := range result.Status.Results {
+		activityMap := map[string]any{
+			"name":         activity.Name,
+			"summary":      activity.Spec.Summary,
+			"changeSource": activity.Spec.ChangeSource,
+			"actor": map[string]any{
+				"type": activity.Spec.Actor.Type,
+				"name": activity.Spec.Actor.Name,
+			},
+			"resource": map[string]any{
+				"apiGroup":  activity.Spec.Resource.APIGroup,
+				"kind":      activity.Spec.Resource.Kind,
+				"name":      activity.Spec.Resource.Name,
+				"namespace": activity.Spec.Resource.Namespace,
+			},
+			"timestamp": activity.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
+		}
+		activities = append(activities, activityMap)
+	}
+
+	output := map[string]any{
+		"count":              len(activities),
+		"continue":           result.Status.Continue,
+		"effectiveStartTime": result.Status.EffectiveStartTime,
+		"effectiveEndTime":   result.Status.EffectiveEndTime,
+		"activities":         activities,
+	}
+
+	return jsonResult(output)
+}
+
+// =============================================================================
+// Get Activity Facets
+// =============================================================================
+
+// GetActivityFacetsArgs contains the arguments for the get_activity_facets tool.
+type GetActivityFacetsArgs struct {
+	// Fields to get facets for.
+	// Valid values: spec.changeSource, spec.actor.name, spec.actor.type,
+	// spec.resource.apiGroup, spec.resource.kind, spec.resource.namespace
+	Fields []string `json:"fields"`
+
+	// StartTime is the beginning of the time window.
+	StartTime string `json:"startTime,omitempty"`
+
+	// EndTime is the end of the time window.
+	EndTime string `json:"endTime,omitempty"`
+
+	// Filter narrows the activities before computing facets.
+	Filter string `json:"filter,omitempty"`
+
+	// Limit is the maximum number of distinct values per field.
+	Limit int `json:"limit,omitempty"`
+}
+
+func (p *ToolProvider) handleGetActivityFacets(ctx context.Context, req *mcp.CallToolRequest, args GetActivityFacetsArgs) (*mcp.CallToolResult, any, error) {
+	limit := int32(args.Limit)
+	if limit == 0 {
+		limit = 20
+	}
+
+	startTime := args.StartTime
+	if startTime == "" {
+		startTime = "now-7d"
+	}
+
+	endTime := args.EndTime
+	if endTime == "" {
+		endTime = "now"
+	}
+
+	facetSpecs := make([]v1alpha1.FacetSpec, 0, len(args.Fields))
+	for _, field := range args.Fields {
+		facetSpecs = append(facetSpecs, v1alpha1.FacetSpec{
+			Field: field,
+			Limit: limit,
+		})
+	}
+
+	query := &v1alpha1.ActivityFacetQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "mcp-activity-facets-",
+		},
+		Spec: v1alpha1.ActivityFacetQuerySpec{
+			TimeRange: v1alpha1.FacetTimeRange{
+				Start: startTime,
+				End:   endTime,
+			},
+			Filter: args.Filter,
+			Facets: facetSpecs,
+		},
+	}
+
+	result, err := p.client.ActivityFacetQueries().Create(ctx, query, metav1.CreateOptions{})
+	if err != nil {
+		return errorResult(fmt.Sprintf("Query failed: %v", err)), nil, nil
+	}
+
+	output := make(map[string]any)
+	for _, facet := range result.Status.Facets {
+		values := make([]map[string]any, 0, len(facet.Values))
+		for _, v := range facet.Values {
+			values = append(values, map[string]any{
+				"value": v.Value,
+				"count": v.Count,
+			})
+		}
+		output[facet.Field] = values
+	}
+
+	return jsonResult(output)
+}
+
+// =============================================================================
+// Find Failed Operations
+// =============================================================================
+
+// FindFailedOperationsArgs contains the arguments for the find_failed_operations tool.
+// Note: This tool queries audit logs directly since Activities don't capture failed operations.
+type FindFailedOperationsArgs struct {
+	// StartTime is the beginning of the search window.
+	StartTime string `json:"startTime"`
+
+	// EndTime is the end of the search window.
+	EndTime string `json:"endTime,omitempty"`
+
+	// StatusCodeMin is the minimum status code to include.
+	StatusCodeMin int `json:"statusCodeMin,omitempty"`
+
+	// StatusCodeMax is the maximum status code to include.
+	StatusCodeMax int `json:"statusCodeMax,omitempty"`
+
+	// Username filters by actor.
+	Username string `json:"username,omitempty"`
+
+	// Resource filters by resource type.
+	Resource string `json:"resource,omitempty"`
+
+	// Verb filters by verb.
+	Verb string `json:"verb,omitempty"`
+
+	// Limit is the maximum number of results.
+	Limit int `json:"limit,omitempty"`
+}
+
+func (p *ToolProvider) handleFindFailedOperations(ctx context.Context, req *mcp.CallToolRequest, args FindFailedOperationsArgs) (*mcp.CallToolResult, any, error) {
+	limit := int32(args.Limit)
+	if limit == 0 {
+		limit = 100
+	}
+
+	endTime := args.EndTime
+	if endTime == "" {
+		endTime = "now"
+	}
+
+	statusCodeMin := args.StatusCodeMin
+	if statusCodeMin == 0 {
+		statusCodeMin = 400
+	}
+
+	statusCodeMax := args.StatusCodeMax
+	if statusCodeMax == 0 {
+		statusCodeMax = 599
+	}
+
+	// Build CEL filter for failed operations
+	filters := []string{
+		fmt.Sprintf("responseStatus.code >= %d", statusCodeMin),
+		fmt.Sprintf("responseStatus.code <= %d", statusCodeMax),
+	}
+
+	if args.Username != "" {
+		filters = append(filters, fmt.Sprintf("user.username == '%s'", args.Username))
+	}
+	if args.Resource != "" {
+		filters = append(filters, fmt.Sprintf("objectRef.resource == '%s'", args.Resource))
+	}
+	if args.Verb != "" {
+		filters = append(filters, fmt.Sprintf("verb == '%s'", args.Verb))
+	}
+
+	filter := strings.Join(filters, " && ")
+
+	// Note: Failed operations are queried from audit logs since Activities
+	// are only created for successful operations that match ActivityPolicies.
+	query := &v1alpha1.AuditLogQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "mcp-failed-ops-",
+		},
+		Spec: v1alpha1.AuditLogQuerySpec{
+			StartTime: args.StartTime,
+			EndTime:   endTime,
+			Filter:    filter,
+			Limit:     limit,
+		},
+	}
+
+	result, err := p.client.AuditLogQueries().Create(ctx, query, metav1.CreateOptions{})
+	if err != nil {
+		return errorResult(fmt.Sprintf("Query failed: %v", err)), nil, nil
+	}
+
+	// Count by status code
+	statusCodeCounts := make(map[int]int)
+	failures := make([]map[string]any, 0, len(result.Status.Results))
+
+	for _, event := range result.Status.Results {
+		code := int(event.ResponseStatus.Code)
+		statusCodeCounts[code]++
+
+		failure := map[string]any{
+			"timestamp":  event.RequestReceivedTimestamp.Format("2006-01-02T15:04:05Z"),
+			"user":       event.User.Username,
+			"verb":       event.Verb,
+			"resource":   event.ObjectRef.Resource,
+			"name":       event.ObjectRef.Name,
+			"namespace":  event.ObjectRef.Namespace,
+			"statusCode": code,
+		}
+
+		if event.ResponseStatus.Message != "" {
+			failure["message"] = event.ResponseStatus.Message
+		}
+
+		failures = append(failures, failure)
+	}
+
+	output := map[string]any{
+		"count":        len(failures),
+		"byStatusCode": statusCodeCounts,
+		"failures":     failures,
+	}
+
+	return jsonResult(output)
+}
+
+// =============================================================================
+// Get Resource History
+// =============================================================================
+
+// GetResourceHistoryArgs contains the arguments for the get_resource_history tool.
+type GetResourceHistoryArgs struct {
+	// ResourceUID is the UID of the resource.
+	ResourceUID string `json:"resourceUID,omitempty"`
+
+	// APIGroup of the resource.
+	APIGroup string `json:"apiGroup,omitempty"`
+
+	// Kind of the resource.
+	Kind string `json:"kind,omitempty"`
+
+	// Name of the resource.
+	Name string `json:"name,omitempty"`
+
+	// Namespace of the resource.
+	Namespace string `json:"namespace,omitempty"`
+
+	// StartTime limits history to after this time.
+	StartTime string `json:"startTime,omitempty"`
+
+	// EndTime limits history to before this time.
+	EndTime string `json:"endTime,omitempty"`
+
+	// Limit is the maximum number of events to return.
+	Limit int `json:"limit,omitempty"`
+}
+
+func (p *ToolProvider) handleGetResourceHistory(ctx context.Context, req *mcp.CallToolRequest, args GetResourceHistoryArgs) (*mcp.CallToolResult, any, error) {
+	limit := int32(args.Limit)
+	if limit == 0 {
+		limit = 100
+	}
+
+	startTime := args.StartTime
+	if startTime == "" {
+		startTime = "now-30d"
+	}
+
+	endTime := args.EndTime
+	if endTime == "" {
+		endTime = "now"
+	}
+
+	if args.ResourceUID == "" && args.Name == "" {
+		return errorResult("Either resourceUID or name is required"), nil, nil
+	}
+
+	// Query activities for this resource
+	query := &v1alpha1.ActivityQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "mcp-resource-history-",
+		},
+		Spec: v1alpha1.ActivityQuerySpec{
+			StartTime:    startTime,
+			EndTime:      endTime,
+			Namespace:    args.Namespace,
+			APIGroup:     args.APIGroup,
+			ResourceKind: args.Kind,
+			ResourceUID:  args.ResourceUID,
+			Limit:        limit,
+		},
+	}
+
+	result, err := p.client.ActivityQueries().Create(ctx, query, metav1.CreateOptions{})
+	if err != nil {
+		return errorResult(fmt.Sprintf("Query failed: %v", err)), nil, nil
+	}
+
+	// Filter by name if specified (ActivityQuery doesn't support name filter directly)
+	history := make([]map[string]any, 0, len(result.Status.Results))
+	for _, activity := range result.Status.Results {
+		// Skip if name filter specified and doesn't match
+		if args.Name != "" && activity.Spec.Resource.Name != args.Name {
+			continue
+		}
+
+		entry := map[string]any{
+			"timestamp":    activity.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
+			"actor":        activity.Spec.Actor.Name,
+			"summary":      activity.Spec.Summary,
+			"changeSource": activity.Spec.ChangeSource,
+		}
+
+		history = append(history, entry)
+	}
+
+	// Build resource identifier for output
+	resource := map[string]any{
+		"name":      args.Name,
+		"kind":      args.Kind,
+		"apiGroup":  args.APIGroup,
+		"namespace": args.Namespace,
+	}
+	if len(result.Status.Results) > 0 {
+		r := result.Status.Results[0].Spec.Resource
+		resource["apiGroup"] = r.APIGroup
+		resource["kind"] = r.Kind
+		resource["name"] = r.Name
+		resource["namespace"] = r.Namespace
+	}
+
+	output := map[string]any{
+		"resource":  resource,
+		"count":     len(history),
+		"timeRange": map[string]any{"start": result.Status.EffectiveStartTime, "end": result.Status.EffectiveEndTime},
+		"history":   history,
+	}
+
+	return jsonResult(output)
+}
+
+// =============================================================================
+// Get User Activity Summary
+// =============================================================================
+
+// GetUserActivitySummaryArgs contains the arguments for the get_user_activity_summary tool.
+type GetUserActivitySummaryArgs struct {
+	// Username is the username or email to get activity for.
+	Username string `json:"username,omitempty"`
+
+	// StartTime is the beginning of the time window.
+	StartTime string `json:"startTime,omitempty"`
+
+	// EndTime is the end of the time window.
+	EndTime string `json:"endTime,omitempty"`
+
+	// IncludeDetails includes individual activities in the response.
+	IncludeDetails bool `json:"includeDetails,omitempty"`
+}
+
+func (p *ToolProvider) handleGetUserActivitySummary(ctx context.Context, req *mcp.CallToolRequest, args GetUserActivitySummaryArgs) (*mcp.CallToolResult, any, error) {
+	if args.Username == "" {
+		return errorResult("Username is required"), nil, nil
+	}
+
+	startTime := args.StartTime
+	if startTime == "" {
+		startTime = "now-7d"
+	}
+
+	endTime := args.EndTime
+	if endTime == "" {
+		endTime = "now"
+	}
+
+	// Query activities by actor name
+	query := &v1alpha1.ActivityQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "mcp-user-summary-",
+		},
+		Spec: v1alpha1.ActivityQuerySpec{
+			StartTime: startTime,
+			EndTime:   endTime,
+			ActorName: args.Username,
+			Limit:     1000, // Get more activities for summary
+		},
+	}
+
+	result, err := p.client.ActivityQueries().Create(ctx, query, metav1.CreateOptions{})
+	if err != nil {
+		return errorResult(fmt.Sprintf("Query failed: %v", err)), nil, nil
+	}
+
+	// Build summary
+	changeSourceCounts := make(map[string]int)
+	resourceKindCounts := make(map[string]int)
+	dayCounts := make(map[string]int)
+	var recentActivities []map[string]any
+
+	for i, activity := range result.Status.Results {
+		changeSourceCounts[activity.Spec.ChangeSource]++
+		resourceKindCounts[activity.Spec.Resource.Kind]++
+
+		day := activity.CreationTimestamp.Format("2006-01-02")
+		dayCounts[day]++
+
+		if args.IncludeDetails && i < 20 {
+			recentActivities = append(recentActivities, map[string]any{
+				"timestamp":    activity.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
+				"summary":      activity.Spec.Summary,
+				"changeSource": activity.Spec.ChangeSource,
+				"resource": map[string]any{
+					"kind":      activity.Spec.Resource.Kind,
+					"name":      activity.Spec.Resource.Name,
+					"namespace": activity.Spec.Resource.Namespace,
+				},
+			})
+		}
+	}
+
+	// Convert day counts to sorted list
+	dayList := make([]map[string]any, 0, len(dayCounts))
+	for day, count := range dayCounts {
+		dayList = append(dayList, map[string]any{
+			"date":  day,
+			"count": count,
+		})
+	}
+
+	output := map[string]any{
+		"user": map[string]any{
+			"username": args.Username,
+		},
+		"timeRange": map[string]any{
+			"start": result.Status.EffectiveStartTime,
+			"end":   result.Status.EffectiveEndTime,
+		},
+		"totalActivities": len(result.Status.Results),
+		"breakdown": map[string]any{
+			"byChangeSource": changeSourceCounts,
+			"byResourceKind": resourceKindCounts,
+			"byDay":          dayList,
+		},
+	}
+
+	if args.IncludeDetails && len(recentActivities) > 0 {
+		output["recentActivities"] = recentActivities
+	}
+
+	return jsonResult(output)
+}
+
+// =============================================================================
+// Get Activity Timeline
+// =============================================================================
+
+// GetActivityTimelineArgs contains the arguments for the get_activity_timeline tool.
+type GetActivityTimelineArgs struct {
+	// StartTime is the beginning of the timeline.
+	StartTime string `json:"startTime"`
+
+	// EndTime is the end of the timeline.
+	EndTime string `json:"endTime,omitempty"`
+
+	// BucketSize is the time bucket size (hour, day).
+	BucketSize string `json:"bucketSize,omitempty"`
+
+	// ChangeSource filters by change source (human, system).
+	ChangeSource string `json:"changeSource,omitempty"`
+}
+
+func (p *ToolProvider) handleGetActivityTimeline(ctx context.Context, req *mcp.CallToolRequest, args GetActivityTimelineArgs) (*mcp.CallToolResult, any, error) {
+	endTime := args.EndTime
+	if endTime == "" {
+		endTime = "now"
+	}
+
+	query := &v1alpha1.ActivityQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "mcp-timeline-",
+		},
+		Spec: v1alpha1.ActivityQuerySpec{
+			StartTime:    args.StartTime,
+			EndTime:      endTime,
+			ChangeSource: args.ChangeSource,
+			Limit:        1000,
+		},
+	}
+
+	result, err := p.client.ActivityQueries().Create(ctx, query, metav1.CreateOptions{})
+	if err != nil {
+		return errorResult(fmt.Sprintf("Query failed: %v", err)), nil, nil
+	}
+
+	// Determine bucket size
+	bucketFormat := "2006-01-02T15:00:00Z" // hourly default
+	bucketSize := args.BucketSize
+	if bucketSize == "" {
+		bucketSize = "hour"
+	}
+
+	if bucketSize == "day" {
+		bucketFormat = "2006-01-02T00:00:00Z"
+	}
+
+	// Count by bucket
+	bucketCounts := make(map[string]int)
+	var peakBucket string
+	var peakCount int
+
+	for _, activity := range result.Status.Results {
+		bucket := activity.CreationTimestamp.Format(bucketFormat)
+		bucketCounts[bucket]++
+
+		if bucketCounts[bucket] > peakCount {
+			peakCount = bucketCounts[bucket]
+			peakBucket = bucket
+		}
+	}
+
+	// Convert to sorted list
+	buckets := make([]map[string]any, 0, len(bucketCounts))
+	for bucket, count := range bucketCounts {
+		entry := map[string]any{
+			"timestamp": bucket,
+			"count":     count,
+		}
+		if bucket == peakBucket {
+			entry["note"] = "peak"
+		}
+		buckets = append(buckets, entry)
+	}
+
+	// Calculate average
+	var avg float64
+	if len(buckets) > 0 {
+		avg = float64(len(result.Status.Results)) / float64(len(buckets))
+	}
+
+	output := map[string]any{
+		"timeRange": map[string]any{
+			"start": result.Status.EffectiveStartTime,
+			"end":   result.Status.EffectiveEndTime,
+		},
+		"bucketSize":       bucketSize,
+		"totalCount":       len(result.Status.Results),
+		"buckets":          buckets,
+		"peakBucket":       map[string]any{"timestamp": peakBucket, "count": peakCount},
+		"averagePerBucket": avg,
+	}
+
+	return jsonResult(output)
+}
+
+// =============================================================================
+// Summarize Recent Activity
+// =============================================================================
+
+// SummarizeRecentActivityArgs contains the arguments for the summarize_recent_activity tool.
+type SummarizeRecentActivityArgs struct {
+	// StartTime is the beginning of the summary window.
+	StartTime string `json:"startTime"`
+
+	// EndTime is the end of the summary window.
+	EndTime string `json:"endTime,omitempty"`
+
+	// ChangeSource filters by change source (human, system).
+	ChangeSource string `json:"changeSource,omitempty"`
+
+	// TopN is the number of top items per category.
+	TopN int `json:"topN,omitempty"`
+}
+
+func (p *ToolProvider) handleSummarizeRecentActivity(ctx context.Context, req *mcp.CallToolRequest, args SummarizeRecentActivityArgs) (*mcp.CallToolResult, any, error) {
+	endTime := args.EndTime
+	if endTime == "" {
+		endTime = "now"
+	}
+
+	topN := args.TopN
+	if topN == 0 {
+		topN = 5
+	}
+
+	query := &v1alpha1.ActivityQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "mcp-summary-",
+		},
+		Spec: v1alpha1.ActivityQuerySpec{
+			StartTime:    args.StartTime,
+			EndTime:      endTime,
+			ChangeSource: args.ChangeSource,
+			Limit:        1000,
+		},
+	}
+
+	result, err := p.client.ActivityQueries().Create(ctx, query, metav1.CreateOptions{})
+	if err != nil {
+		return errorResult(fmt.Sprintf("Query failed: %v", err)), nil, nil
+	}
+
+	// Build summary statistics
+	actorCounts := make(map[string]int)
+	resourceKindCounts := make(map[string]int)
+	var humanChanges, systemChanges int
+	var recentSummaries []string
+
+	for i, activity := range result.Status.Results {
+		actorCounts[activity.Spec.Actor.Name]++
+		resourceKindCounts[activity.Spec.Resource.Kind]++
+
+		// Classify as human or system
+		if activity.Spec.ChangeSource == "human" {
+			humanChanges++
+		} else {
+			systemChanges++
+		}
+
+		// Collect recent summaries
+		if i < topN {
+			recentSummaries = append(recentSummaries, activity.Spec.Summary)
+		}
+	}
+
+	// Get top actors and resources
+	topActors := getTopN(actorCounts, topN)
+	topResources := getTopN(resourceKindCounts, topN)
+
+	// Build highlights
+	highlights := []string{
+		fmt.Sprintf("%d total activities (%d human, %d system)", len(result.Status.Results), humanChanges, systemChanges),
+	}
+
+	if len(topActors) > 0 {
+		highlights = append(highlights, fmt.Sprintf("Most active: %s (%d activities)", topActors[0]["name"], topActors[0]["count"]))
+	}
+
+	if len(topResources) > 0 {
+		highlights = append(highlights, fmt.Sprintf("Most changed resource type: %s (%d activities)", topResources[0]["name"], topResources[0]["count"]))
+	}
+
+	output := map[string]any{
+		"timeRange": map[string]any{
+			"start": result.Status.EffectiveStartTime,
+			"end":   result.Status.EffectiveEndTime,
+		},
+		"totalActivities": len(result.Status.Results),
+		"humanChanges":    humanChanges,
+		"systemChanges":   systemChanges,
+		"highlights":      highlights,
+		"topActors":       topActors,
+		"topResources":    topResources,
+		"recentSummaries": recentSummaries,
+	}
+
+	return jsonResult(output)
+}
+
+// =============================================================================
+// Compare Activity Periods
+// =============================================================================
+
+// CompareActivityPeriodsArgs contains the arguments for the compare_activity_periods tool.
+type CompareActivityPeriodsArgs struct {
+	// BaselineStart is the start of the baseline period.
+	BaselineStart string `json:"baselineStart"`
+
+	// BaselineEnd is the end of the baseline period.
+	BaselineEnd string `json:"baselineEnd"`
+
+	// ComparisonStart is the start of the comparison period.
+	ComparisonStart string `json:"comparisonStart"`
+
+	// ComparisonEnd is the end of the comparison period.
+	ComparisonEnd string `json:"comparisonEnd"`
+}
+
+func (p *ToolProvider) handleCompareActivityPeriods(ctx context.Context, req *mcp.CallToolRequest, args CompareActivityPeriodsArgs) (*mcp.CallToolResult, any, error) {
+	// Query baseline period
+	baselineQuery := &v1alpha1.ActivityQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "mcp-compare-baseline-",
+		},
+		Spec: v1alpha1.ActivityQuerySpec{
+			StartTime: args.BaselineStart,
+			EndTime:   args.BaselineEnd,
+			Limit:     1000,
+		},
+	}
+
+	baselineResult, err := p.client.ActivityQueries().Create(ctx, baselineQuery, metav1.CreateOptions{})
+	if err != nil {
+		return errorResult(fmt.Sprintf("Baseline query failed: %v", err)), nil, nil
+	}
+
+	// Query comparison period
+	comparisonQuery := &v1alpha1.ActivityQuery{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "mcp-compare-comparison-",
+		},
+		Spec: v1alpha1.ActivityQuerySpec{
+			StartTime: args.ComparisonStart,
+			EndTime:   args.ComparisonEnd,
+			Limit:     1000,
+		},
+	}
+
+	comparisonResult, err := p.client.ActivityQueries().Create(ctx, comparisonQuery, metav1.CreateOptions{})
+	if err != nil {
+		return errorResult(fmt.Sprintf("Comparison query failed: %v", err)), nil, nil
+	}
+
+	// Build counts for both periods
+	baselineCounts := buildActivityCounts(baselineResult.Status.Results)
+	comparisonCounts := buildActivityCounts(comparisonResult.Status.Results)
+
+	// Find differences
+	newInComparison := findNew(baselineCounts.actors, comparisonCounts.actors)
+	increasedActivity := findIncreased(baselineCounts.resourceKinds, comparisonCounts.resourceKinds)
+	decreasedActivity := findDecreased(baselineCounts.resourceKinds, comparisonCounts.resourceKinds)
+
+	// Calculate change percentage
+	var changePercent float64
+	if baselineCounts.total > 0 {
+		changePercent = float64(comparisonCounts.total-baselineCounts.total) / float64(baselineCounts.total) * 100
+	}
+
+	output := map[string]any{
+		"baseline": map[string]any{
+			"start": baselineResult.Status.EffectiveStartTime,
+			"end":   baselineResult.Status.EffectiveEndTime,
+			"count": baselineCounts.total,
+		},
+		"comparison": map[string]any{
+			"start": comparisonResult.Status.EffectiveStartTime,
+			"end":   comparisonResult.Status.EffectiveEndTime,
+			"count": comparisonCounts.total,
+		},
+		"changePercent":     changePercent,
+		"newInComparison":   newInComparison,
+		"increasedActivity": increasedActivity,
+		"decreasedActivity": decreasedActivity,
+	}
+
+	// Add analysis summary
+	direction := "more"
+	if changePercent < 0 {
+		direction = "less"
+	}
+	analysis := fmt.Sprintf("Comparison period shows %.0f%% %s activity.", absFloat(changePercent), direction)
+
+	if len(newInComparison) > 0 {
+		analysis += fmt.Sprintf(" %d new actors appeared.", len(newInComparison))
+	}
+
+	output["analysis"] = analysis
+
+	return jsonResult(output)
+}
+
+// =============================================================================
+// List Activity Policies
+// =============================================================================
+
+// ListActivityPoliciesArgs contains the arguments for the list_activity_policies tool.
+type ListActivityPoliciesArgs struct {
+	// APIGroup filters by resource API group.
+	APIGroup string `json:"apiGroup,omitempty"`
+
+	// Kind filters by resource kind.
+	Kind string `json:"kind,omitempty"`
+
+	// IncludeRules includes full rule definitions in output.
+	IncludeRules bool `json:"includeRules,omitempty"`
+}
+
+func (p *ToolProvider) handleListActivityPolicies(ctx context.Context, req *mcp.CallToolRequest, args ListActivityPoliciesArgs) (*mcp.CallToolResult, any, error) {
+	result, err := p.client.ActivityPolicies().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return errorResult(fmt.Sprintf("Query failed: %v", err)), nil, nil
+	}
+
+	policies := make([]map[string]any, 0, len(result.Items))
+	for _, policy := range result.Items {
+		// Apply filters
+		if args.APIGroup != "" && policy.Spec.Resource.APIGroup != args.APIGroup {
+			continue
+		}
+		if args.Kind != "" && policy.Spec.Resource.Kind != args.Kind {
+			continue
+		}
+
+		policyMap := map[string]any{
+			"name": policy.Name,
+			"resource": map[string]any{
+				"apiGroup": policy.Spec.Resource.APIGroup,
+				"kind":     policy.Spec.Resource.Kind,
+			},
+			"auditRuleCount": len(policy.Spec.AuditRules),
+			"eventRuleCount": len(policy.Spec.EventRules),
+		}
+
+		// Get status
+		status := "Unknown"
+		for _, cond := range policy.Status.Conditions {
+			if cond.Type == "Ready" {
+				if cond.Status == "True" {
+					status = "Ready"
+				} else {
+					status = cond.Reason
+				}
+				break
+			}
+		}
+		policyMap["status"] = status
+
+		if args.IncludeRules {
+			policyMap["auditRules"] = policy.Spec.AuditRules
+			policyMap["eventRules"] = policy.Spec.EventRules
+		}
+
+		policies = append(policies, policyMap)
+	}
+
+	output := map[string]any{
+		"policies": policies,
+		"summary":  fmt.Sprintf("%d policies covering %d resource types", len(policies), len(policies)),
+	}
+
+	return jsonResult(output)
+}
+
+// =============================================================================
+// Preview Activity Policy
+// =============================================================================
+
+// PreviewActivityPolicyArgs contains the arguments for the preview_activity_policy tool.
+type PreviewActivityPolicyArgs struct {
+	// Policy is the ActivityPolicy spec to test.
+	Policy v1alpha1.ActivityPolicySpec `json:"policy"`
+
+	// Inputs are sample audit/event inputs to test.
+	Inputs []v1alpha1.PolicyPreviewInput `json:"inputs"`
+}
+
+func (p *ToolProvider) handlePreviewActivityPolicy(ctx context.Context, req *mcp.CallToolRequest, args PreviewActivityPolicyArgs) (*mcp.CallToolResult, any, error) {
+	preview := &v1alpha1.PolicyPreview{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "mcp-preview-",
+		},
+		Spec: v1alpha1.PolicyPreviewSpec{
+			Policy: args.Policy,
+			Inputs: args.Inputs,
+		},
+	}
+
+	result, err := p.client.PolicyPreviews().Create(ctx, preview, metav1.CreateOptions{})
+	if err != nil {
+		return errorResult(fmt.Sprintf("Preview failed: %v", err)), nil, nil
+	}
+
+	if result.Status.Error != "" {
+		return errorResult(fmt.Sprintf("Preview error: %s", result.Status.Error)), nil, nil
+	}
+
+	// Format results
+	results := make([]map[string]any, 0, len(result.Status.Results))
+	for _, r := range result.Status.Results {
+		resultMap := map[string]any{
+			"inputIndex": r.InputIndex,
+			"matched":    r.Matched,
+		}
+
+		if r.Matched {
+			resultMap["matchedRule"] = map[string]any{
+				"type":  r.MatchedRuleType,
+				"index": r.MatchedRuleIndex,
+			}
+		}
+
+		if r.Error != "" {
+			resultMap["error"] = r.Error
+		}
+
+		results = append(results, resultMap)
+	}
+
+	// Format generated activities
+	activities := make([]map[string]any, 0, len(result.Status.Activities))
+	for _, a := range result.Status.Activities {
+		activities = append(activities, map[string]any{
+			"summary": a.Spec.Summary,
+			"actor": map[string]any{
+				"type": a.Spec.Actor.Type,
+				"name": a.Spec.Actor.Name,
+			},
+			"resource": map[string]any{
+				"kind": a.Spec.Resource.Kind,
+				"name": a.Spec.Resource.Name,
+			},
+		})
+	}
+
+	output := map[string]any{
+		"results":    results,
+		"activities": activities,
+	}
+
+	return jsonResult(output)
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
 
 func textResult(text string) *mcp.CallToolResult {
 	return &mcp.CallToolResult{
@@ -278,4 +1308,130 @@ func errorResult(message string) *mcp.CallToolResult {
 			&mcp.TextContent{Text: message},
 		},
 	}
+}
+
+func jsonResult(output any) (*mcp.CallToolResult, any, error) {
+	jsonBytes, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return errorResult(fmt.Sprintf("Failed to format results: %v", err)), nil, nil
+	}
+	return textResult(string(jsonBytes)), nil, nil
+}
+
+func isSystemUser(username string) bool {
+	return strings.HasPrefix(username, "system:") ||
+		strings.Contains(username, "serviceaccount") ||
+		strings.Contains(username, "controller")
+}
+
+func getTopN(counts map[string]int, n int) []map[string]any {
+	// Convert to slice and sort
+	type kv struct {
+		Key   string
+		Value int
+	}
+	var sorted []kv
+	for k, v := range counts {
+		sorted = append(sorted, kv{k, v})
+	}
+
+	// Sort by count descending
+	for i := 0; i < len(sorted)-1; i++ {
+		for j := i + 1; j < len(sorted); j++ {
+			if sorted[j].Value > sorted[i].Value {
+				sorted[i], sorted[j] = sorted[j], sorted[i]
+			}
+		}
+	}
+
+	// Take top N
+	result := make([]map[string]any, 0, n)
+	for i := 0; i < len(sorted) && i < n; i++ {
+		result = append(result, map[string]any{
+			"name":  sorted[i].Key,
+			"count": sorted[i].Value,
+		})
+	}
+	return result
+}
+
+type activityCounts struct {
+	total         int
+	actors        map[string]int
+	resourceKinds map[string]int
+	changeSources map[string]int
+}
+
+func buildActivityCounts(activities []v1alpha1.Activity) activityCounts {
+	counts := activityCounts{
+		total:         len(activities),
+		actors:        make(map[string]int),
+		resourceKinds: make(map[string]int),
+		changeSources: make(map[string]int),
+	}
+
+	for _, activity := range activities {
+		counts.actors[activity.Spec.Actor.Name]++
+		counts.resourceKinds[activity.Spec.Resource.Kind]++
+		counts.changeSources[activity.Spec.ChangeSource]++
+	}
+
+	return counts
+}
+
+func findNew(baseline, comparison map[string]int) []map[string]any {
+	var result []map[string]any
+	for k, v := range comparison {
+		if _, exists := baseline[k]; !exists {
+			result = append(result, map[string]any{
+				"name":  k,
+				"count": v,
+				"note":  "Not present in baseline",
+			})
+		}
+	}
+	return result
+}
+
+func findIncreased(baseline, comparison map[string]int) []map[string]any {
+	var result []map[string]any
+	for k, v := range comparison {
+		if baselineV, exists := baseline[k]; exists && v > baselineV {
+			changePercent := float64(v-baselineV) / float64(baselineV) * 100
+			if changePercent >= 50 { // Only include significant increases
+				result = append(result, map[string]any{
+					"name":          k,
+					"baseline":      baselineV,
+					"comparison":    v,
+					"changePercent": changePercent,
+				})
+			}
+		}
+	}
+	return result
+}
+
+func findDecreased(baseline, comparison map[string]int) []map[string]any {
+	var result []map[string]any
+	for k, v := range baseline {
+		if compV, exists := comparison[k]; exists && compV < v {
+			changePercent := float64(v-compV) / float64(v) * 100
+			if changePercent >= 50 { // Only include significant decreases
+				result = append(result, map[string]any{
+					"name":          k,
+					"baseline":      v,
+					"comparison":    compV,
+					"changePercent": -changePercent,
+				})
+			}
+		}
+	}
+	return result
+}
+
+func absFloat(f float64) float64 {
+	if f < 0 {
+		return -f
+	}
+	return f
 }

--- a/pkg/mcp/tools/tools_test.go
+++ b/pkg/mcp/tools/tools_test.go
@@ -1,0 +1,1136 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	authnv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	"k8s.io/client-go/rest"
+
+	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
+	activityclient "go.miloapis.com/activity/pkg/client/clientset/versioned/typed/activity/v1alpha1"
+)
+
+// =============================================================================
+// Mock Client Implementation
+// =============================================================================
+
+type mockActivityV1alpha1Client struct {
+	auditLogQueries       *mockAuditLogQueryInterface
+	auditLogFacetsQueries *mockAuditLogFacetsQueryInterface
+	activityQueries       *mockActivityQueryInterface
+	activityFacetQueries  *mockActivityFacetQueryInterface
+	activityPolicies      *mockActivityPolicyInterface
+	policyPreviews        *mockPolicyPreviewInterface
+	activities            *mockActivityInterface
+}
+
+func newMockClient() *mockActivityV1alpha1Client {
+	return &mockActivityV1alpha1Client{
+		auditLogQueries:       &mockAuditLogQueryInterface{},
+		auditLogFacetsQueries: &mockAuditLogFacetsQueryInterface{},
+		activityQueries:       &mockActivityQueryInterface{},
+		activityFacetQueries:  &mockActivityFacetQueryInterface{},
+		activityPolicies:      &mockActivityPolicyInterface{},
+		policyPreviews:        &mockPolicyPreviewInterface{},
+		activities:            &mockActivityInterface{},
+	}
+}
+
+func (m *mockActivityV1alpha1Client) AuditLogQueries() activityclient.AuditLogQueryInterface {
+	return m.auditLogQueries
+}
+
+func (m *mockActivityV1alpha1Client) AuditLogFacetsQueries() activityclient.AuditLogFacetsQueryInterface {
+	return m.auditLogFacetsQueries
+}
+
+func (m *mockActivityV1alpha1Client) ActivityQueries() activityclient.ActivityQueryInterface {
+	return m.activityQueries
+}
+
+func (m *mockActivityV1alpha1Client) ActivityFacetQueries() activityclient.ActivityFacetQueryInterface {
+	return m.activityFacetQueries
+}
+
+func (m *mockActivityV1alpha1Client) ActivityPolicies() activityclient.ActivityPolicyInterface {
+	return m.activityPolicies
+}
+
+func (m *mockActivityV1alpha1Client) PolicyPreviews() activityclient.PolicyPreviewInterface {
+	return m.policyPreviews
+}
+
+func (m *mockActivityV1alpha1Client) Activities(namespace string) activityclient.ActivityInterface {
+	return m.activities
+}
+
+func (m *mockActivityV1alpha1Client) RESTClient() rest.Interface {
+	return nil
+}
+
+// =============================================================================
+// Mock AuditLogQuery Interface
+// =============================================================================
+
+type mockAuditLogQueryInterface struct {
+	createFunc func(ctx context.Context, query *v1alpha1.AuditLogQuery, opts metav1.CreateOptions) (*v1alpha1.AuditLogQuery, error)
+}
+
+func (m *mockAuditLogQueryInterface) Create(ctx context.Context, query *v1alpha1.AuditLogQuery, opts metav1.CreateOptions) (*v1alpha1.AuditLogQuery, error) {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, query, opts)
+	}
+	// Default response
+	now := metav1.NewMicroTime(time.Now())
+	return &v1alpha1.AuditLogQuery{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-query"},
+		Spec:       query.Spec,
+		Status: v1alpha1.AuditLogQueryStatus{
+			Results: []auditv1.Event{
+				{
+					TypeMeta:                 metav1.TypeMeta{Kind: "Event", APIVersion: "audit.k8s.io/v1"},
+					Level:                    auditv1.LevelRequestResponse,
+					AuditID:                  "test-audit-id",
+					Stage:                    auditv1.StageResponseComplete,
+					RequestURI:               "/api/v1/namespaces/default/pods",
+					Verb:                     "create",
+					User:                     authnv1.UserInfo{Username: "alice@example.com", UID: "user-123"},
+					ObjectRef:                &auditv1.ObjectReference{Resource: "pods", Namespace: "default", Name: "my-pod", APIGroup: "", APIVersion: "v1"},
+					ResponseStatus:           &metav1.Status{Code: 201},
+					RequestReceivedTimestamp: now,
+					StageTimestamp:           now,
+				},
+			},
+			Continue:           "",
+			EffectiveStartTime: "2024-01-01T00:00:00Z",
+			EffectiveEndTime:   "2024-01-07T00:00:00Z",
+		},
+	}, nil
+}
+
+// =============================================================================
+// Mock AuditLogFacetsQuery Interface
+// =============================================================================
+
+type mockAuditLogFacetsQueryInterface struct {
+	createFunc func(ctx context.Context, query *v1alpha1.AuditLogFacetsQuery, opts metav1.CreateOptions) (*v1alpha1.AuditLogFacetsQuery, error)
+}
+
+func (m *mockAuditLogFacetsQueryInterface) Create(ctx context.Context, query *v1alpha1.AuditLogFacetsQuery, opts metav1.CreateOptions) (*v1alpha1.AuditLogFacetsQuery, error) {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, query, opts)
+	}
+	// Default response
+	facets := make([]v1alpha1.FacetResult, 0, len(query.Spec.Facets))
+	for _, spec := range query.Spec.Facets {
+		facets = append(facets, v1alpha1.FacetResult{
+			Field: spec.Field,
+			Values: []v1alpha1.FacetValue{
+				{Value: "test-value-1", Count: 100},
+				{Value: "test-value-2", Count: 50},
+			},
+		})
+	}
+	return &v1alpha1.AuditLogFacetsQuery{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-facets"},
+		Spec:       query.Spec,
+		Status:     v1alpha1.AuditLogFacetsQueryStatus{Facets: facets},
+	}, nil
+}
+
+// =============================================================================
+// Mock ActivityQuery Interface
+// =============================================================================
+
+type mockActivityQueryInterface struct {
+	createFunc func(ctx context.Context, query *v1alpha1.ActivityQuery, opts metav1.CreateOptions) (*v1alpha1.ActivityQuery, error)
+}
+
+func (m *mockActivityQueryInterface) Create(ctx context.Context, query *v1alpha1.ActivityQuery, opts metav1.CreateOptions) (*v1alpha1.ActivityQuery, error) {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, query, opts)
+	}
+	// Default response
+	return &v1alpha1.ActivityQuery{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-activity-query"},
+		Spec:       query.Spec,
+		Status: v1alpha1.ActivityQueryStatus{
+			Results: []v1alpha1.Activity{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "activity-1",
+						CreationTimestamp: metav1.NewTime(time.Now()),
+					},
+					Spec: v1alpha1.ActivitySpec{
+						Summary:      "alice created HTTP proxy api-gateway",
+						ChangeSource: "human",
+						Actor:        v1alpha1.ActivityActor{Type: "user", Name: "alice@example.com"},
+						Resource:     v1alpha1.ActivityResource{APIGroup: "networking.datumapis.com", APIVersion: "v1", Kind: "HTTPProxy", Name: "api-gateway", Namespace: "default"},
+						Tenant:       v1alpha1.ActivityTenant{Type: "organization", Name: "acme"},
+						Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "audit-123"},
+					},
+				},
+			},
+			Continue:           "",
+			EffectiveStartTime: "2024-01-01T00:00:00Z",
+			EffectiveEndTime:   "2024-01-07T00:00:00Z",
+		},
+	}, nil
+}
+
+// =============================================================================
+// Mock ActivityFacetQuery Interface
+// =============================================================================
+
+type mockActivityFacetQueryInterface struct {
+	createFunc func(ctx context.Context, query *v1alpha1.ActivityFacetQuery, opts metav1.CreateOptions) (*v1alpha1.ActivityFacetQuery, error)
+}
+
+func (m *mockActivityFacetQueryInterface) Create(ctx context.Context, query *v1alpha1.ActivityFacetQuery, opts metav1.CreateOptions) (*v1alpha1.ActivityFacetQuery, error) {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, query, opts)
+	}
+	// Default response
+	facets := make([]v1alpha1.FacetResult, 0, len(query.Spec.Facets))
+	for _, spec := range query.Spec.Facets {
+		facets = append(facets, v1alpha1.FacetResult{
+			Field: spec.Field,
+			Values: []v1alpha1.FacetValue{
+				{Value: "alice@example.com", Count: 42},
+				{Value: "bob@example.com", Count: 28},
+			},
+		})
+	}
+	return &v1alpha1.ActivityFacetQuery{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-activity-facets"},
+		Spec:       query.Spec,
+		Status:     v1alpha1.ActivityFacetQueryStatus{Facets: facets},
+	}, nil
+}
+
+// =============================================================================
+// Mock ActivityPolicy Interface
+// =============================================================================
+
+type mockActivityPolicyInterface struct {
+	listFunc func(ctx context.Context, opts metav1.ListOptions) (*v1alpha1.ActivityPolicyList, error)
+}
+
+func (m *mockActivityPolicyInterface) Create(ctx context.Context, policy *v1alpha1.ActivityPolicy, opts metav1.CreateOptions) (*v1alpha1.ActivityPolicy, error) {
+	return policy, nil
+}
+
+func (m *mockActivityPolicyInterface) Update(ctx context.Context, policy *v1alpha1.ActivityPolicy, opts metav1.UpdateOptions) (*v1alpha1.ActivityPolicy, error) {
+	return policy, nil
+}
+
+func (m *mockActivityPolicyInterface) UpdateStatus(ctx context.Context, policy *v1alpha1.ActivityPolicy, opts metav1.UpdateOptions) (*v1alpha1.ActivityPolicy, error) {
+	return policy, nil
+}
+
+func (m *mockActivityPolicyInterface) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return nil
+}
+
+func (m *mockActivityPolicyInterface) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	return nil
+}
+
+func (m *mockActivityPolicyInterface) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1alpha1.ActivityPolicy, error) {
+	return &v1alpha1.ActivityPolicy{ObjectMeta: metav1.ObjectMeta{Name: name}}, nil
+}
+
+func (m *mockActivityPolicyInterface) List(ctx context.Context, opts metav1.ListOptions) (*v1alpha1.ActivityPolicyList, error) {
+	if m.listFunc != nil {
+		return m.listFunc(ctx, opts)
+	}
+	return &v1alpha1.ActivityPolicyList{
+		Items: []v1alpha1.ActivityPolicy{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "networking-httpproxy"},
+				Spec: v1alpha1.ActivityPolicySpec{
+					Resource: v1alpha1.ActivityPolicyResource{APIGroup: "networking.datumapis.com", Kind: "HTTPProxy"},
+					AuditRules: []v1alpha1.ActivityPolicyRule{
+						{Match: "audit.verb == 'create'", Summary: "{{ actor }} created HTTPProxy"},
+					},
+				},
+				Status: v1alpha1.ActivityPolicyStatus{
+					Conditions: []metav1.Condition{
+						{Type: "Ready", Status: metav1.ConditionTrue},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (m *mockActivityPolicyInterface) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return nil, nil
+}
+
+func (m *mockActivityPolicyInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*v1alpha1.ActivityPolicy, error) {
+	return &v1alpha1.ActivityPolicy{ObjectMeta: metav1.ObjectMeta{Name: name}}, nil
+}
+
+// =============================================================================
+// Mock PolicyPreview Interface
+// =============================================================================
+
+type mockPolicyPreviewInterface struct {
+	createFunc func(ctx context.Context, preview *v1alpha1.PolicyPreview, opts metav1.CreateOptions) (*v1alpha1.PolicyPreview, error)
+}
+
+func (m *mockPolicyPreviewInterface) Create(ctx context.Context, preview *v1alpha1.PolicyPreview, opts metav1.CreateOptions) (*v1alpha1.PolicyPreview, error) {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, preview, opts)
+	}
+	return &v1alpha1.PolicyPreview{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-preview"},
+		Spec:       preview.Spec,
+		Status: v1alpha1.PolicyPreviewStatus{
+			Results: []v1alpha1.PolicyPreviewInputResult{
+				{InputIndex: 0, Matched: true, MatchedRuleIndex: 0, MatchedRuleType: "audit"},
+			},
+			Activities: []v1alpha1.Activity{
+				{
+					Spec: v1alpha1.ActivitySpec{
+						Summary: "alice created HTTPProxy",
+						Actor:   v1alpha1.ActivityActor{Type: "user", Name: "alice@example.com"},
+						Resource: v1alpha1.ActivityResource{
+							Kind: "HTTPProxy",
+							Name: "my-proxy",
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+// =============================================================================
+// Mock Activity Interface (for namespaced activities)
+// =============================================================================
+
+type mockActivityInterface struct{}
+
+func (m *mockActivityInterface) Create(ctx context.Context, activity *v1alpha1.Activity, opts metav1.CreateOptions) (*v1alpha1.Activity, error) {
+	return activity, nil
+}
+
+func (m *mockActivityInterface) Update(ctx context.Context, activity *v1alpha1.Activity, opts metav1.UpdateOptions) (*v1alpha1.Activity, error) {
+	return activity, nil
+}
+
+func (m *mockActivityInterface) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return nil
+}
+
+func (m *mockActivityInterface) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	return nil
+}
+
+func (m *mockActivityInterface) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1alpha1.Activity, error) {
+	return &v1alpha1.Activity{ObjectMeta: metav1.ObjectMeta{Name: name}}, nil
+}
+
+func (m *mockActivityInterface) List(ctx context.Context, opts metav1.ListOptions) (*v1alpha1.ActivityList, error) {
+	return &v1alpha1.ActivityList{}, nil
+}
+
+func (m *mockActivityInterface) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return nil, nil
+}
+
+func (m *mockActivityInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*v1alpha1.Activity, error) {
+	return &v1alpha1.Activity{ObjectMeta: metav1.ObjectMeta{Name: name}}, nil
+}
+
+// =============================================================================
+// Test Helper Functions
+// =============================================================================
+
+func createTestProvider(client *mockActivityV1alpha1Client) *ToolProvider {
+	return NewToolProviderWithClient(client, "default")
+}
+
+func parseJSONResult(t *testing.T, result *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	if result.IsError {
+		t.Fatalf("Expected success but got error: %v", result.Content)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("Expected content but got none")
+	}
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("Expected TextContent but got %T", result.Content[0])
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal([]byte(textContent.Text), &output); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v\nContent: %s", err, textContent.Text)
+	}
+	return output
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+func TestQueryAuditLogs(t *testing.T) {
+	client := newMockClient()
+	provider := createTestProvider(client)
+
+	args := QueryAuditLogsArgs{
+		StartTime: "now-7d",
+		EndTime:   "now",
+		Filter:    "verb == 'create'",
+		Limit:     100,
+	}
+
+	result, _, err := provider.handleQueryAuditLogs(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	if output["count"].(float64) != 1 {
+		t.Errorf("Expected count=1, got %v", output["count"])
+	}
+	if output["effectiveStartTime"] != "2024-01-01T00:00:00Z" {
+		t.Errorf("Expected effectiveStartTime, got %v", output["effectiveStartTime"])
+	}
+
+	events := output["events"].([]any)
+	if len(events) != 1 {
+		t.Errorf("Expected 1 event, got %d", len(events))
+	}
+
+	t.Log("✓ query_audit_logs works correctly")
+}
+
+func TestGetAuditLogFacets(t *testing.T) {
+	client := newMockClient()
+	provider := createTestProvider(client)
+
+	args := GetAuditLogFacetsArgs{
+		Fields:    []string{"verb", "user.username"},
+		StartTime: "now-7d",
+		EndTime:   "now",
+		Limit:     20,
+	}
+
+	result, _, err := provider.handleGetAuditLogFacets(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	verbFacets := output["verb"].([]any)
+	if len(verbFacets) != 2 {
+		t.Errorf("Expected 2 verb facet values, got %d", len(verbFacets))
+	}
+
+	userFacets := output["user.username"].([]any)
+	if len(userFacets) != 2 {
+		t.Errorf("Expected 2 user facet values, got %d", len(userFacets))
+	}
+
+	t.Log("✓ get_audit_log_facets works correctly")
+}
+
+func TestQueryActivities(t *testing.T) {
+	client := newMockClient()
+	provider := createTestProvider(client)
+
+	args := QueryActivitiesArgs{
+		StartTime:    "now-7d",
+		EndTime:      "now",
+		ChangeSource: "human",
+		Limit:        100,
+	}
+
+	result, _, err := provider.handleQueryActivities(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	if output["count"].(float64) != 1 {
+		t.Errorf("Expected count=1, got %v", output["count"])
+	}
+
+	activities := output["activities"].([]any)
+	if len(activities) != 1 {
+		t.Errorf("Expected 1 activity, got %d", len(activities))
+	}
+
+	activity := activities[0].(map[string]any)
+	if activity["summary"] != "alice created HTTP proxy api-gateway" {
+		t.Errorf("Expected summary, got %v", activity["summary"])
+	}
+
+	t.Log("✓ query_activities works correctly")
+}
+
+func TestGetActivityFacets(t *testing.T) {
+	client := newMockClient()
+	provider := createTestProvider(client)
+
+	args := GetActivityFacetsArgs{
+		Fields:    []string{"spec.actor.name", "spec.resource.kind"},
+		StartTime: "now-7d",
+		EndTime:   "now",
+		Limit:     20,
+	}
+
+	result, _, err := provider.handleGetActivityFacets(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	actorFacets := output["spec.actor.name"].([]any)
+	if len(actorFacets) != 2 {
+		t.Errorf("Expected 2 actor facet values, got %d", len(actorFacets))
+	}
+
+	t.Log("✓ get_activity_facets works correctly")
+}
+
+func TestFindFailedOperations(t *testing.T) {
+	client := newMockClient()
+
+	// Setup mock to return a failed operation
+	client.auditLogQueries.createFunc = func(ctx context.Context, query *v1alpha1.AuditLogQuery, opts metav1.CreateOptions) (*v1alpha1.AuditLogQuery, error) {
+		now := metav1.NewMicroTime(time.Now())
+		return &v1alpha1.AuditLogQuery{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-failed-ops"},
+			Status: v1alpha1.AuditLogQueryStatus{
+				Results: []auditv1.Event{
+					{
+						Verb:                     "create",
+						User:                     authnv1.UserInfo{Username: "alice@example.com"},
+						ObjectRef:                &auditv1.ObjectReference{Resource: "pods", Name: "bad-pod", Namespace: "default"},
+						ResponseStatus:           &metav1.Status{Code: 403, Message: "Forbidden"},
+						RequestReceivedTimestamp: now,
+					},
+				},
+				EffectiveStartTime: "2024-01-01T00:00:00Z",
+				EffectiveEndTime:   "2024-01-07T00:00:00Z",
+			},
+		}, nil
+	}
+
+	provider := createTestProvider(client)
+
+	args := FindFailedOperationsArgs{
+		StartTime: "now-7d",
+		Limit:     100,
+	}
+
+	result, _, err := provider.handleFindFailedOperations(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	if output["count"].(float64) != 1 {
+		t.Errorf("Expected count=1, got %v", output["count"])
+	}
+
+	byStatusCode := output["byStatusCode"].(map[string]any)
+	if byStatusCode["403"].(float64) != 1 {
+		t.Errorf("Expected 403 count=1, got %v", byStatusCode["403"])
+	}
+
+	t.Log("✓ find_failed_operations works correctly")
+}
+
+func TestGetResourceHistory(t *testing.T) {
+	client := newMockClient()
+
+	// Setup mock to return activities for the resource
+	client.activityQueries.createFunc = func(ctx context.Context, query *v1alpha1.ActivityQuery, opts metav1.CreateOptions) (*v1alpha1.ActivityQuery, error) {
+		now := metav1.NewTime(time.Now())
+		return &v1alpha1.ActivityQuery{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-history"},
+			Status: v1alpha1.ActivityQueryStatus{
+				Results: []v1alpha1.Activity{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "activity-1", CreationTimestamp: now},
+						Spec: v1alpha1.ActivitySpec{
+							Summary:      "alice created Deployment my-app",
+							ChangeSource: "human",
+							Actor:        v1alpha1.ActivityActor{Type: "user", Name: "alice@example.com"},
+							Resource:     v1alpha1.ActivityResource{APIGroup: "apps", APIVersion: "v1", Kind: "Deployment", Name: "my-app", Namespace: "default"},
+							Tenant:       v1alpha1.ActivityTenant{Type: "organization", Name: "acme"},
+							Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "audit-1"},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "activity-2", CreationTimestamp: now},
+						Spec: v1alpha1.ActivitySpec{
+							Summary:      "bob updated Deployment my-app",
+							ChangeSource: "human",
+							Actor:        v1alpha1.ActivityActor{Type: "user", Name: "bob@example.com"},
+							Resource:     v1alpha1.ActivityResource{APIGroup: "apps", APIVersion: "v1", Kind: "Deployment", Name: "my-app", Namespace: "default"},
+							Tenant:       v1alpha1.ActivityTenant{Type: "organization", Name: "acme"},
+							Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "audit-2"},
+						},
+					},
+				},
+				EffectiveStartTime: "2024-01-01T00:00:00Z",
+				EffectiveEndTime:   "2024-01-07T00:00:00Z",
+			},
+		}, nil
+	}
+
+	provider := createTestProvider(client)
+
+	args := GetResourceHistoryArgs{
+		Name:      "my-app",
+		Kind:      "Deployment",
+		Namespace: "default",
+	}
+
+	result, _, err := provider.handleGetResourceHistory(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	if output["count"].(float64) != 2 {
+		t.Errorf("Expected count=2, got %v", output["count"])
+	}
+
+	history := output["history"].([]any)
+	if len(history) != 2 {
+		t.Errorf("Expected 2 history entries, got %d", len(history))
+	}
+
+	t.Log("✓ get_resource_history works correctly")
+}
+
+func TestGetResourceHistoryRequiresName(t *testing.T) {
+	client := newMockClient()
+	provider := createTestProvider(client)
+
+	args := GetResourceHistoryArgs{
+		// No name or resourceUID provided
+	}
+
+	result, _, _ := provider.handleGetResourceHistory(context.Background(), nil, args)
+
+	if !result.IsError {
+		t.Error("Expected error when neither name nor resourceUID provided")
+	}
+
+	t.Log("✓ get_resource_history validates required fields")
+}
+
+func TestGetUserActivitySummary(t *testing.T) {
+	client := newMockClient()
+
+	// Setup mock with user activities
+	client.activityQueries.createFunc = func(ctx context.Context, query *v1alpha1.ActivityQuery, opts metav1.CreateOptions) (*v1alpha1.ActivityQuery, error) {
+		now := metav1.NewTime(time.Now())
+		return &v1alpha1.ActivityQuery{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-user-summary"},
+			Status: v1alpha1.ActivityQueryStatus{
+				Results: []v1alpha1.Activity{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "activity-1", CreationTimestamp: now},
+						Spec: v1alpha1.ActivitySpec{
+							Summary:      "alice created Pod pod-1",
+							ChangeSource: "human",
+							Actor:        v1alpha1.ActivityActor{Type: "user", Name: "alice@example.com"},
+							Resource:     v1alpha1.ActivityResource{APIVersion: "v1", Kind: "Pod", Name: "pod-1"},
+							Tenant:       v1alpha1.ActivityTenant{Type: "organization", Name: "acme"},
+							Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "audit-1"},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "activity-2", CreationTimestamp: now},
+						Spec: v1alpha1.ActivitySpec{
+							Summary:      "alice updated Deployment deploy-1",
+							ChangeSource: "human",
+							Actor:        v1alpha1.ActivityActor{Type: "user", Name: "alice@example.com"},
+							Resource:     v1alpha1.ActivityResource{APIGroup: "apps", APIVersion: "v1", Kind: "Deployment", Name: "deploy-1"},
+							Tenant:       v1alpha1.ActivityTenant{Type: "organization", Name: "acme"},
+							Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "audit-2"},
+						},
+					},
+				},
+				EffectiveStartTime: "2024-01-01T00:00:00Z",
+				EffectiveEndTime:   "2024-01-07T00:00:00Z",
+			},
+		}, nil
+	}
+
+	provider := createTestProvider(client)
+
+	args := GetUserActivitySummaryArgs{
+		Username: "alice@example.com",
+	}
+
+	result, _, err := provider.handleGetUserActivitySummary(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	if output["totalActivities"].(float64) != 2 {
+		t.Errorf("Expected totalActivities=2, got %v", output["totalActivities"])
+	}
+
+	user := output["user"].(map[string]any)
+	if user["username"] != "alice@example.com" {
+		t.Errorf("Expected username=alice@example.com, got %v", user["username"])
+	}
+
+	t.Log("✓ get_user_activity_summary works correctly")
+}
+
+func TestGetUserActivitySummaryRequiresUser(t *testing.T) {
+	client := newMockClient()
+	provider := createTestProvider(client)
+
+	args := GetUserActivitySummaryArgs{
+		// No username or userUID
+	}
+
+	result, _, _ := provider.handleGetUserActivitySummary(context.Background(), nil, args)
+
+	if !result.IsError {
+		t.Error("Expected error when neither username nor userUID provided")
+	}
+
+	t.Log("✓ get_user_activity_summary validates required fields")
+}
+
+func TestGetActivityTimeline(t *testing.T) {
+	client := newMockClient()
+	provider := createTestProvider(client)
+
+	args := GetActivityTimelineArgs{
+		StartTime:  "now-7d",
+		EndTime:    "now",
+		BucketSize: "day",
+	}
+
+	result, _, err := provider.handleGetActivityTimeline(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	if output["bucketSize"] != "day" {
+		t.Errorf("Expected bucketSize=day, got %v", output["bucketSize"])
+	}
+
+	buckets := output["buckets"].([]any)
+	if len(buckets) == 0 {
+		t.Error("Expected at least 1 bucket")
+	}
+
+	t.Log("✓ get_activity_timeline works correctly")
+}
+
+func TestSummarizeRecentActivity(t *testing.T) {
+	client := newMockClient()
+
+	// Setup mock with varied activity
+	client.activityQueries.createFunc = func(ctx context.Context, query *v1alpha1.ActivityQuery, opts metav1.CreateOptions) (*v1alpha1.ActivityQuery, error) {
+		now := metav1.NewTime(time.Now())
+		return &v1alpha1.ActivityQuery{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-summary"},
+			Status: v1alpha1.ActivityQueryStatus{
+				Results: []v1alpha1.Activity{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "activity-1", CreationTimestamp: now},
+						Spec: v1alpha1.ActivitySpec{
+							Summary:      "alice created Pod my-pod",
+							ChangeSource: "human",
+							Actor:        v1alpha1.ActivityActor{Type: "user", Name: "alice@example.com"},
+							Resource:     v1alpha1.ActivityResource{APIVersion: "v1", Kind: "Pod", Name: "my-pod"},
+							Tenant:       v1alpha1.ActivityTenant{Type: "organization", Name: "acme"},
+							Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "audit-1"},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "activity-2", CreationTimestamp: now},
+						Spec: v1alpha1.ActivitySpec{
+							Summary:      "controller deleted Pod old-pod",
+							ChangeSource: "system",
+							Actor:        v1alpha1.ActivityActor{Type: "controller", Name: "system:controller"},
+							Resource:     v1alpha1.ActivityResource{APIVersion: "v1", Kind: "Pod", Name: "old-pod", Namespace: "default"},
+							Tenant:       v1alpha1.ActivityTenant{Type: "organization", Name: "acme"},
+							Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "audit-2"},
+						},
+					},
+				},
+				EffectiveStartTime: "2024-01-01T00:00:00Z",
+				EffectiveEndTime:   "2024-01-07T00:00:00Z",
+			},
+		}, nil
+	}
+
+	provider := createTestProvider(client)
+
+	args := SummarizeRecentActivityArgs{
+		StartTime: "now-24h",
+		TopN:      5,
+	}
+
+	result, _, err := provider.handleSummarizeRecentActivity(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	if output["totalActivities"].(float64) != 2 {
+		t.Errorf("Expected totalActivities=2, got %v", output["totalActivities"])
+	}
+
+	if output["humanChanges"].(float64) != 1 {
+		t.Errorf("Expected humanChanges=1, got %v", output["humanChanges"])
+	}
+
+	if output["systemChanges"].(float64) != 1 {
+		t.Errorf("Expected systemChanges=1, got %v", output["systemChanges"])
+	}
+
+	highlights := output["highlights"].([]any)
+	if len(highlights) == 0 {
+		t.Error("Expected highlights")
+	}
+
+	t.Log("✓ summarize_recent_activity works correctly")
+}
+
+func TestCompareActivityPeriods(t *testing.T) {
+	client := newMockClient()
+
+	callCount := 0
+	client.activityQueries.createFunc = func(ctx context.Context, query *v1alpha1.ActivityQuery, opts metav1.CreateOptions) (*v1alpha1.ActivityQuery, error) {
+		callCount++
+		now := metav1.NewTime(time.Now())
+
+		var results []v1alpha1.Activity
+		if callCount == 1 {
+			// Baseline: 2 activities
+			results = []v1alpha1.Activity{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "baseline-1", CreationTimestamp: now},
+					Spec: v1alpha1.ActivitySpec{
+						Summary:      "alice created pod test-pod",
+						ChangeSource: "human",
+						Actor:        v1alpha1.ActivityActor{Name: "alice", Type: "user"},
+						Resource:     v1alpha1.ActivityResource{Kind: "Pod", APIVersion: "v1"},
+						Tenant:       v1alpha1.ActivityTenant{Type: "global", Name: "default"},
+						Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "test-1"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "baseline-2", CreationTimestamp: now},
+					Spec: v1alpha1.ActivitySpec{
+						Summary:      "alice updated pod test-pod",
+						ChangeSource: "human",
+						Actor:        v1alpha1.ActivityActor{Name: "alice", Type: "user"},
+						Resource:     v1alpha1.ActivityResource{Kind: "Pod", APIVersion: "v1"},
+						Tenant:       v1alpha1.ActivityTenant{Type: "global", Name: "default"},
+						Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "test-2"},
+					},
+				},
+			}
+		} else {
+			// Comparison: 4 activities (100% increase)
+			results = []v1alpha1.Activity{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "compare-1", CreationTimestamp: now},
+					Spec: v1alpha1.ActivitySpec{
+						Summary:      "alice created pod test-pod",
+						ChangeSource: "human",
+						Actor:        v1alpha1.ActivityActor{Name: "alice", Type: "user"},
+						Resource:     v1alpha1.ActivityResource{Kind: "Pod", APIVersion: "v1"},
+						Tenant:       v1alpha1.ActivityTenant{Type: "global", Name: "default"},
+						Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "test-3"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "compare-2", CreationTimestamp: now},
+					Spec: v1alpha1.ActivitySpec{
+						Summary:      "alice updated pod test-pod",
+						ChangeSource: "human",
+						Actor:        v1alpha1.ActivityActor{Name: "alice", Type: "user"},
+						Resource:     v1alpha1.ActivityResource{Kind: "Pod", APIVersion: "v1"},
+						Tenant:       v1alpha1.ActivityTenant{Type: "global", Name: "default"},
+						Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "test-4"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "compare-3", CreationTimestamp: now},
+					Spec: v1alpha1.ActivitySpec{
+						Summary:      "bob created deployment test-deploy",
+						ChangeSource: "human",
+						Actor:        v1alpha1.ActivityActor{Name: "bob", Type: "user"},
+						Resource:     v1alpha1.ActivityResource{Kind: "Deployment", APIVersion: "apps/v1"},
+						Tenant:       v1alpha1.ActivityTenant{Type: "global", Name: "default"},
+						Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "test-5"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "compare-4", CreationTimestamp: now},
+					Spec: v1alpha1.ActivitySpec{
+						Summary:      "bob updated deployment test-deploy",
+						ChangeSource: "human",
+						Actor:        v1alpha1.ActivityActor{Name: "bob", Type: "user"},
+						Resource:     v1alpha1.ActivityResource{Kind: "Deployment", APIVersion: "apps/v1"},
+						Tenant:       v1alpha1.ActivityTenant{Type: "global", Name: "default"},
+						Origin:       v1alpha1.ActivityOrigin{Type: "audit", ID: "test-6"},
+					},
+				},
+			}
+		}
+
+		return &v1alpha1.ActivityQuery{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-compare"},
+			Status: v1alpha1.ActivityQueryStatus{
+				Results:            results,
+				EffectiveStartTime: query.Spec.StartTime,
+				EffectiveEndTime:   query.Spec.EndTime,
+			},
+		}, nil
+	}
+
+	provider := createTestProvider(client)
+
+	args := CompareActivityPeriodsArgs{
+		BaselineStart:   "now-14d",
+		BaselineEnd:     "now-7d",
+		ComparisonStart: "now-7d",
+		ComparisonEnd:   "now",
+	}
+
+	result, _, err := provider.handleCompareActivityPeriods(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	baseline := output["baseline"].(map[string]any)
+	if baseline["count"].(float64) != 2 {
+		t.Errorf("Expected baseline count=2, got %v", baseline["count"])
+	}
+
+	comparison := output["comparison"].(map[string]any)
+	if comparison["count"].(float64) != 4 {
+		t.Errorf("Expected comparison count=4, got %v", comparison["count"])
+	}
+
+	changePercent := output["changePercent"].(float64)
+	if changePercent != 100 {
+		t.Errorf("Expected changePercent=100, got %v", changePercent)
+	}
+
+	analysis := output["analysis"].(string)
+	if analysis == "" {
+		t.Error("Expected analysis string")
+	}
+
+	t.Log("✓ compare_activity_periods works correctly")
+}
+
+func TestListActivityPolicies(t *testing.T) {
+	client := newMockClient()
+	provider := createTestProvider(client)
+
+	args := ListActivityPoliciesArgs{}
+
+	result, _, err := provider.handleListActivityPolicies(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	policies := output["policies"].([]any)
+	if len(policies) != 1 {
+		t.Errorf("Expected 1 policy, got %d", len(policies))
+	}
+
+	policy := policies[0].(map[string]any)
+	if policy["name"] != "networking-httpproxy" {
+		t.Errorf("Expected name=networking-httpproxy, got %v", policy["name"])
+	}
+	if policy["status"] != "Ready" {
+		t.Errorf("Expected status=Ready, got %v", policy["status"])
+	}
+
+	t.Log("✓ list_activity_policies works correctly")
+}
+
+func TestListActivityPoliciesWithFilter(t *testing.T) {
+	client := newMockClient()
+	provider := createTestProvider(client)
+
+	args := ListActivityPoliciesArgs{
+		Kind: "SomethingElse", // Won't match
+	}
+
+	result, _, err := provider.handleListActivityPolicies(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	policies := output["policies"].([]any)
+	if len(policies) != 0 {
+		t.Errorf("Expected 0 policies after filter, got %d", len(policies))
+	}
+
+	t.Log("✓ list_activity_policies filtering works correctly")
+}
+
+func TestPreviewActivityPolicy(t *testing.T) {
+	client := newMockClient()
+	provider := createTestProvider(client)
+
+	args := PreviewActivityPolicyArgs{
+		Policy: v1alpha1.ActivityPolicySpec{
+			Resource: v1alpha1.ActivityPolicyResource{
+				APIGroup: "networking.datumapis.com",
+				Kind:     "HTTPProxy",
+			},
+			AuditRules: []v1alpha1.ActivityPolicyRule{
+				{Match: "audit.verb == 'create'", Summary: "{{ actor }} created HTTPProxy"},
+			},
+		},
+		Inputs: []v1alpha1.PolicyPreviewInput{
+			{Type: "audit"},
+		},
+	}
+
+	result, _, err := provider.handlePreviewActivityPolicy(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := parseJSONResult(t, result)
+
+	results := output["results"].([]any)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(results))
+	}
+
+	resultEntry := results[0].(map[string]any)
+	if resultEntry["matched"] != true {
+		t.Error("Expected matched=true")
+	}
+
+	activities := output["activities"].([]any)
+	if len(activities) != 1 {
+		t.Errorf("Expected 1 activity, got %d", len(activities))
+	}
+
+	t.Log("✓ preview_activity_policy works correctly")
+}
+
+// =============================================================================
+// Test Tool Registration
+// =============================================================================
+
+func TestRegisterTools(t *testing.T) {
+	client := newMockClient()
+	provider := createTestProvider(client)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0.0"}, nil)
+	provider.RegisterTools(server)
+
+	t.Log("✓ RegisterTools completed without error")
+}
+
+// =============================================================================
+// Test Helper Functions
+// =============================================================================
+
+func TestIsSystemUser(t *testing.T) {
+	tests := []struct {
+		username string
+		expected bool
+	}{
+		{"alice@example.com", false},
+		{"bob", false},
+		{"system:serviceaccount:default:my-sa", true},
+		{"system:controller", true},
+		{"my-controller", true},
+	}
+
+	for _, tc := range tests {
+		result := isSystemUser(tc.username)
+		if result != tc.expected {
+			t.Errorf("isSystemUser(%q) = %v, expected %v", tc.username, result, tc.expected)
+		}
+	}
+
+	t.Log("✓ isSystemUser works correctly")
+}
+
+func TestGetTopN(t *testing.T) {
+	counts := map[string]int{
+		"a": 10,
+		"b": 50,
+		"c": 30,
+		"d": 5,
+	}
+
+	result := getTopN(counts, 2)
+
+	if len(result) != 2 {
+		t.Errorf("Expected 2 items, got %d", len(result))
+	}
+
+	if result[0]["name"] != "b" {
+		t.Errorf("Expected first item to be 'b', got %v", result[0]["name"])
+	}
+
+	if result[1]["name"] != "c" {
+		t.Errorf("Expected second item to be 'c', got %v", result[1]["name"])
+	}
+
+	t.Log("✓ getTopN works correctly")
+}
+
+func TestAbsFloat(t *testing.T) {
+	if absFloat(-5.0) != 5.0 {
+		t.Error("absFloat(-5.0) should be 5.0")
+	}
+	if absFloat(5.0) != 5.0 {
+		t.Error("absFloat(5.0) should be 5.0")
+	}
+	if absFloat(0) != 0 {
+		t.Error("absFloat(0) should be 0")
+	}
+
+	t.Log("✓ absFloat works correctly")
+}


### PR DESCRIPTION
### Summary

Add tools that let Claude and other AI assistants explore audit logs and activity history through the Model Context Protocol (MCP).

### Tools added

- query_audit_logs / get_audit_log_facets: dig through raw audit events
- query_activities / get_activity_facets: find things in plain English
- find_failed_operations: figure out what went wrong
- get_resource_history: see who touched a resource and when
- get_user_activity_summary: check what someone's been up to
- get_activity_timeline: spot busy periods at a glance
- summarize_recent_activity: catch up on what's happened lately
- compare_activity_periods: see if things are busier than usual
- list_activity_policies / preview_activity_policy: work with policies

To use, configure your MCP client (e.g., Claude Desktop) to run:

```
  activity mcp --kubeconfig ~/.kube/config
```

---

Relates to https://github.com/datum-cloud/enhancements/issues/469