### PR TITLE
Export cluster events for long-term storage

### DIFF
--- a/cmd/activity/event_exporter.go
+++ b/cmd/activity/event_exporter.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.miloapis.com/activity/internal/eventexporter"
+)
+
+// NewEventExporterCommand creates the event-exporter subcommand.
+func NewEventExporterCommand() *cobra.Command {
+	cfg := eventexporter.Config{
+		NATSUrl:       getEnvOrDefault("NATS_URL", "nats://nats.nats-system.svc.cluster.local:4222"),
+		SubjectPrefix: getEnvOrDefault("SUBJECT_PREFIX", "events.k8s"),
+		ScopeType:     getEnvOrDefault("SCOPE_TYPE", "organization"),
+		ScopeName:     getEnvOrDefault("SCOPE_NAME", "dev-org"),
+		Kubeconfig:    os.Getenv("KUBECONFIG"),
+		ResyncPeriod:  30 * time.Minute,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "event-exporter",
+		Short: "Export Kubernetes Events to NATS JetStream",
+		Long: `Watch Kubernetes Events and publish them to NATS JetStream for ingestion
+into ClickHouse. This exporter ensures format consistency by using the same
+corev1.Event types for both serialization and deserialization throughout
+the pipeline.
+
+Events are published with scope annotations for multi-tenant isolation.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return eventexporter.Run(cmd.Context(), cfg)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&cfg.NATSUrl, "nats-url", cfg.NATSUrl, "NATS server URL")
+	flags.StringVar(&cfg.SubjectPrefix, "subject-prefix", cfg.SubjectPrefix, "NATS subject prefix")
+	flags.StringVar(&cfg.ScopeType, "scope-type", cfg.ScopeType, "Scope type annotation value")
+	flags.StringVar(&cfg.ScopeName, "scope-name", cfg.ScopeName, "Scope name annotation value")
+	flags.StringVar(&cfg.Kubeconfig, "kubeconfig", cfg.Kubeconfig, "Path to kubeconfig (empty for in-cluster)")
+	flags.DurationVar(&cfg.ResyncPeriod, "resync-period", cfg.ResyncPeriod, "Informer resync period")
+
+	return cmd
+}
+
+// getEnvOrDefault returns the environment variable value or a default.
+func getEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/cmd/activity/main.go
+++ b/cmd/activity/main.go
@@ -53,6 +53,7 @@ AuditLogQuery resources accessible through kubectl or any Kubernetes client.`,
 	cmd.AddCommand(NewServeCommand())
 	cmd.AddCommand(NewControllerManagerCommand())
 	cmd.AddCommand(NewProcessorCommand())
+	cmd.AddCommand(NewEventExporterCommand())
 	cmd.AddCommand(NewVersionCommand())
 	cmd.AddCommand(NewMCPCommand())
 

--- a/config/components/k8s-event-exporter/deployment.yaml
+++ b/config/components/k8s-event-exporter/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-event-exporter
+  namespace: activity-system
+  labels:
+    app: k8s-event-exporter
+    app.kubernetes.io/name: k8s-event-exporter
+    app.kubernetes.io/component: event-forwarder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k8s-event-exporter
+  template:
+    metadata:
+      labels:
+        app: k8s-event-exporter
+        app.kubernetes.io/name: k8s-event-exporter
+        app.kubernetes.io/component: event-forwarder
+    spec:
+      serviceAccountName: k8s-event-exporter
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        fsGroup: 65532
+      containers:
+        - name: event-exporter
+          # Uses the same activity image with the event-exporter subcommand
+          image: ghcr.io/datum-cloud/activity:dev
+          imagePullPolicy: IfNotPresent
+          args:
+            - event-exporter
+            - -v=2
+          env:
+            - name: NATS_URL
+              value: "nats://nats.nats-system.svc.cluster.local:4222"
+            - name: SUBJECT_PREFIX
+              value: "events"
+            # SCOPE_TYPE and SCOPE_NAME provide default scope annotations for bootstrapping.
+            # In production, Milo injects these values at request time via admission webhook.
+            # Override these defaults per-environment using Kustomize patches.
+            - name: SCOPE_TYPE
+              value: "organization"
+            - name: SCOPE_NAME
+              value: "dev-org"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/config/components/k8s-event-exporter/kustomization.yaml
+++ b/config/components/k8s-event-exporter/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - deployment.yaml
+  - serviceaccount.yaml
+  - rbac.yaml

--- a/config/components/k8s-event-exporter/rbac.yaml
+++ b/config/components/k8s-event-exporter/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-event-exporter
+  labels:
+    app: k8s-event-exporter
+    app.kubernetes.io/name: k8s-event-exporter
+    app.kubernetes.io/component: event-forwarder
+rules:
+  # Read events from all namespaces
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "watch", "list"]
+  # Read events.k8s.io (newer Events API)
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-event-exporter
+  labels:
+    app: k8s-event-exporter
+    app.kubernetes.io/name: k8s-event-exporter
+    app.kubernetes.io/component: event-forwarder
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-event-exporter
+subjects:
+  - kind: ServiceAccount
+    name: k8s-event-exporter
+    namespace: activity-system

--- a/config/components/k8s-event-exporter/serviceaccount.yaml
+++ b/config/components/k8s-event-exporter/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-event-exporter
+  namespace: activity-system
+  labels:
+    app: k8s-event-exporter
+    app.kubernetes.io/name: k8s-event-exporter
+    app.kubernetes.io/component: event-forwarder

--- a/internal/eventexporter/exporter.go
+++ b/internal/eventexporter/exporter.go
@@ -1,0 +1,222 @@
+// Package eventexporter implements a Kubernetes Event exporter that watches for Events
+// and publishes them to NATS JetStream for ingestion into ClickHouse.
+//
+// This exporter ensures format consistency by using the same corev1.Event types
+// for both serialization and deserialization throughout the pipeline.
+package eventexporter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+)
+
+// Config holds the exporter configuration.
+type Config struct {
+	// NATS connection URL
+	NATSUrl string
+
+	// NATS subject prefix for events (subject will be {prefix}.{namespace})
+	SubjectPrefix string
+
+	// Scope annotations to inject for multi-tenant isolation
+	ScopeType string
+	ScopeName string
+
+	// Kubeconfig path (empty for in-cluster)
+	Kubeconfig string
+
+	// Resync period for the informer
+	ResyncPeriod time.Duration
+}
+
+// Run starts the event exporter and blocks until the context is cancelled.
+func Run(ctx context.Context, cfg Config) error {
+	klog.InfoS("Starting k8s-event-exporter",
+		"natsUrl", cfg.NATSUrl,
+		"subjectPrefix", cfg.SubjectPrefix,
+		"scopeType", cfg.ScopeType,
+		"scopeName", cfg.ScopeName,
+	)
+
+	// Create Kubernetes client
+	k8sClient, err := createK8sClient(cfg.Kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(cfg.NATSUrl,
+		nats.Name("k8s-event-exporter"),
+		nats.ReconnectWait(2*time.Second),
+		nats.MaxReconnects(-1), // Unlimited reconnects
+		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			klog.ErrorS(err, "NATS disconnected")
+		}),
+		nats.ReconnectHandler(func(_ *nats.Conn) {
+			klog.InfoS("NATS reconnected")
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to connect to NATS: %w", err)
+	}
+	defer nc.Close()
+
+	// Get JetStream context
+	js, err := nc.JetStream()
+	if err != nil {
+		return fmt.Errorf("failed to get JetStream context: %w", err)
+	}
+
+	klog.InfoS("Connected to NATS", "url", cfg.NATSUrl)
+
+	// Create the event exporter
+	exporter := &Exporter{
+		js:            js,
+		subjectPrefix: cfg.SubjectPrefix,
+		scopeType:     cfg.ScopeType,
+		scopeName:     cfg.ScopeName,
+	}
+
+	// Create informer factory for all namespaces
+	factory := informers.NewSharedInformerFactory(k8sClient, cfg.ResyncPeriod)
+	eventInformer := factory.Core().V1().Events().Informer()
+
+	// Register event handlers
+	eventInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			event, ok := obj.(*corev1.Event)
+			if !ok {
+				return
+			}
+			if err := exporter.publishEvent(ctx, event, "ADDED"); err != nil {
+				klog.ErrorS(err, "Failed to publish event",
+					"namespace", event.Namespace,
+					"name", event.Name,
+				)
+			}
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			event, ok := newObj.(*corev1.Event)
+			if !ok {
+				return
+			}
+			if err := exporter.publishEvent(ctx, event, "MODIFIED"); err != nil {
+				klog.ErrorS(err, "Failed to publish event",
+					"namespace", event.Namespace,
+					"name", event.Name,
+				)
+			}
+		},
+		// We don't need to handle deletes - events are ephemeral and TTL'd
+	})
+
+	// Start the informer
+	factory.Start(ctx.Done())
+
+	// Wait for cache sync
+	klog.InfoS("Waiting for informer cache to sync")
+	if !cache.WaitForCacheSync(ctx.Done(), eventInformer.HasSynced) {
+		return fmt.Errorf("failed to sync informer cache")
+	}
+	klog.InfoS("Informer cache synced, watching for events")
+
+	// Wait for shutdown
+	<-ctx.Done()
+	klog.InfoS("Shutting down")
+	return nil
+}
+
+// Exporter handles publishing Kubernetes events to NATS.
+type Exporter struct {
+	js            nats.JetStreamContext
+	subjectPrefix string
+	scopeType     string
+	scopeName     string
+}
+
+// publishEvent publishes a Kubernetes event to NATS JetStream.
+func (e *Exporter) publishEvent(ctx context.Context, event *corev1.Event, eventType string) error {
+	// Create a copy to avoid modifying the cached object
+	eventCopy := event.DeepCopy()
+
+	// Inject scope annotations
+	if eventCopy.Annotations == nil {
+		eventCopy.Annotations = make(map[string]string)
+	}
+	eventCopy.Annotations["platform.miloapis.com/scope.type"] = e.scopeType
+	eventCopy.Annotations["platform.miloapis.com/scope.name"] = e.scopeName
+
+	// Ensure TypeMeta is set (informer objects don't have it populated)
+	eventCopy.TypeMeta = metav1.TypeMeta{
+		APIVersion: "v1",
+		Kind:       "Event",
+	}
+
+	// Serialize to JSON
+	data, err := json.Marshal(eventCopy)
+	if err != nil {
+		return fmt.Errorf("failed to marshal event: %w", err)
+	}
+
+	// Build subject: events.k8s.{namespace}
+	subject := fmt.Sprintf("%s.%s", e.subjectPrefix, event.Namespace)
+
+	// Publish with message ID for deduplication
+	msgID := string(event.UID)
+	if eventType == "MODIFIED" {
+		// For updates, include resource version to allow updates through
+		msgID = fmt.Sprintf("%s-%s", event.UID, event.ResourceVersion)
+	}
+
+	_, err = e.js.Publish(subject, data,
+		nats.MsgId(msgID),
+		nats.Context(ctx),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to publish to NATS: %w", err)
+	}
+
+	klog.V(4).InfoS("Published event",
+		"namespace", event.Namespace,
+		"name", event.Name,
+		"reason", event.Reason,
+		"type", eventType,
+		"subject", subject,
+	)
+
+	return nil
+}
+
+// createK8sClient creates a Kubernetes client.
+func createK8sClient(kubeconfig string) (*kubernetes.Clientset, error) {
+	var config *rest.Config
+	var err error
+
+	if kubeconfig != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	} else {
+		config, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to build config: %w", err)
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	return client, nil
+}


### PR DESCRIPTION
## Overview

Adds a lightweight event exporter for development and testing environments. This component watches cluster events and persists them to ClickHouse, enabling a functional end-to-end pipeline without external dependencies.

## Purpose

This exporter is intended for:
- **Local development** - Quickly stand up a working events pipeline
- **Testing** - Validate event queries and processing logic
- **Demo environments** - Show the full Activity experience

For production deployments, the Activity API server will integrate directly with the control plane's event storage, removing the need for a separate exporter.

## What It Does

- Watches Kubernetes Events across all namespaces
- Publishes events to NATS for delivery to ClickHouse
- Retains events for 60 days (vs default 1 hour)

## Deployment

The exporter runs as a single-replica deployment with read-only access to events.