### PR TITLE
Generate activities from cluster events

### DIFF
--- a/examples/basic-kubernetes/events.yaml
+++ b/examples/basic-kubernetes/events.yaml
@@ -1,0 +1,67 @@
+# ActivityPolicies for Kubernetes Events
+# These rules transform raw Kubernetes events into human-readable activities.
+#
+# Events are emitted by controllers and provide a way to understand what's
+# happening in the cluster. Common event types include pod scheduling,
+# image pulling, volume mounting, etc.
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: pod-events
+spec:
+  resource:
+    apiGroup: ""
+    kind: Pod
+  eventRules:
+    - match: 'event.reason == "Scheduled"'
+      summary: "{{ link(event.regarding.name, event.regarding) }} scheduled to node {{ event.note }}"
+    - match: 'event.reason == "Pulling"'
+      summary: "Pulling image for {{ link(event.regarding.name, event.regarding) }}"
+    - match: 'event.reason == "Pulled"'
+      summary: "Successfully pulled image for {{ link(event.regarding.name, event.regarding) }}"
+    - match: 'event.reason == "Created"'
+      summary: "Created container in {{ link(event.regarding.name, event.regarding) }}"
+    - match: 'event.reason == "Started"'
+      summary: "Started container in {{ link(event.regarding.name, event.regarding) }}"
+    - match: 'event.reason == "Killing"'
+      summary: "Stopping container in {{ link(event.regarding.name, event.regarding) }}"
+    - match: 'event.reason == "BackOff"'
+      summary: "{{ link(event.regarding.name, event.regarding) }} failed to start: {{ event.note }}"
+    - match: 'event.reason == "FailedScheduling"'
+      summary: "Failed to schedule {{ link(event.regarding.name, event.regarding) }}: {{ event.note }}"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: node-events
+spec:
+  resource:
+    apiGroup: ""
+    kind: Node
+  eventRules:
+    - match: 'event.reason == "NodeReady"'
+      summary: "Node {{ link(event.regarding.name, event.regarding) }} is ready"
+    - match: 'event.reason == "NodeNotReady"'
+      summary: "Node {{ link(event.regarding.name, event.regarding) }} is not ready"
+    - match: 'event.reason == "NodeSchedulable"'
+      summary: "Node {{ link(event.regarding.name, event.regarding) }} is now schedulable"
+    - match: 'event.reason == "RegisteredNode"'
+      summary: "Node {{ link(event.regarding.name, event.regarding) }} joined the cluster"
+
+---
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: deployment-events
+spec:
+  resource:
+    apiGroup: "apps"
+    kind: Deployment
+  eventRules:
+    - match: 'event.reason == "ScalingReplicaSet"'
+      summary: "Scaling replica set for {{ link(event.regarding.name, event.regarding) }}"
+    - match: 'event.reason == "SuccessfulCreate"'
+      summary: "Created replica set for {{ link(event.regarding.name, event.regarding) }}"

--- a/examples/basic-kubernetes/kustomization.yaml
+++ b/examples/basic-kubernetes/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - batch.yaml      # Job, CronJob
   - networking.yaml # Ingress
   - rbac.yaml       # ClusterRole, ClusterRoleBinding, Role, RoleBinding
+  - events.yaml     # Event rules for Pods, Nodes, Deployments

--- a/internal/processor/classifier.go
+++ b/internal/processor/classifier.go
@@ -27,8 +27,9 @@ func ClassifyChangeSource(user authnv1.UserInfo) string {
 
 // ActorType constants for actor classification.
 const (
-	ActorTypeUser   = "user"
-	ActorTypeSystem = "system"
+	ActorTypeUser       = "user"
+	ActorTypeSystem     = "system"
+	ActorTypeController = "controller"
 )
 
 // ResolveActor extracts actor information from the audit user field.

--- a/internal/processor/event.go
+++ b/internal/processor/event.go
@@ -1,0 +1,426 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nats-io/nats.go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	"go.miloapis.com/activity/internal/cel"
+	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
+)
+
+// EventProcessor processes Kubernetes events from a NATS JetStream pull consumer
+// and generates Activity records via ActivityPolicy event rules.
+type EventProcessor struct {
+	js             nats.JetStreamContext
+	streamName     string
+	consumerName   string
+	activityPrefix string
+	batchSize      int
+	policyLookup   EventPolicyLookup
+	workers        int
+}
+
+// NewEventProcessor creates a new event processor.
+// js is the JetStream context used for both consuming events and publishing activities.
+// streamName is the NATS stream to consume from (e.g., "EVENTS").
+// consumerName is the durable pull consumer name.
+// activityPrefix is the subject prefix for publishing generated activities.
+// policyLookup is used to evaluate events against ActivityPolicy event rules.
+func NewEventProcessor(
+	js nats.JetStreamContext,
+	streamName string,
+	consumerName string,
+	activityPrefix string,
+	policyLookup EventPolicyLookup,
+	workers int,
+	batchSize int,
+) *EventProcessor {
+	return &EventProcessor{
+		js:             js,
+		streamName:     streamName,
+		consumerName:   consumerName,
+		activityPrefix: activityPrefix,
+		policyLookup:   policyLookup,
+		workers:        workers,
+		batchSize:      batchSize,
+	}
+}
+
+// Run starts the event processor workers and blocks until ctx is cancelled.
+func (p *EventProcessor) Run(ctx context.Context) error {
+	klog.InfoS("Starting event processor",
+		"stream", p.streamName,
+		"consumer", p.consumerName,
+		"workers", p.workers,
+	)
+
+	var wg sync.WaitGroup
+	for i := 0; i < p.workers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			p.worker(ctx, workerID)
+		}(i)
+	}
+
+	klog.InfoS("Event processor running", "workers", p.workers)
+
+	<-ctx.Done()
+	wg.Wait()
+
+	klog.Info("Event processor stopped")
+	return nil
+}
+
+// worker consumes messages from the JetStream pull consumer and processes them.
+// Messages are explicitly Acked on success and Naked on failure so that failed
+// messages are redelivered (up to MaxDeliver on the consumer config).
+func (p *EventProcessor) worker(ctx context.Context, id int) {
+	klog.V(4).InfoS("Event worker started", "worker", id)
+
+	sub, err := p.js.PullSubscribe(
+		"events.>",
+		p.consumerName,
+		nats.Bind(p.streamName, p.consumerName),
+	)
+	if err != nil {
+		klog.ErrorS(err, "Failed to create pull subscription for events", "worker", id)
+		return
+	}
+	defer sub.Unsubscribe()
+
+	for {
+		select {
+		case <-ctx.Done():
+			klog.V(4).InfoS("Event worker stopping", "worker", id)
+			return
+		default:
+		}
+
+		msgs, err := sub.Fetch(p.batchSize, nats.MaxWait(5*time.Second))
+		if err != nil {
+			if err == nats.ErrTimeout {
+				continue
+			}
+			klog.ErrorS(err, "Failed to fetch event messages", "worker", id)
+			continue
+		}
+
+		for _, msg := range msgs {
+			if err := p.processMessage(ctx, msg); err != nil {
+				klog.ErrorS(err, "Failed to process event message", "worker", id)
+				msg.Nak()
+				continue
+			}
+			msg.Ack()
+		}
+	}
+}
+
+// processMessage processes a single Kubernetes event message.
+func (p *EventProcessor) processMessage(ctx context.Context, msg *nats.Msg) error {
+	// Parse the Kubernetes event.
+	var event map[string]interface{}
+	if err := json.Unmarshal(msg.Data, &event); err != nil {
+		return fmt.Errorf("failed to unmarshal event: %w", err)
+	}
+
+	// Extract involved object info to find matching policy.
+	// Kubernetes events have either "regarding" (events.k8s.io/v1) or
+	// "involvedObject" (core/v1) to identify the subject resource.
+	involvedObject := p.getInvolvedObject(event)
+	if involvedObject == nil {
+		klog.V(4).Info("Event has no involved object, skipping")
+		return nil
+	}
+
+	apiGroup := getStringFromMap(involvedObject, "apiGroup")
+	// For core resources, apiVersion is "v1" with empty apiGroup.
+	if apiGroup == "" {
+		if apiVersion := getStringFromMap(involvedObject, "apiVersion"); apiVersion != "" && apiVersion != "v1" {
+			apiGroup = parseAPIGroup(apiVersion)
+		}
+	}
+	kind := getStringFromMap(involvedObject, "kind")
+
+	if kind == "" {
+		klog.V(4).InfoS("Could not determine kind from event, skipping")
+		return nil
+	}
+
+	// Normalize event so CEL expressions can always use event.regarding.
+	normalizedEvent := p.normalizeEvent(event, involvedObject)
+
+	// Delegate policy matching to the lookup (avoids import cycle with activityprocessor).
+	matched, err := p.policyLookup.MatchEvent(apiGroup, kind, normalizedEvent)
+	if err != nil {
+		return fmt.Errorf("failed to match event against policies: %w", err)
+	}
+
+	if matched == nil {
+		klog.V(4).InfoS("No policy matched event",
+			"apiGroup", apiGroup, "kind", kind)
+		return nil
+	}
+
+	activity := p.buildActivity(event, matched, involvedObject, matched.Summary, matched.Links)
+
+	if err := p.publishActivity(ctx, activity); err != nil {
+		return fmt.Errorf("failed to publish activity: %w", err)
+	}
+
+	klog.V(3).InfoS("Generated activity from event",
+		"activity", activity.Name,
+		"summary", activity.Spec.Summary,
+		"reason", getStringFromMap(event, "reason"),
+	)
+
+	return nil
+}
+
+// getInvolvedObject extracts the involved object from a Kubernetes event.
+// Handles both v1.Event (regarding) and corev1.Event (involvedObject) formats.
+func (p *EventProcessor) getInvolvedObject(event map[string]interface{}) map[string]interface{} {
+	// Try "regarding" first (events.k8s.io/v1).
+	if regarding, ok := event["regarding"].(map[string]interface{}); ok {
+		return regarding
+	}
+	// Fall back to "involvedObject" (v1).
+	if involvedObject, ok := event["involvedObject"].(map[string]interface{}); ok {
+		return involvedObject
+	}
+	return nil
+}
+
+// normalizeEvent creates a copy of the event with a "regarding" field.
+// This ensures CEL expressions can consistently use event.regarding regardless
+// of whether the original event used "regarding" or "involvedObject".
+func (p *EventProcessor) normalizeEvent(event map[string]interface{}, involvedObject map[string]interface{}) map[string]interface{} {
+	// If the event already has "regarding", return as-is.
+	if _, ok := event["regarding"]; ok {
+		return event
+	}
+
+	// Create a shallow copy with "regarding" added.
+	normalized := make(map[string]interface{}, len(event)+1)
+	for k, v := range event {
+		normalized[k] = v
+	}
+	normalized["regarding"] = involvedObject
+
+	return normalized
+}
+
+// buildActivity constructs an Activity resource from event data.
+func (p *EventProcessor) buildActivity(
+	event map[string]interface{},
+	matched *MatchedPolicy,
+	involvedObject map[string]interface{},
+	summary string,
+	links []cel.Link,
+) *v1alpha1.Activity {
+	// Extract timestamps - try eventTime first (events.k8s.io/v1).
+	var timestamp time.Time
+	if ts := getStringFromMap(event, "eventTime"); ts != "" {
+		if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+			timestamp = t
+		}
+	}
+	// Fall back to lastTimestamp or firstTimestamp.
+	if timestamp.IsZero() {
+		if ts := getStringFromMap(event, "lastTimestamp"); ts != "" {
+			if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+				timestamp = t
+			}
+		}
+	}
+	if timestamp.IsZero() {
+		if ts := getStringFromMap(event, "firstTimestamp"); ts != "" {
+			if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+				timestamp = t
+			}
+		}
+	}
+	// Fall back to metadata.creationTimestamp.
+	if timestamp.IsZero() {
+		if metadata, ok := event["metadata"].(map[string]interface{}); ok {
+			if ts := getStringFromMap(metadata, "creationTimestamp"); ts != "" {
+				if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+					timestamp = t
+				}
+			}
+		}
+	}
+	if timestamp.IsZero() {
+		timestamp = time.Now()
+	}
+
+	// Extract resource info from involved object.
+	namespace := getStringFromMap(involvedObject, "namespace")
+	resourceName := getStringFromMap(involvedObject, "name")
+	resourceUID := getStringFromMap(involvedObject, "uid")
+	apiVersion := getStringFromMap(involvedObject, "apiVersion")
+
+	// Resolve actor from reporting controller or source component.
+	actor := p.resolveEventActor(event)
+
+	// Events from controllers are always system-initiated.
+	changeSource := ChangeSourceSystem
+
+	// Extract event UID for origin tracking.
+	eventUID := ""
+	if metadata, ok := event["metadata"].(map[string]interface{}); ok {
+		eventUID = getStringFromMap(metadata, "uid")
+	}
+
+	// Generate activity name.
+	activityName := fmt.Sprintf("act-%s", uuid.New().String()[:8])
+
+	// Convert links.
+	var activityLinks []v1alpha1.ActivityLink
+	for _, link := range links {
+		activityLinks = append(activityLinks, v1alpha1.ActivityLink{
+			Marker: link.Marker,
+			Resource: v1alpha1.ActivityResource{
+				APIGroup:  getStringFromMap(link.Resource, "apiGroup"),
+				Kind:      getStringFromMap(link.Resource, "kind"),
+				Name:      getStringFromMap(link.Resource, "name"),
+				Namespace: getStringFromMap(link.Resource, "namespace"),
+				UID:       getStringFromMap(link.Resource, "uid"),
+			},
+		})
+	}
+
+	return &v1alpha1.Activity{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       "Activity",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              activityName,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.NewTime(timestamp),
+			Labels: map[string]string{
+				"activity.miloapis.com/origin-type":   "event",
+				"activity.miloapis.com/change-source": changeSource,
+				"activity.miloapis.com/api-group":     matched.APIGroup,
+				"activity.miloapis.com/resource-kind": matched.Kind,
+				"activity.miloapis.com/event-reason":  getStringFromMap(event, "reason"),
+			},
+		},
+		Spec: v1alpha1.ActivitySpec{
+			Summary:      summary,
+			ChangeSource: changeSource,
+			Actor:        actor,
+			Resource: v1alpha1.ActivityResource{
+				APIGroup:   matched.APIGroup,
+				APIVersion: apiVersion,
+				Kind:       matched.Kind,
+				Name:       resourceName,
+				Namespace:  namespace,
+				UID:        resourceUID,
+			},
+			Links: activityLinks,
+			Tenant: v1alpha1.ActivityTenant{
+				Type: "platform",
+				Name: "",
+			},
+			Origin: v1alpha1.ActivityOrigin{
+				Type: "event",
+				ID:   eventUID,
+			},
+		},
+	}
+}
+
+// resolveEventActor extracts actor information from a Kubernetes event.
+// Events are generated by controllers, so we extract the reporting controller or source component.
+func (p *EventProcessor) resolveEventActor(event map[string]interface{}) v1alpha1.ActivityActor {
+	// Try reportingController first (events.k8s.io/v1).
+	reportingController := getStringFromMap(event, "reportingController")
+
+	// Fall back to source.component (v1).
+	if reportingController == "" {
+		if source, ok := event["source"].(map[string]interface{}); ok {
+			reportingController = getStringFromMap(source, "component")
+		}
+	}
+
+	// Default to unknown if we can't find the controller.
+	if reportingController == "" {
+		reportingController = "unknown"
+	}
+
+	return v1alpha1.ActivityActor{
+		Type: ActorTypeController,
+		Name: reportingController,
+	}
+}
+
+// publishActivity serializes and publishes an Activity to the NATS ACTIVITIES stream.
+func (p *EventProcessor) publishActivity(ctx context.Context, activity *v1alpha1.Activity) error {
+	data, err := json.Marshal(activity)
+	if err != nil {
+		return fmt.Errorf("failed to marshal activity: %w", err)
+	}
+
+	subject := p.buildActivitySubject(activity)
+
+	// Use activity name as MsgID for NATS deduplication.
+	_, err = p.js.Publish(subject, data, nats.MsgId(activity.Name))
+	if err != nil {
+		return fmt.Errorf("failed to publish activity to NATS: %w", err)
+	}
+
+	return nil
+}
+
+// buildActivitySubject returns the NATS subject for routing activities.
+// Format: <prefix>.<tenant_type>.<tenant_name>.<api_group>.<origin>.<kind>.<namespace>.<name>
+func (p *EventProcessor) buildActivitySubject(activity *v1alpha1.Activity) string {
+	prefix := p.activityPrefix
+
+	tenantType := activity.Spec.Tenant.Type
+	if tenantType == "" {
+		tenantType = "platform"
+	}
+	tenantName := activity.Spec.Tenant.Name
+	if tenantName == "" {
+		tenantName = "_"
+	}
+
+	apiGroup := activity.Spec.Resource.APIGroup
+	if apiGroup == "" {
+		apiGroup = "core"
+	}
+
+	origin := activity.Spec.Origin.Type
+	kind := activity.Spec.Resource.Kind
+	namespace := activity.Spec.Resource.Namespace
+	if namespace == "" {
+		namespace = "_"
+	}
+	name := activity.Name
+
+	return fmt.Sprintf("%s.%s.%s.%s.%s.%s.%s.%s",
+		prefix, tenantType, tenantName, apiGroup, origin, kind, namespace, name)
+}
+
+// parseAPIGroup extracts the API group from an apiVersion string.
+// For "apps/v1", returns "apps". For "v1", returns "".
+func parseAPIGroup(apiVersion string) string {
+	for i := len(apiVersion) - 1; i >= 0; i-- {
+		if apiVersion[i] == '/' {
+			return apiVersion[:i]
+		}
+	}
+	return ""
+}

--- a/internal/processor/event_test.go
+++ b/internal/processor/event_test.go
@@ -1,0 +1,329 @@
+package processor
+
+import (
+	"testing"
+)
+
+func TestGetInvolvedObject(t *testing.T) {
+	p := &EventProcessor{}
+
+	tests := []struct {
+		name     string
+		event    map[string]any
+		wantNil  bool
+		wantKind string
+	}{
+		{
+			name: "events.k8s.io/v1 with regarding",
+			event: map[string]any{
+				"regarding": map[string]any{
+					"kind":       "Pod",
+					"name":       "my-pod",
+					"namespace":  "default",
+					"apiVersion": "v1",
+				},
+			},
+			wantNil:  false,
+			wantKind: "Pod",
+		},
+		{
+			name: "v1 with involvedObject",
+			event: map[string]any{
+				"involvedObject": map[string]any{
+					"kind":       "Deployment",
+					"name":       "my-deployment",
+					"namespace":  "default",
+					"apiVersion": "apps/v1",
+				},
+			},
+			wantNil:  false,
+			wantKind: "Deployment",
+		},
+		{
+			name:    "no involved object",
+			event:   map[string]any{},
+			wantNil: true,
+		},
+		{
+			name: "prefers regarding over involvedObject",
+			event: map[string]any{
+				"regarding": map[string]any{
+					"kind": "Service",
+				},
+				"involvedObject": map[string]any{
+					"kind": "Pod",
+				},
+			},
+			wantNil:  false,
+			wantKind: "Service",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.getInvolvedObject(tt.event)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("getInvolvedObject() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Errorf("getInvolvedObject() = nil, want non-nil")
+				return
+			}
+			if kind := getStringFromMap(got, "kind"); kind != tt.wantKind {
+				t.Errorf("getInvolvedObject() kind = %v, want %v", kind, tt.wantKind)
+			}
+		})
+	}
+}
+
+func TestParseAPIGroup(t *testing.T) {
+	tests := []struct {
+		apiVersion string
+		want       string
+	}{
+		{"v1", ""},
+		{"apps/v1", "apps"},
+		{"networking.k8s.io/v1", "networking.k8s.io"},
+		{"projectcontour.io/v1", "projectcontour.io"},
+		{"v1beta1", ""},
+		{"batch/v1", "batch"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.apiVersion, func(t *testing.T) {
+			if got := parseAPIGroup(tt.apiVersion); got != tt.want {
+				t.Errorf("parseAPIGroup(%q) = %q, want %q", tt.apiVersion, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveEventActor(t *testing.T) {
+	p := &EventProcessor{}
+
+	tests := []struct {
+		name      string
+		event     map[string]any
+		wantType  string
+		wantName  string
+	}{
+		{
+			name: "events.k8s.io/v1 with reportingController",
+			event: map[string]any{
+				"reportingController": "deployment-controller",
+			},
+			wantType: ActorTypeController,
+			wantName: "deployment-controller",
+		},
+		{
+			name: "v1 with source.component",
+			event: map[string]any{
+				"source": map[string]any{
+					"component": "kubelet",
+				},
+			},
+			wantType: ActorTypeController,
+			wantName: "kubelet",
+		},
+		{
+			name: "prefers reportingController over source",
+			event: map[string]any{
+				"reportingController": "scheduler",
+				"source": map[string]any{
+					"component": "kubelet",
+				},
+			},
+			wantType: ActorTypeController,
+			wantName: "scheduler",
+		},
+		{
+			name:     "no actor info",
+			event:    map[string]any{},
+			wantType: ActorTypeController,
+			wantName: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actor := p.resolveEventActor(tt.event)
+			if actor.Type != tt.wantType {
+				t.Errorf("resolveEventActor() Type = %v, want %v", actor.Type, tt.wantType)
+			}
+			if actor.Name != tt.wantName {
+				t.Errorf("resolveEventActor() Name = %v, want %v", actor.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestNormalizeEvent(t *testing.T) {
+	p := &EventProcessor{}
+
+	tests := []struct {
+		name           string
+		event          map[string]any
+		involvedObject map[string]any
+		wantRegarding  bool
+	}{
+		{
+			name: "event already has regarding",
+			event: map[string]any{
+				"reason": "Scheduled",
+				"regarding": map[string]any{
+					"kind": "Pod",
+					"name": "my-pod",
+				},
+			},
+			involvedObject: map[string]any{
+				"kind": "Pod",
+				"name": "my-pod",
+			},
+			wantRegarding: true,
+		},
+		{
+			name: "event has involvedObject, should add regarding",
+			event: map[string]any{
+				"reason": "Scheduled",
+				"involvedObject": map[string]any{
+					"kind": "Deployment",
+					"name": "my-deployment",
+				},
+			},
+			involvedObject: map[string]any{
+				"kind": "Deployment",
+				"name": "my-deployment",
+			},
+			wantRegarding: true,
+		},
+		{
+			name: "event has neither, should add regarding",
+			event: map[string]any{
+				"reason": "Unknown",
+			},
+			involvedObject: map[string]any{
+				"kind": "Service",
+				"name": "my-service",
+			},
+			wantRegarding: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized := p.normalizeEvent(tt.event, tt.involvedObject)
+
+			// Check that regarding exists
+			regarding, ok := normalized["regarding"].(map[string]any)
+			if tt.wantRegarding && !ok {
+				t.Error("normalizeEvent() should have 'regarding' field")
+				return
+			}
+
+			// Verify the regarding content matches involvedObject
+			if regarding != nil {
+				if regarding["kind"] != tt.involvedObject["kind"] {
+					t.Errorf("regarding.kind = %v, want %v", regarding["kind"], tt.involvedObject["kind"])
+				}
+				if regarding["name"] != tt.involvedObject["name"] {
+					t.Errorf("regarding.name = %v, want %v", regarding["name"], tt.involvedObject["name"])
+				}
+			}
+
+			// Verify original event is not modified when it had regarding
+			// (we return the same map reference if it already has regarding)
+
+			// Verify other fields are preserved
+			if normalized["reason"] != tt.event["reason"] {
+				t.Errorf("reason field not preserved: got %v, want %v", normalized["reason"], tt.event["reason"])
+			}
+		})
+	}
+}
+
+func TestBuildActivityFromEvent(t *testing.T) {
+	p := &EventProcessor{}
+
+	event := map[string]any{
+		"metadata": map[string]any{
+			"uid":               "event-123",
+			"creationTimestamp": "2024-01-15T10:30:00Z",
+		},
+		"reason":              "Scheduled",
+		"message":             "Successfully assigned default/my-pod to node-1",
+		"reportingController": "default-scheduler",
+		"regarding": map[string]any{
+			"kind":       "Pod",
+			"name":       "my-pod",
+			"namespace":  "default",
+			"uid":        "pod-456",
+			"apiVersion": "v1",
+		},
+	}
+
+	involvedObject := map[string]any{
+		"kind":       "Pod",
+		"name":       "my-pod",
+		"namespace":  "default",
+		"uid":        "pod-456",
+		"apiVersion": "v1",
+	}
+
+	matched := &MatchedPolicy{
+		PolicyName: "core-pods",
+		APIGroup:   "",
+		Kind:       "Pod",
+		Summary:    "Pod my-pod was scheduled",
+	}
+
+	activity := p.buildActivity(event, matched, involvedObject, matched.Summary, nil)
+
+	// Verify activity fields
+	if activity.Spec.Summary != "Pod my-pod was scheduled" {
+		t.Errorf("Summary = %q, want %q", activity.Spec.Summary, "Pod my-pod was scheduled")
+	}
+
+	if activity.Spec.ChangeSource != ChangeSourceSystem {
+		t.Errorf("ChangeSource = %q, want %q", activity.Spec.ChangeSource, ChangeSourceSystem)
+	}
+
+	if activity.Spec.Actor.Type != ActorTypeController {
+		t.Errorf("Actor.Type = %q, want %q", activity.Spec.Actor.Type, ActorTypeController)
+	}
+
+	if activity.Spec.Actor.Name != "default-scheduler" {
+		t.Errorf("Actor.Name = %q, want %q", activity.Spec.Actor.Name, "default-scheduler")
+	}
+
+	if activity.Spec.Resource.Kind != "Pod" {
+		t.Errorf("Resource.Kind = %q, want %q", activity.Spec.Resource.Kind, "Pod")
+	}
+
+	if activity.Spec.Resource.Name != "my-pod" {
+		t.Errorf("Resource.Name = %q, want %q", activity.Spec.Resource.Name, "my-pod")
+	}
+
+	if activity.Spec.Resource.Namespace != "default" {
+		t.Errorf("Resource.Namespace = %q, want %q", activity.Spec.Resource.Namespace, "default")
+	}
+
+	if activity.Spec.Origin.Type != "event" {
+		t.Errorf("Origin.Type = %q, want %q", activity.Spec.Origin.Type, "event")
+	}
+
+	if activity.Spec.Origin.ID != "event-123" {
+		t.Errorf("Origin.ID = %q, want %q", activity.Spec.Origin.ID, "event-123")
+	}
+
+	// Verify labels
+	if activity.Labels["activity.miloapis.com/origin-type"] != "event" {
+		t.Errorf("origin-type label = %q, want %q", activity.Labels["activity.miloapis.com/origin-type"], "event")
+	}
+
+	if activity.Labels["activity.miloapis.com/event-reason"] != "Scheduled" {
+		t.Errorf("event-reason label = %q, want %q", activity.Labels["activity.miloapis.com/event-reason"], "Scheduled")
+	}
+}

--- a/internal/processor/policy.go
+++ b/internal/processor/policy.go
@@ -1,0 +1,87 @@
+package processor
+
+import "go.miloapis.com/activity/internal/cel"
+
+// PolicyRule represents a compiled activity policy rule for CEL evaluation.
+// This is the minimal interface that EventProcessor and AuditProcessor need
+// to match events/audit records against policy rules. The activityprocessor
+// package provides concrete implementations of this interface.
+type PolicyRule interface {
+	// IsValid returns true if the rule compiled successfully.
+	IsValid() bool
+	// EvaluateEventMatch evaluates the match expression against an event map.
+	EvaluateEventMatch(eventMap map[string]any) (bool, error)
+	// EvaluateAuditMatch evaluates the match expression against an audit map.
+	EvaluateAuditMatch(auditMap map[string]any) (bool, error)
+	// EvaluateSummary evaluates the summary template with the given variables.
+	// Returns the rendered summary, any links collected via link() calls, and any error.
+	EvaluateSummary(vars map[string]any) (string, []cel.Link, error)
+}
+
+// MatchedPolicy contains the result of matching an event against policy rules.
+type MatchedPolicy struct {
+	// PolicyName is the name of the matching policy.
+	PolicyName string
+	// APIGroup is the API group of the target resource.
+	APIGroup string
+	// Kind is the kind of the target resource.
+	Kind string
+	// Summary is the generated activity summary.
+	Summary string
+	// Links contains clickable references extracted from link() calls in the summary template.
+	Links []cel.Link
+}
+
+// EventPolicyLookup is the interface used by EventProcessor to look up and
+// evaluate activity policies against Kubernetes events.
+// activityprocessor.PolicyCache provides an adapter that satisfies this interface.
+type EventPolicyLookup interface {
+	// MatchEvent looks up matching event rules for the given resource and
+	// evaluates them against the provided event map.
+	// Returns the first matching result, or nil if no policy matched.
+	MatchEvent(apiGroup, kind string, eventMap map[string]any) (*MatchedPolicy, error)
+}
+
+// AuditPolicyLookup is the interface used by AuditProcessor to look up and
+// evaluate activity policies against audit log events.
+type AuditPolicyLookup interface {
+	// MatchAudit looks up matching audit rules for the given resource and
+	// evaluates them against the provided audit map.
+	// Returns the first matching result, or nil if no policy matched.
+	MatchAudit(apiGroup, resource string, auditMap map[string]any) (*MatchedPolicy, error)
+}
+
+// PolicyUpdater is the interface used by the Processor to update the policy cache
+// when ActivityPolicy resources change.
+type PolicyUpdater interface {
+	// AddPolicy adds a policy to the cache.
+	AddPolicy(policy *PolicySpec) error
+	// UpdatePolicy updates a policy in the cache.
+	UpdatePolicy(oldPolicy, newPolicy *PolicySpec) error
+	// RemovePolicy removes a policy from the cache.
+	RemovePolicy(policy *PolicySpec)
+}
+
+// PolicySpec contains the minimal information needed to add a policy to the cache.
+type PolicySpec struct {
+	// Name is the policy name.
+	Name string
+	// APIGroup is the target resource's API group.
+	APIGroup string
+	// Kind is the target resource's kind.
+	Kind string
+	// Resource is the plural resource name.
+	Resource string
+	// ResourceVersion is used for cache invalidation.
+	ResourceVersion string
+	// AuditRules are the CEL match/summary rule pairs for audit events.
+	AuditRules []RuleSpec
+	// EventRules are the CEL match/summary rule pairs for Kubernetes events.
+	EventRules []RuleSpec
+}
+
+// RuleSpec contains a match/summary rule pair.
+type RuleSpec struct {
+	Match   string
+	Summary string
+}


### PR DESCRIPTION
## Overview

Extends the activity processor to transform Kubernetes events into human-readable activities.

## How It Works

ActivityPolicy rules can match on events using `eventRules`. When an event matches, the processor generates an activity with a human-readable summary.

## Example

```yaml
apiVersion: activity.datum.net/v1alpha1
kind: ActivityPolicy
metadata:
  name: pod-events
spec:
  match:
    involvedObject:
      kind: Pod
  eventRules:
  - name: scheduled
    match: 'reason == "Scheduled"'
    activity:
      summary: 'involvedObject.name + " scheduled"'
```

## Use Cases

- See deployment progress as pods schedule and start
- Track image pull activity across the cluster
- Monitor health check failures and restarts