### PR TITLE
feat: add events ingestion pipeline to Vector aggregator

### DIFF
--- a/config/components/nats-streams/clickhouse-events-consumer.yaml
+++ b/config/components/nats-streams/clickhouse-events-consumer.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Consumer
+metadata:
+  name: clickhouse-ingest-events
+spec:
+  # Link to the stream
+  streamName: EVENTS
+
+  # Durable consumer name
+  durableName: clickhouse-ingest-events
+
+  # Delivery policy: deliver all messages (including historical)
+  deliverPolicy: all
+
+  # Ack policy: explicit acknowledgments required
+  ackPolicy: explicit
+
+  # Replay policy: instant (process as fast as possible)
+  replayPolicy: instant
+
+  # Filter subject: all events
+  filterSubject: events.>
+
+  # Max delivery attempts: unlimited (-1)
+  maxDeliver: -1
+
+  # Max ack pending: allow 5000 unacknowledged messages
+  # Vector pulls in batches of 1000, so this allows multiple batches in-flight
+  # Events are smaller than audit logs, so we can use a smaller buffer
+  maxAckPending: 5000
+
+  # Ack wait: 60 seconds before redelivery
+  # Vector v0.50.0+ properly acknowledges messages after successful processing
+  # This timeout handles cases where Vector crashes during processing
+  ackWait: 60s
+
+  # PULL-based consumer (no deliverSubject)
+  # Vector will pull messages directly using JetStream pull consumer protocol
+  # Messages are acknowledged only after successful delivery to ClickHouse

--- a/config/components/nats-streams/kustomization.yaml
+++ b/config/components/nats-streams/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - clickhouse-activities-consumer.yaml
   - events-stream.yaml
   - events-processor-consumer.yaml
+  - clickhouse-events-consumer.yaml
 
 # Note: This contains application-specific NATS JetStream stream configurations.
 # The NATS infrastructure (server + NACK controller) is deployed from config/dependencies/nats/

--- a/config/components/vector-aggregator/vector-hr.yaml
+++ b/config/components/vector-aggregator/vector-hr.yaml
@@ -102,6 +102,28 @@ spec:
           decoding:
             codec: json
 
+        # NATS JetStream consumer for Kubernetes events
+        # Events are exported by the activity-event-exporter from the Kubernetes API
+        nats_events_consumer:
+          type: nats
+          connection_name: vector-aggregator-events
+          url: nats://nats.nats-system.svc.cluster.local:4222
+
+          # Subject filter for all events
+          subject: events.>
+
+          # JetStream configuration
+          jetstream:
+            stream: EVENTS
+            consumer: clickhouse-ingest-events
+
+            batch_config:
+              batch: 1000
+              # Maximum 5MB per batch (events are smaller than audit events)
+              max_bytes: 5242880
+          decoding:
+            codec: json
+
         internal_metrics:
           type: internal_metrics
           namespace: vector
@@ -223,6 +245,24 @@ spec:
               "activity_json": .activity_json
             }
 
+        # ========================================================================
+        # Events Pipeline
+        # ========================================================================
+
+        # Prepare events for ClickHouse
+        # Events are exported by the activity-event-exporter from the Kubernetes API.
+        # We wrap them as event_json for the k8s_events table schema.
+        prepare_events_for_clickhouse:
+          type: remap
+          inputs:
+            - nats_events_consumer
+          source: |
+            # Wrap entire event as event_json for ClickHouse
+            .event_json = encode_json(.)
+            . = {
+              "event_json": .event_json
+            }
+
       sinks:
         # Export audit events to ClickHouse audit.events table
         clickhouse_audit_events:
@@ -263,6 +303,34 @@ spec:
           encoding:
             only_fields:
               - activity_json
+          batch:
+            max_bytes: 5242880
+            max_events: 5000
+            timeout_secs: 10
+          buffer:
+            type: disk
+            max_size: 5368709120
+            when_full: block
+          request:
+            retry_attempts: 9999999
+            retry_initial_backoff_secs: 1
+            retry_max_duration_secs: 300
+            timeout_secs: 60
+          healthcheck:
+            enabled: true
+          compression: gzip
+
+        # Export Kubernetes events to ClickHouse audit.k8s_events table
+        clickhouse_k8s_events:
+          type: clickhouse
+          inputs:
+            - prepare_events_for_clickhouse
+          endpoint: http://clickhouse.activity-system.svc.cluster.local:8123
+          database: audit
+          table: k8s_events
+          encoding:
+            only_fields:
+              - event_json
           batch:
             max_bytes: 5242880
             max_events: 5000

--- a/config/overlays/dev/kustomization.yaml
+++ b/config/overlays/dev/kustomization.yaml
@@ -20,6 +20,7 @@ components:
   - ../../components/grafana-clickhouse
   - ../../components/vector-sidecar
   - ../../components/vector-aggregator
+  - ../../components/k8s-event-exporter            # Kubernetes events → NATS
   - ../../components/tracing
   - ../../components/observability            # ServiceMonitors, alerts, dashboards
 


### PR DESCRIPTION
## Summary

This adds the Vector aggregator configuration needed to ingest control plane events into ClickHouse for long-term storage and querying.

## What This Enables

- **Event Ingestion**: Control plane events flow from NATS JetStream into ClickHouse
- **Event Querying**: Once ingested, events can be queried through the Activity API's `EventQuery` and `EventFacetQuery` resources
- **Activity Correlation**: Events become available for correlation with audit logs and activities

## Configuration Added

The Vector aggregator now includes:
- A NATS JetStream source consuming from the `EVENTS` stream
- A transform that structures events for ClickHouse
- A ClickHouse sink that writes to the `events` table

## Dependencies

This configuration requires:
- The `EVENTS` NATS stream (added in a prior PR)
- The ClickHouse `events` table migration
- The k8s-event-exporter component (for development environments)