### PR TITLE
feat(config): add TLS and kubeconfig env vars to base deployments

### DIFF
--- a/config/base/controller-manager.yaml
+++ b/config/base/controller-manager.yaml
@@ -66,11 +66,14 @@ spec:
         - /activity
         - controller-manager
         args:
+        - --kubeconfig=$(KUBECONFIG)
         - --workers=$(WORKERS)
         - --metrics-addr=$(METRICS_ADDR)
         - --health-probe-addr=$(HEALTH_PROBE_ADDR)
         - -v=$(LOG_LEVEL)
         env:
+        - name: KUBECONFIG
+          value: ""
         - name: WORKERS
           value: "2"
         - name: METRICS_ADDR

--- a/config/base/processor.yaml
+++ b/config/base/processor.yaml
@@ -76,8 +76,13 @@ spec:
         - --consumer-name=$(CONSUMER_NAME)
         - --output-stream=$(OUTPUT_STREAM)
         - --output-subject-prefix=$(OUTPUT_SUBJECT_PREFIX)
+        - --nats-tls-enabled=$(NATS_TLS_ENABLED)
+        - --nats-tls-cert-file=$(NATS_TLS_CERT_FILE)
+        - --nats-tls-key-file=$(NATS_TLS_KEY_FILE)
+        - --nats-tls-ca-file=$(NATS_TLS_CA_FILE)
         - --workers=$(WORKERS)
         - --batch-size=$(BATCH_SIZE)
+        - --health-probe-addr=$(HEALTH_PROBE_ADDR)
         - -v=$(LOG_LEVEL)
         env:
         - name: NATS_URL
@@ -90,10 +95,20 @@ spec:
           value: "ACTIVITIES"
         - name: OUTPUT_SUBJECT_PREFIX
           value: "activities"
+        - name: NATS_TLS_ENABLED
+          value: "false"
+        - name: NATS_TLS_CERT_FILE
+          value: ""
+        - name: NATS_TLS_KEY_FILE
+          value: ""
+        - name: NATS_TLS_CA_FILE
+          value: ""
         - name: WORKERS
           value: "4"
         - name: BATCH_SIZE
           value: "100"
+        - name: HEALTH_PROBE_ADDR
+          value: ":8081"
         - name: LOG_LEVEL
           value: "2"
         resources:


### PR DESCRIPTION
## Summary
- Add environment variables for NATS TLS configuration to processor deployment
- Add KUBECONFIG env var to controller-manager deployment
- Enables overlays to configure TLS by patching env vars instead of rewriting args

## Changes

**Processor** (`config/base/processor.yaml`):
- `NATS_TLS_ENABLED` (default: false)
- `NATS_TLS_CERT_FILE`
- `NATS_TLS_KEY_FILE`
- `NATS_TLS_CA_FILE`
- `HEALTH_PROBE_ADDR` (default: :8081)

**Controller-manager** (`config/base/controller-manager.yaml`):
- `KUBECONFIG` (default: empty, uses in-cluster config)

## Why
Environment-specific overlays (like staging) previously had to rewrite the entire args list to add TLS flags. This caused maintenance issues when flags changed in the code. Now overlays only need to patch env var values and add volume mounts.