### PR TITLE
feat(processor): add event processing pipeline with DLQ support

### DIFF
--- a/cmd/activity/event_exporter.go
+++ b/cmd/activity/event_exporter.go
@@ -11,21 +11,21 @@ import (
 // NewEventExporterCommand creates the event-exporter subcommand.
 func NewEventExporterCommand() *cobra.Command {
 	cfg := eventexporter.Config{
-		NATSUrl:       getEnvOrDefault("NATS_URL", "nats://nats.nats-system.svc.cluster.local:4222"),
-		SubjectPrefix: getEnvOrDefault("SUBJECT_PREFIX", "events.k8s"),
-		ScopeType:     getEnvOrDefault("SCOPE_TYPE", "organization"),
-		ScopeName:     getEnvOrDefault("SCOPE_NAME", "dev-org"),
-		Kubeconfig:    os.Getenv("KUBECONFIG"),
-		ResyncPeriod:  30 * time.Minute,
+		NATSUrl:         getEnvOrDefault("NATS_URL", "nats://nats.nats-system.svc.cluster.local:4222"),
+		SubjectPrefix:   getEnvOrDefault("SUBJECT_PREFIX", "events.k8s"),
+		ScopeType:       getEnvOrDefault("SCOPE_TYPE", "organization"),
+		ScopeName:       getEnvOrDefault("SCOPE_NAME", "dev-org"),
+		Kubeconfig:      os.Getenv("KUBECONFIG"),
+		ResyncPeriod:    30 * time.Minute,
+		HealthProbeAddr: getEnvOrDefault("HEALTH_PROBE_ADDR", ":8081"),
 	}
 
 	cmd := &cobra.Command{
 		Use:   "event-exporter",
 		Short: "Export Kubernetes Events to NATS JetStream",
 		Long: `Watch Kubernetes Events and publish them to NATS JetStream for ingestion
-into ClickHouse. This exporter ensures format consistency by using the same
-corev1.Event types for both serialization and deserialization throughout
-the pipeline.
+into ClickHouse. This exporter uses events.k8s.io/v1 Event format for
+consistency with the EventRecord API and ClickHouse schema.
 
 Events are published with scope annotations for multi-tenant isolation.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -40,6 +40,7 @@ Events are published with scope annotations for multi-tenant isolation.`,
 	flags.StringVar(&cfg.ScopeName, "scope-name", cfg.ScopeName, "Scope name annotation value")
 	flags.StringVar(&cfg.Kubeconfig, "kubeconfig", cfg.Kubeconfig, "Path to kubeconfig (empty for in-cluster)")
 	flags.DurationVar(&cfg.ResyncPeriod, "resync-period", cfg.ResyncPeriod, "Informer resync period")
+	flags.StringVar(&cfg.HealthProbeAddr, "health-probe-addr", cfg.HealthProbeAddr, "Health probe server bind address")
 
 	return cmd
 }

--- a/config/base/processor.yaml
+++ b/config/base/processor.yaml
@@ -67,10 +67,15 @@ spec:
           capabilities:
             drop:
             - ALL
+        ports:
+        - containerPort: 8081
+          name: health
+          protocol: TCP
         command:
         - /activity
         - processor
         args:
+        - --kubeconfig=$(ACTIVITY_KUBECONFIG)
         - --nats-url=$(NATS_URL)
         - --nats-stream=$(NATS_STREAM)
         - --consumer-name=$(CONSUMER_NAME)
@@ -85,6 +90,8 @@ spec:
         - --health-probe-addr=$(HEALTH_PROBE_ADDR)
         - -v=$(LOG_LEVEL)
         env:
+        - name: ACTIVITY_KUBECONFIG
+          value: ""
         - name: NATS_URL
           value: "nats://nats.nats-system.svc.cluster.local:4222"
         - name: NATS_STREAM
@@ -118,9 +125,47 @@ spec:
           limits:
             cpu: 500m
             memory: 512Mi
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: health
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
         volumeMounts:
         - name: tmp
           mountPath: /tmp
       volumes:
       - name: tmp
         emptyDir: {}
+---
+# Service for metrics scraping by Prometheus
+apiVersion: v1
+kind: Service
+metadata:
+  name: activity-processor
+  namespace: activity-system
+  labels:
+    app: activity-processor
+    app.kubernetes.io/name: activity-processor
+    app.kubernetes.io/component: processor
+spec:
+  ports:
+  - name: health
+    port: 8081
+    protocol: TCP
+    targetPort: health
+  selector:
+    app: activity-processor
+  type: ClusterIP

--- a/config/components/k8s-event-exporter/deployment.yaml
+++ b/config/components/k8s-event-exporter/deployment.yaml
@@ -32,6 +32,10 @@ spec:
           args:
             - event-exporter
             - -v=2
+          ports:
+            - containerPort: 8081
+              name: health
+              protocol: TCP
           env:
             - name: NATS_URL
               value: "nats://nats.nats-system.svc.cluster.local:4222"
@@ -57,3 +61,21 @@ spec:
             limits:
               cpu: 100m
               memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/config/components/k8s-event-exporter/kustomization.yaml
+++ b/config/components/k8s-event-exporter/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Component
 
 resources:
   - deployment.yaml
+  - service.yaml
   - serviceaccount.yaml
   - rbac.yaml

--- a/config/components/k8s-event-exporter/service.yaml
+++ b/config/components/k8s-event-exporter/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8s-event-exporter
+  namespace: activity-system
+  labels:
+    app: k8s-event-exporter
+    app.kubernetes.io/name: k8s-event-exporter
+    app.kubernetes.io/component: event-forwarder
+spec:
+  ports:
+  - name: health
+    port: 8081
+    protocol: TCP
+    targetPort: health
+  selector:
+    app: k8s-event-exporter
+  type: ClusterIP

--- a/config/components/nats-streams/dlq-stream.yaml
+++ b/config/components/nats-streams/dlq-stream.yaml
@@ -1,0 +1,76 @@
+# Dead-Letter Queue Stream for failed activity events.
+#
+# This stream captures events that failed processing due to CEL evaluation errors,
+# template rendering failures, or other issues. Events are preserved for debugging
+# while allowing processing to continue.
+#
+# CONSUMING FROM THE DLQ:
+#
+# 1. View recent dead-lettered events:
+#    nats stream view ACTIVITY_DEAD_LETTER --last 10
+#
+# 2. Create a temporary consumer to filter by event type:
+#    nats consumer add ACTIVITY_DEAD_LETTER temp --filter "activity.dlq.audit.>"
+#    nats consumer add ACTIVITY_DEAD_LETTER temp --filter "activity.dlq.k8s-event.>"
+#
+# 3. Filter by API group and kind:
+#    nats consumer add ACTIVITY_DEAD_LETTER temp --filter "activity.dlq.audit.apps.Deployment"
+#
+# 4. Replay events after fixing policy:
+#    - Extract originalPayload from DLQ message
+#    - Republish to AUDIT_EVENTS or EVENTS stream
+#    - Event will be reprocessed with fixed policy
+#
+# 5. Purge old messages:
+#    nats stream purge ACTIVITY_DEAD_LETTER --keep 0 --filter ">" --older 168h
+#
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: activity-dead-letter
+spec:
+  # Stream name in NATS
+  name: ACTIVITY_DEAD_LETTER
+
+  # Subjects to consume - wildcard for all DLQ events
+  # Format: activity.dlq.<event_type>.<api_group>.<kind>
+  subjects:
+    - activity.dlq.>
+
+  # Retention policy: limits-based (time + size)
+  retention: limits
+
+  # Storage: file-based for durability
+  storage: file
+
+  # Maximum age: 30 days (longer retention for debugging)
+  maxAge: 720h  # 30 days = 720 hours
+
+  # Maximum bytes: 1GB (sufficient for dev/test environments)
+  # Production should increase to 10GB for longer debugging cycles
+  maxBytes: 1073741824  # 1 * 1024 * 1024 * 1024
+
+  # Number of replicas for high availability
+  replicas: 1  # Increase to 3 for production HA
+
+  # Discard policy when limits are reached
+  discard: old
+
+  # Allow direct access for queries
+  allowDirect: true
+
+  # Deduplication window
+  duplicateWindow: 5m
+
+  # Maximum number of consumers
+  maxConsumers: 10
+
+  # Maximum message size (1MB - sufficient for audit events + metadata)
+  maxMsgSize: 1048576  # 1 * 1024 * 1024
+
+  # No message limit - rely on age and size limits
+  maxMsgs: -1
+
+  # Performance tuning
+  noAck: false  # Require acknowledgments for durability

--- a/config/components/nats-streams/kustomization.yaml
+++ b/config/components/nats-streams/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - events-stream.yaml
   - events-processor-consumer.yaml
   - clickhouse-events-consumer.yaml
+  - dlq-stream.yaml
 
 # Note: This contains application-specific NATS JetStream stream configurations.
 # The NATS infrastructure (server + NACK controller) is deployed from config/dependencies/nats/

--- a/config/components/vector-aggregator/vector-hr.yaml
+++ b/config/components/vector-aggregator/vector-hr.yaml
@@ -264,14 +264,14 @@ spec:
             }
 
       sinks:
-        # Export audit events to ClickHouse audit.events table
+        # Export audit events to ClickHouse audit.audit_logs table
         clickhouse_audit_events:
           type: clickhouse
           inputs:
             - prepare_audit_for_clickhouse
           endpoint: http://clickhouse.activity-system.svc.cluster.local:8123
           database: audit
-          table: events
+          table: audit_logs
           encoding:
             only_fields:
               - event_json

--- a/internal/activityprocessor/event_emitter.go
+++ b/internal/activityprocessor/event_emitter.go
@@ -1,0 +1,68 @@
+package activityprocessor
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
+)
+
+const (
+	// EventReasonEvaluationFailed is the reason for Warning events when CEL evaluation fails.
+	EventReasonEvaluationFailed = "EvaluationFailed"
+)
+
+// EventEmitter emits Kubernetes Warning events for policy evaluation failures.
+type EventEmitter struct {
+	client   client.Client
+	recorder record.EventRecorder
+}
+
+// NewEventEmitter creates a new event emitter.
+func NewEventEmitter(client client.Client, recorder record.EventRecorder) *EventEmitter {
+	return &EventEmitter{
+		client:   client,
+		recorder: recorder,
+	}
+}
+
+// EmitEvaluationError emits a Kubernetes Warning event for an evaluation failure.
+func (e *EventEmitter) EmitEvaluationError(ctx context.Context, policyName string, ruleIndex int, err error) {
+	// Fetch the current policy to emit event on it
+	var policy v1alpha1.ActivityPolicy
+	if fetchErr := e.client.Get(ctx, types.NamespacedName{Name: policyName}, &policy); fetchErr != nil {
+		if client.IgnoreNotFound(fetchErr) == nil {
+			// Policy was deleted, nothing to report
+			return
+		}
+		klog.ErrorS(fetchErr, "Failed to fetch policy for event emission", "policy", policyName)
+		return
+	}
+
+	// Build event message
+	message := fmt.Sprintf("CEL evaluation failed on rule %d: %s",
+		ruleIndex,
+		truncateString(err.Error(), 200),
+	)
+
+	e.recorder.Event(&policy, corev1.EventTypeWarning, EventReasonEvaluationFailed, message)
+
+	klog.V(2).InfoS("Emitted evaluation error event",
+		"policy", policyName,
+		"ruleIndex", ruleIndex,
+	)
+}
+
+// truncateString truncates a string to the specified maximum length.
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen]
+}

--- a/internal/activityprocessor/event_emitter_test.go
+++ b/internal/activityprocessor/event_emitter_test.go
@@ -1,0 +1,150 @@
+package activityprocessor
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"go.miloapis.com/activity/internal/controller"
+	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
+)
+
+func TestEventEmitter_EmitEvaluationError(t *testing.T) {
+	policy := &v1alpha1.ActivityPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-policy",
+		},
+		Spec: v1alpha1.ActivityPolicySpec{
+			Resource: v1alpha1.ActivityPolicyResource{
+				APIGroup: "test.example.com",
+				Kind:     "TestResource",
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(controller.Scheme).
+		WithObjects(policy).
+		Build()
+
+	recorder := record.NewFakeRecorder(10)
+	emitter := NewEventEmitter(k8sClient, recorder)
+
+	testErr := errors.New("CEL evaluation failed: undefined variable")
+	emitter.EmitEvaluationError(context.Background(), "test-policy", 2, testErr)
+
+	// Check that an event was emitted
+	select {
+	case event := <-recorder.Events:
+		if !strings.Contains(event, "CEL evaluation failed") {
+			t.Errorf("expected event to contain 'CEL evaluation failed', got: %s", event)
+		}
+		if !strings.Contains(event, "rule 2") {
+			t.Errorf("expected event to contain 'rule 2', got: %s", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected event to be emitted, but none was received")
+	}
+}
+
+func TestEventEmitter_PolicyDeleted(t *testing.T) {
+	// Create client without the policy
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(controller.Scheme).
+		Build()
+
+	recorder := record.NewFakeRecorder(10)
+	emitter := NewEventEmitter(k8sClient, recorder)
+
+	testErr := errors.New("test error")
+	// Should not panic when policy is deleted
+	emitter.EmitEvaluationError(context.Background(), "test-policy", 0, testErr)
+
+	// No event should be emitted
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("expected no event when policy is deleted, but got: %s", event)
+	case <-time.After(100 * time.Millisecond):
+		// No event as expected
+	}
+}
+
+func TestEventEmitter_LongErrorMessage(t *testing.T) {
+	policy := &v1alpha1.ActivityPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-policy",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(controller.Scheme).
+		WithObjects(policy).
+		Build()
+
+	recorder := record.NewFakeRecorder(10)
+	emitter := NewEventEmitter(k8sClient, recorder)
+
+	// Create a very long error message
+	longError := errors.New(strings.Repeat("x", 500))
+	emitter.EmitEvaluationError(context.Background(), "test-policy", 0, longError)
+
+	// Check that event was emitted with truncated message
+	select {
+	case event := <-recorder.Events:
+		// Message should be truncated to 200 characters for the error portion
+		if len(event) > 500 {
+			t.Logf("Event message length: %d", len(event))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected event to be emitted")
+	}
+}
+
+func TestTruncateString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxLen   int
+		expected string
+	}{
+		{
+			name:     "short string",
+			input:    "hello",
+			maxLen:   10,
+			expected: "hello",
+		},
+		{
+			name:     "exact length",
+			input:    "hello",
+			maxLen:   5,
+			expected: "hello",
+		},
+		{
+			name:     "truncated",
+			input:    "hello world",
+			maxLen:   5,
+			expected: "hello",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			maxLen:   5,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncateString(tt.input, tt.maxLen)
+			if result != tt.expected {
+				t.Errorf("truncateString(%q, %d) = %q, want %q", tt.input, tt.maxLen, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/processor/classifier.go
+++ b/internal/processor/classifier.go
@@ -43,23 +43,19 @@ func ResolveActor(user authnv1.UserInfo) v1alpha1.ActivityActor {
 	}
 
 	// Detect actor type based on username pattern
-	switch {
-	case strings.HasPrefix(user.Username, "system:"):
+	if strings.HasPrefix(user.Username, "system:") {
 		// System component (controller, service account, node, etc.)
 		actor.Type = ActorTypeSystem
-		// Remove "system:" prefix for display
 		actor.Name = strings.TrimPrefix(user.Username, "system:")
-
-	case strings.Contains(user.Username, "@"):
-		// Email-based username = human user
+	} else {
+		// Human user
 		actor.Type = ActorTypeUser
-		actor.Name = user.UID
+		actor.Name = user.Username
+	}
+
+	// Populate email field if username looks like an email
+	if strings.Contains(user.Username, "@") {
 		actor.Email = user.Username
-
-	default:
-		// Unknown pattern, treat as user
-		actor.Type = ActorTypeUser
-		actor.Name = user.UID
 	}
 
 	if actor.Name == "" {

--- a/internal/processor/dlq.go
+++ b/internal/processor/dlq.go
@@ -1,0 +1,333 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	dlqEventsPublished = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "activity_processor",
+			Subsystem: "dlq",
+			Name:      "events_published_total",
+			Help:      "Total number of events published to the dead-letter queue",
+		},
+		[]string{"event_type", "api_group", "kind", "error_type"},
+	)
+
+	dlqPublishLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "activity_processor",
+			Subsystem: "dlq",
+			Name:      "publish_latency_seconds",
+			Help:      "Latency of DLQ publish operations",
+			Buckets:   []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1},
+		},
+	)
+
+	dlqPublishErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "activity_processor",
+			Subsystem: "dlq",
+			Name:      "publish_errors_total",
+			Help:      "Total number of errors publishing to the dead-letter queue",
+		},
+		[]string{"event_type", "error_phase"}, // error_phase: "marshal" or "publish"
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		dlqEventsPublished,
+		dlqPublishLatency,
+		dlqPublishErrors,
+	)
+}
+
+// EventType identifies the type of event that failed processing.
+type EventType string
+
+const (
+	// EventTypeAudit indicates an audit log event.
+	EventTypeAudit EventType = "audit"
+	// EventTypeK8sEvent indicates a Kubernetes event.
+	EventTypeK8sEvent EventType = "k8s-event"
+)
+
+// ErrorType classifies the type of error that caused DLQ routing.
+type ErrorType string
+
+const (
+	// ErrorTypeCELMatch indicates the CEL match expression failed to evaluate.
+	// Example: A match expression like "audit.verb == 'create'" fails due to
+	// missing fields or type mismatches in the audit event.
+	ErrorTypeCELMatch ErrorType = "cel_match"
+
+	// ErrorTypeCELSummary indicates the CEL summary template failed to render.
+	// Example: A summary template like "{{ actor }} created {{ resource.name }}"
+	// fails because "resource.name" doesn't exist or has an unexpected type.
+	ErrorTypeCELSummary ErrorType = "cel_summary"
+
+	// ErrorTypeUnmarshal indicates the event JSON could not be parsed.
+	// Example: Malformed JSON in the NATS message payload, or unexpected
+	// structure that doesn't match the expected audit event schema.
+	ErrorTypeUnmarshal ErrorType = "unmarshal"
+
+	// ErrorTypeKindResolve indicates the resource-to-kind resolution failed.
+	// Example: An audit event references resource "widgets" but no CRD or
+	// built-in resource with that plural name exists in the API discovery cache.
+	ErrorTypeKindResolve ErrorType = "kind_resolve"
+)
+
+// Sentinel errors for error classification.
+var (
+	// ErrKindResolution indicates a failure to resolve a resource name to its Kind.
+	// Example: resolving "deployments" -> "Deployment" via API discovery.
+	ErrKindResolution = errors.New("kind resolution failed")
+
+	// ErrActivityBuild indicates a failure to build an Activity from the input.
+	// This wraps errors from link conversion, kind resolution during activity building, etc.
+	ErrActivityBuild = errors.New("activity build failed")
+)
+
+// PolicyEvaluationError wraps an error with policy context for DLQ routing.
+type PolicyEvaluationError struct {
+	PolicyName string
+	RuleIndex  int
+	Err        error
+}
+
+func (e *PolicyEvaluationError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *PolicyEvaluationError) Unwrap() error {
+	return e.Err
+}
+
+// NewPolicyEvaluationError creates a new PolicyEvaluationError.
+func NewPolicyEvaluationError(policyName string, ruleIndex int, err error) *PolicyEvaluationError {
+	return &PolicyEvaluationError{
+		PolicyName: policyName,
+		RuleIndex:  ruleIndex,
+		Err:        err,
+	}
+}
+
+// DeadLetterEvent wraps a failed event with error context for debugging.
+type DeadLetterEvent struct {
+	// Type identifies whether this is an audit log or Kubernetes event.
+	Type EventType `json:"type"`
+
+	// OriginalPayload contains the raw event JSON that failed processing.
+	OriginalPayload json.RawMessage `json:"originalPayload"`
+
+	// Error contains the error message from the failed processing attempt.
+	Error string `json:"error"`
+
+	// ErrorType classifies the type of error (cel_match, cel_summary, unmarshal).
+	ErrorType ErrorType `json:"errorType"`
+
+	// PolicyName is the name of the ActivityPolicy that failed evaluation.
+	PolicyName string `json:"policyName"`
+
+	// RuleIndex is the index of the rule within the policy that failed.
+	// -1 indicates the error occurred before rule evaluation.
+	RuleIndex int `json:"ruleIndex"`
+
+	// Timestamp is when the failure occurred.
+	Timestamp metav1.Time `json:"timestamp"`
+
+	// Tenant contains multi-tenancy information if available.
+	Tenant *DeadLetterTenant `json:"tenant,omitempty"`
+
+	// Resource contains information about the target resource.
+	Resource *DeadLetterResource `json:"resource,omitempty"`
+}
+
+// DeadLetterTenant contains tenant information for a dead-lettered event.
+type DeadLetterTenant struct {
+	// Type is the tenant type (platform, organization, project).
+	Type string `json:"type,omitempty"`
+	// Name is the tenant name.
+	Name string `json:"name,omitempty"`
+}
+
+// NewDeadLetterTenantFromActivity creates a DeadLetterTenant from an ActivityTenant.
+// Returns nil if the input tenant has default/empty values.
+func NewDeadLetterTenantFromActivity(tenantType, tenantName string) *DeadLetterTenant {
+	if tenantType == "" && tenantName == "" {
+		return nil
+	}
+	return &DeadLetterTenant{
+		Type: tenantType,
+		Name: tenantName,
+	}
+}
+
+// DeadLetterResource contains resource information for a dead-lettered event.
+type DeadLetterResource struct {
+	// APIGroup is the API group of the resource (empty for core resources).
+	APIGroup string `json:"apiGroup,omitempty"`
+	// Kind is the kind of the resource.
+	Kind string `json:"kind,omitempty"`
+	// Name is the name of the resource.
+	Name string `json:"name,omitempty"`
+	// Namespace is the namespace of the resource (empty for cluster-scoped).
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// DLQConfig contains configuration for the dead-letter queue.
+type DLQConfig struct {
+	// Enabled controls whether failed events are published to the DLQ.
+	Enabled bool
+
+	// StreamName is the NATS JetStream stream name for the DLQ.
+	StreamName string
+
+	// SubjectPrefix is the subject prefix for DLQ messages.
+	// Messages are published to: <prefix>.<event_type>.<api_group>.<kind>
+	SubjectPrefix string
+}
+
+// DefaultDLQConfig returns the default DLQ configuration.
+func DefaultDLQConfig() DLQConfig {
+	return DLQConfig{
+		Enabled:       true,
+		StreamName:    "ACTIVITY_DEAD_LETTER",
+		SubjectPrefix: "activity.dlq",
+	}
+}
+
+// DLQPublisher publishes failed events to the dead-letter queue.
+type DLQPublisher interface {
+	// PublishAuditFailure publishes a failed audit event to the DLQ.
+	// Returns nil if the DLQ is disabled.
+	PublishAuditFailure(ctx context.Context, payload json.RawMessage, policyName string, ruleIndex int, errorType ErrorType, err error, resource *DeadLetterResource, tenant *DeadLetterTenant) error
+
+	// PublishEventFailure publishes a failed Kubernetes event to the DLQ.
+	// Returns nil if the DLQ is disabled.
+	PublishEventFailure(ctx context.Context, payload json.RawMessage, policyName string, ruleIndex int, errorType ErrorType, err error, resource *DeadLetterResource, tenant *DeadLetterTenant) error
+}
+
+// NATSDLQPublisher implements DLQPublisher using NATS JetStream.
+type NATSDLQPublisher struct {
+	js     nats.JetStreamContext
+	config DLQConfig
+}
+
+// NewDLQPublisher creates a new DLQ publisher.
+// Returns nil if the DLQ is disabled.
+func NewDLQPublisher(js nats.JetStreamContext, config DLQConfig) DLQPublisher {
+	if !config.Enabled {
+		return &noopDLQPublisher{}
+	}
+
+	return &NATSDLQPublisher{
+		js:     js,
+		config: config,
+	}
+}
+
+// PublishAuditFailure publishes a failed audit event to the DLQ.
+func (p *NATSDLQPublisher) PublishAuditFailure(ctx context.Context, payload json.RawMessage, policyName string, ruleIndex int, errorType ErrorType, err error, resource *DeadLetterResource, tenant *DeadLetterTenant) error {
+	return p.publish(ctx, EventTypeAudit, payload, policyName, ruleIndex, errorType, err, resource, tenant)
+}
+
+// PublishEventFailure publishes a failed Kubernetes event to the DLQ.
+func (p *NATSDLQPublisher) PublishEventFailure(ctx context.Context, payload json.RawMessage, policyName string, ruleIndex int, errorType ErrorType, err error, resource *DeadLetterResource, tenant *DeadLetterTenant) error {
+	return p.publish(ctx, EventTypeK8sEvent, payload, policyName, ruleIndex, errorType, err, resource, tenant)
+}
+
+// publish publishes a dead-letter event to NATS.
+func (p *NATSDLQPublisher) publish(ctx context.Context, eventType EventType, payload json.RawMessage, policyName string, ruleIndex int, errorType ErrorType, originalErr error, resource *DeadLetterResource, tenant *DeadLetterTenant) error {
+	// Safely extract error message
+	errMsg := ""
+	if originalErr != nil {
+		errMsg = originalErr.Error()
+	}
+
+	dlEvent := DeadLetterEvent{
+		Type:            eventType,
+		OriginalPayload: payload,
+		Error:           errMsg,
+		ErrorType:       errorType,
+		PolicyName:      policyName,
+		RuleIndex:       ruleIndex,
+		Timestamp:       metav1.Now(),
+		Resource:        resource,
+		Tenant:          tenant,
+	}
+
+	data, err := json.Marshal(dlEvent)
+	if err != nil {
+		dlqPublishErrors.WithLabelValues(string(eventType), "marshal").Inc()
+		return fmt.Errorf("failed to marshal DLQ event: %w", err)
+	}
+
+	// Build subject: <prefix>.<event_type>.<api_group>.<kind>
+	apiGroup := "unknown"
+	kind := "unknown"
+	if resource != nil {
+		if resource.APIGroup != "" {
+			apiGroup = resource.APIGroup
+		} else {
+			apiGroup = "core"
+		}
+		if resource.Kind != "" {
+			kind = resource.Kind
+		}
+	}
+	subject := fmt.Sprintf("%s.%s.%s.%s", p.config.SubjectPrefix, eventType, apiGroup, kind)
+
+	// Use a timeout to prevent indefinite blocking on slow/stuck NATS
+	publishCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	publishStart := time.Now()
+	_, err = p.js.Publish(subject, data, nats.Context(publishCtx))
+	dlqPublishLatency.Observe(time.Since(publishStart).Seconds())
+
+	if err != nil {
+		dlqPublishErrors.WithLabelValues(string(eventType), "publish").Inc()
+		return fmt.Errorf("failed to publish to DLQ: %w", err)
+	}
+
+	dlqEventsPublished.WithLabelValues(
+		string(eventType),
+		apiGroup,
+		kind,
+		string(errorType),
+	).Inc()
+
+	klog.V(2).InfoS("Published event to DLQ",
+		"eventType", eventType,
+		"policy", policyName,
+		"ruleIndex", ruleIndex,
+		"errorType", errorType,
+		"subject", subject,
+	)
+
+	return nil
+}
+
+// noopDLQPublisher is a no-op implementation when DLQ is disabled.
+type noopDLQPublisher struct{}
+
+func (p *noopDLQPublisher) PublishAuditFailure(ctx context.Context, payload json.RawMessage, policyName string, ruleIndex int, errorType ErrorType, err error, resource *DeadLetterResource, tenant *DeadLetterTenant) error {
+	return nil
+}
+
+func (p *noopDLQPublisher) PublishEventFailure(ctx context.Context, payload json.RawMessage, policyName string, ruleIndex int, errorType ErrorType, err error, resource *DeadLetterResource, tenant *DeadLetterTenant) error {
+	return nil
+}

--- a/internal/processor/dlq_test.go
+++ b/internal/processor/dlq_test.go
@@ -1,0 +1,515 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestPolicyEvaluationError(t *testing.T) {
+	tests := []struct {
+		name       string
+		policyName string
+		ruleIndex  int
+		err        error
+	}{
+		{
+			name:       "basic error",
+			policyName: "test-policy",
+			ruleIndex:  0,
+			err:        errors.New("CEL evaluation failed"),
+		},
+		{
+			name:       "negative rule index",
+			policyName: "test-policy",
+			ruleIndex:  -1,
+			err:        errors.New("pre-rule error"),
+		},
+		{
+			name:       "empty policy name",
+			policyName: "",
+			ruleIndex:  2,
+			err:        errors.New("some error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policyErr := NewPolicyEvaluationError(tt.policyName, tt.ruleIndex, tt.err)
+
+			if policyErr.PolicyName != tt.policyName {
+				t.Errorf("PolicyName = %q, want %q", policyErr.PolicyName, tt.policyName)
+			}
+			if policyErr.RuleIndex != tt.ruleIndex {
+				t.Errorf("RuleIndex = %d, want %d", policyErr.RuleIndex, tt.ruleIndex)
+			}
+			if policyErr.Error() != tt.err.Error() {
+				t.Errorf("Error() = %q, want %q", policyErr.Error(), tt.err.Error())
+			}
+			if policyErr.Unwrap() != tt.err {
+				t.Errorf("Unwrap() = %v, want %v", policyErr.Unwrap(), tt.err)
+			}
+		})
+	}
+}
+
+func TestPolicyEvaluationErrorIs(t *testing.T) {
+	originalErr := errors.New("original error")
+	policyErr := NewPolicyEvaluationError("test-policy", 1, originalErr)
+
+	var unwrapped *PolicyEvaluationError
+	if !errors.As(policyErr, &unwrapped) {
+		t.Error("errors.As should succeed for PolicyEvaluationError")
+	}
+	if unwrapped.PolicyName != "test-policy" {
+		t.Errorf("unwrapped PolicyName = %q, want %q", unwrapped.PolicyName, "test-policy")
+	}
+	if unwrapped.RuleIndex != 1 {
+		t.Errorf("unwrapped RuleIndex = %d, want %d", unwrapped.RuleIndex, 1)
+	}
+}
+
+func TestNoopDLQPublisher(t *testing.T) {
+	publisher := &noopDLQPublisher{}
+	ctx := context.Background()
+	payload := json.RawMessage(`{"test": "data"}`)
+	testErr := errors.New("test error")
+
+	t.Run("PublishAuditFailure returns nil", func(t *testing.T) {
+		err := publisher.PublishAuditFailure(ctx, payload, "policy", 0, ErrorTypeCELMatch, testErr, nil, nil)
+		if err != nil {
+			t.Errorf("PublishAuditFailure() returned error: %v", err)
+		}
+	})
+
+	t.Run("PublishEventFailure returns nil", func(t *testing.T) {
+		err := publisher.PublishEventFailure(ctx, payload, "policy", 0, ErrorTypeCELMatch, testErr, nil, nil)
+		if err != nil {
+			t.Errorf("PublishEventFailure() returned error: %v", err)
+		}
+	})
+}
+
+func TestDefaultDLQConfig(t *testing.T) {
+	config := DefaultDLQConfig()
+
+	if !config.Enabled {
+		t.Error("default config should have Enabled = true")
+	}
+	if config.StreamName != "ACTIVITY_DEAD_LETTER" {
+		t.Errorf("StreamName = %q, want %q", config.StreamName, "ACTIVITY_DEAD_LETTER")
+	}
+	if config.SubjectPrefix != "activity.dlq" {
+		t.Errorf("SubjectPrefix = %q, want %q", config.SubjectPrefix, "activity.dlq")
+	}
+}
+
+func TestNewDLQPublisher_Disabled(t *testing.T) {
+	config := DLQConfig{
+		Enabled: false,
+	}
+	publisher := NewDLQPublisher(nil, config)
+
+	// Should return a noop publisher
+	_, isNoop := publisher.(*noopDLQPublisher)
+	if !isNoop {
+		t.Error("NewDLQPublisher with disabled config should return noopDLQPublisher")
+	}
+}
+
+func TestErrorTypes(t *testing.T) {
+	// Verify error type constants are distinct
+	errorTypes := []ErrorType{
+		ErrorTypeCELMatch,
+		ErrorTypeCELSummary,
+		ErrorTypeUnmarshal,
+		ErrorTypeKindResolve,
+	}
+
+	seen := make(map[ErrorType]bool)
+	for _, et := range errorTypes {
+		if seen[et] {
+			t.Errorf("duplicate error type: %s", et)
+		}
+		seen[et] = true
+	}
+}
+
+func TestEventTypes(t *testing.T) {
+	// Verify event type constants are distinct
+	if EventTypeAudit == EventTypeK8sEvent {
+		t.Error("EventTypeAudit and EventTypeK8sEvent should be different")
+	}
+
+	if EventTypeAudit != "audit" {
+		t.Errorf("EventTypeAudit = %q, want %q", EventTypeAudit, "audit")
+	}
+	if EventTypeK8sEvent != "k8s-event" {
+		t.Errorf("EventTypeK8sEvent = %q, want %q", EventTypeK8sEvent, "k8s-event")
+	}
+}
+
+func TestDeadLetterEventSerialization(t *testing.T) {
+	dlEvent := DeadLetterEvent{
+		Type:            EventTypeAudit,
+		OriginalPayload: json.RawMessage(`{"verb": "create"}`),
+		Error:           "CEL evaluation failed",
+		ErrorType:       ErrorTypeCELMatch,
+		PolicyName:      "test-policy",
+		RuleIndex:       1,
+		Resource: &DeadLetterResource{
+			APIGroup:  "apps",
+			Kind:      "Deployment",
+			Name:      "my-deployment",
+			Namespace: "default",
+		},
+		Tenant: &DeadLetterTenant{
+			Type: "project",
+			Name: "my-project",
+		},
+	}
+
+	data, err := json.Marshal(dlEvent)
+	if err != nil {
+		t.Fatalf("failed to marshal DeadLetterEvent: %v", err)
+	}
+
+	var unmarshaled DeadLetterEvent
+	if err := json.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("failed to unmarshal DeadLetterEvent: %v", err)
+	}
+
+	if unmarshaled.Type != dlEvent.Type {
+		t.Errorf("Type = %q, want %q", unmarshaled.Type, dlEvent.Type)
+	}
+	if unmarshaled.PolicyName != dlEvent.PolicyName {
+		t.Errorf("PolicyName = %q, want %q", unmarshaled.PolicyName, dlEvent.PolicyName)
+	}
+	if unmarshaled.RuleIndex != dlEvent.RuleIndex {
+		t.Errorf("RuleIndex = %d, want %d", unmarshaled.RuleIndex, dlEvent.RuleIndex)
+	}
+	if unmarshaled.Resource == nil {
+		t.Fatal("Resource should not be nil")
+	}
+	if unmarshaled.Resource.Kind != "Deployment" {
+		t.Errorf("Resource.Kind = %q, want %q", unmarshaled.Resource.Kind, "Deployment")
+	}
+	if unmarshaled.Tenant == nil {
+		t.Fatal("Tenant should not be nil")
+	}
+	if unmarshaled.Tenant.Type != "project" {
+		t.Errorf("Tenant.Type = %q, want %q", unmarshaled.Tenant.Type, "project")
+	}
+	if unmarshaled.Tenant.Name != "my-project" {
+		t.Errorf("Tenant.Name = %q, want %q", unmarshaled.Tenant.Name, "my-project")
+	}
+}
+
+func TestDeadLetterEventSerializationOmitEmpty(t *testing.T) {
+	dlEvent := DeadLetterEvent{
+		Type:            EventTypeK8sEvent,
+		OriginalPayload: json.RawMessage(`{}`),
+		Error:           "test error",
+		ErrorType:       ErrorTypeUnmarshal,
+		RuleIndex:       -1,
+		// Resource and Tenant are nil
+	}
+
+	data, err := json.Marshal(dlEvent)
+	if err != nil {
+		t.Fatalf("failed to marshal DeadLetterEvent: %v", err)
+	}
+
+	// Verify omitempty works
+	dataStr := string(data)
+	if strings.Contains(dataStr, `"resource"`) && !strings.Contains(dataStr, `"resource":null`) {
+		// The resource field should be omitted entirely or be null
+		var m map[string]interface{}
+		json.Unmarshal(data, &m)
+		if _, hasResource := m["resource"]; hasResource && m["resource"] != nil {
+			t.Error("resource should be omitted when nil")
+		}
+	}
+	if strings.Contains(dataStr, `"tenant"`) && !strings.Contains(dataStr, `"tenant":null`) {
+		var m map[string]interface{}
+		json.Unmarshal(data, &m)
+		if _, hasTenant := m["tenant"]; hasTenant && m["tenant"] != nil {
+			t.Error("tenant should be omitted when nil")
+		}
+	}
+}
+
+// mockPublishedMessage stores published messages for verification.
+type mockPublishedMessage struct {
+	Subject string
+	Data    []byte
+}
+
+// testPublisher is a test wrapper that captures published messages.
+// It uses a function-based approach to avoid implementing the full JetStreamContext interface.
+type testPublisher struct {
+	published   []mockPublishedMessage
+	publishFunc func(subj string, data []byte) error
+}
+
+func (t *testPublisher) publish(ctx context.Context, eventType EventType, payload json.RawMessage, policyName string, ruleIndex int, errorType ErrorType, originalErr error, resource *DeadLetterResource, tenant *DeadLetterTenant) error {
+	// Safely extract error message
+	errMsg := ""
+	if originalErr != nil {
+		errMsg = originalErr.Error()
+	}
+
+	dlEvent := DeadLetterEvent{
+		Type:            eventType,
+		OriginalPayload: payload,
+		Error:           errMsg,
+		ErrorType:       errorType,
+		PolicyName:      policyName,
+		RuleIndex:       ruleIndex,
+		Resource:        resource,
+		Tenant:          tenant,
+	}
+
+	data, err := json.Marshal(dlEvent)
+	if err != nil {
+		return err
+	}
+
+	// Build subject: <prefix>.<event_type>.<api_group>.<kind>
+	apiGroup := "unknown"
+	kind := "unknown"
+	if resource != nil {
+		if resource.APIGroup != "" {
+			apiGroup = resource.APIGroup
+		} else {
+			apiGroup = "core"
+		}
+		if resource.Kind != "" {
+			kind = resource.Kind
+		}
+	}
+	subject := "test.dlq." + string(eventType) + "." + apiGroup + "." + kind
+
+	t.published = append(t.published, mockPublishedMessage{Subject: subject, Data: data})
+
+	if t.publishFunc != nil {
+		return t.publishFunc(subject, data)
+	}
+	return nil
+}
+
+func TestDLQPublish_SubjectConstruction(t *testing.T) {
+	tests := []struct {
+		name            string
+		eventType       EventType
+		resource        *DeadLetterResource
+		wantSubjectPart string
+	}{
+		{
+			name:      "audit with full resource",
+			eventType: EventTypeAudit,
+			resource: &DeadLetterResource{
+				APIGroup: "apps",
+				Kind:     "Deployment",
+			},
+			wantSubjectPart: "test.dlq.audit.apps.Deployment",
+		},
+		{
+			name:      "k8s-event with core resource",
+			eventType: EventTypeK8sEvent,
+			resource: &DeadLetterResource{
+				APIGroup: "", // Core resources have empty apiGroup
+				Kind:     "Pod",
+			},
+			wantSubjectPart: "test.dlq.k8s-event.core.Pod",
+		},
+		{
+			name:            "nil resource uses unknown",
+			eventType:       EventTypeAudit,
+			resource:        nil,
+			wantSubjectPart: "test.dlq.audit.unknown.unknown",
+		},
+		{
+			name:      "resource with empty kind",
+			eventType: EventTypeK8sEvent,
+			resource: &DeadLetterResource{
+				APIGroup: "networking.k8s.io",
+				Kind:     "",
+			},
+			wantSubjectPart: "test.dlq.k8s-event.networking.k8s.io.unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			publisher := &testPublisher{}
+			ctx := context.Background()
+			payload := json.RawMessage(`{"test": true}`)
+			testErr := errors.New("test error")
+
+			err := publisher.publish(ctx, tt.eventType, payload, "policy", 0, ErrorTypeCELMatch, testErr, tt.resource, nil)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(publisher.published) != 1 {
+				t.Fatalf("expected 1 published message, got %d", len(publisher.published))
+			}
+
+			if publisher.published[0].Subject != tt.wantSubjectPart {
+				t.Errorf("subject = %q, want %q", publisher.published[0].Subject, tt.wantSubjectPart)
+			}
+		})
+	}
+}
+
+func TestDLQPublish_PublishFailure(t *testing.T) {
+	publishErr := errors.New("NATS connection failed")
+	publisher := &testPublisher{
+		publishFunc: func(subj string, data []byte) error {
+			return publishErr
+		},
+	}
+
+	ctx := context.Background()
+	payload := json.RawMessage(`{"test": true}`)
+	testErr := errors.New("original error")
+
+	err := publisher.publish(ctx, EventTypeAudit, payload, "policy", 0, ErrorTypeCELMatch, testErr, nil, nil)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "NATS connection failed") {
+		t.Errorf("error message = %q, want to contain %q", err.Error(), "NATS connection failed")
+	}
+}
+
+func TestDLQPublish_NilError(t *testing.T) {
+	publisher := &testPublisher{}
+	ctx := context.Background()
+	payload := json.RawMessage(`{"test": true}`)
+
+	// Test with nil error (should not panic)
+	err := publisher.publish(ctx, EventTypeAudit, payload, "policy", 0, ErrorTypeCELMatch, nil, nil, nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(publisher.published) != 1 {
+		t.Fatalf("expected 1 published message, got %d", len(publisher.published))
+	}
+
+	// Verify the error field is empty in the published message
+	var dlEvent DeadLetterEvent
+	if err := json.Unmarshal(publisher.published[0].Data, &dlEvent); err != nil {
+		t.Fatalf("failed to unmarshal published data: %v", err)
+	}
+
+	if dlEvent.Error != "" {
+		t.Errorf("Error field = %q, want empty string", dlEvent.Error)
+	}
+}
+
+func TestDLQPublish_PayloadPreserved(t *testing.T) {
+	publisher := &testPublisher{}
+	ctx := context.Background()
+	originalPayload := json.RawMessage(`{"verb": "create", "objectRef": {"name": "test-pod"}}`)
+	testErr := errors.New("evaluation failed")
+	resource := &DeadLetterResource{
+		APIGroup:  "apps",
+		Kind:      "Deployment",
+		Name:      "my-deployment",
+		Namespace: "default",
+	}
+	tenant := &DeadLetterTenant{
+		Type: "project",
+		Name: "my-project",
+	}
+
+	err := publisher.publish(ctx, EventTypeAudit, originalPayload, "test-policy", 2, ErrorTypeCELSummary, testErr, resource, tenant)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(publisher.published) != 1 {
+		t.Fatalf("expected 1 published message, got %d", len(publisher.published))
+	}
+
+	var dlEvent DeadLetterEvent
+	if err := json.Unmarshal(publisher.published[0].Data, &dlEvent); err != nil {
+		t.Fatalf("failed to unmarshal published data: %v", err)
+	}
+
+	// Verify all fields are preserved correctly
+	if dlEvent.Type != EventTypeAudit {
+		t.Errorf("Type = %q, want %q", dlEvent.Type, EventTypeAudit)
+	}
+	// Compare JSON payloads by unmarshaling to handle whitespace differences
+	var originalParsed, preservedParsed map[string]interface{}
+	json.Unmarshal(originalPayload, &originalParsed)
+	json.Unmarshal(dlEvent.OriginalPayload, &preservedParsed)
+	if originalParsed["verb"] != preservedParsed["verb"] {
+		t.Errorf("OriginalPayload verb mismatch: got %v, want %v", preservedParsed["verb"], originalParsed["verb"])
+	}
+	if dlEvent.Error != "evaluation failed" {
+		t.Errorf("Error = %q, want %q", dlEvent.Error, "evaluation failed")
+	}
+	if dlEvent.ErrorType != ErrorTypeCELSummary {
+		t.Errorf("ErrorType = %q, want %q", dlEvent.ErrorType, ErrorTypeCELSummary)
+	}
+	if dlEvent.PolicyName != "test-policy" {
+		t.Errorf("PolicyName = %q, want %q", dlEvent.PolicyName, "test-policy")
+	}
+	if dlEvent.RuleIndex != 2 {
+		t.Errorf("RuleIndex = %d, want %d", dlEvent.RuleIndex, 2)
+	}
+	if dlEvent.Resource == nil {
+		t.Fatal("Resource should not be nil")
+	}
+	if dlEvent.Resource.Kind != "Deployment" {
+		t.Errorf("Resource.Kind = %q, want %q", dlEvent.Resource.Kind, "Deployment")
+	}
+	if dlEvent.Tenant == nil {
+		t.Fatal("Tenant should not be nil")
+	}
+	if dlEvent.Tenant.Name != "my-project" {
+		t.Errorf("Tenant.Name = %q, want %q", dlEvent.Tenant.Name, "my-project")
+	}
+}
+
+func TestSentinelErrors(t *testing.T) {
+	// Test that sentinel errors work correctly with errors.Is
+	t.Run("ErrKindResolution", func(t *testing.T) {
+		wrapped := errors.New("discovery cache miss")
+		err := errors.Join(ErrKindResolution, wrapped)
+
+		if !errors.Is(err, ErrKindResolution) {
+			t.Error("errors.Is should return true for wrapped ErrKindResolution")
+		}
+	})
+
+	t.Run("ErrActivityBuild", func(t *testing.T) {
+		wrapped := errors.New("link conversion failed")
+		err := errors.Join(ErrActivityBuild, wrapped)
+
+		if !errors.Is(err, ErrActivityBuild) {
+			t.Error("errors.Is should return true for wrapped ErrActivityBuild")
+		}
+	})
+
+	t.Run("ErrKindResolution is distinct from ErrActivityBuild", func(t *testing.T) {
+		if errors.Is(ErrKindResolution, ErrActivityBuild) {
+			t.Error("ErrKindResolution should not match ErrActivityBuild")
+		}
+		if errors.Is(ErrActivityBuild, ErrKindResolution) {
+			t.Error("ErrActivityBuild should not match ErrKindResolution")
+		}
+	})
+}

--- a/internal/processor/utils_test.go
+++ b/internal/processor/utils_test.go
@@ -1,0 +1,391 @@
+package processor
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"go.miloapis.com/activity/internal/cel"
+	authnv1 "k8s.io/api/authentication/v1"
+)
+
+func TestConvertLinks(t *testing.T) {
+	// Mock KindResolver for testing resource-to-kind conversion
+	mockResolver := func(apiGroup, resource string) (string, error) {
+		kinds := map[string]string{
+			"deployments": "Deployment",
+			"services":    "Service",
+			"pods":        "Pod",
+		}
+		if kind, ok := kinds[resource]; ok {
+			return kind, nil
+		}
+		return "", nil
+	}
+	tests := []struct {
+		name     string
+		celLinks []cel.Link
+		want     int
+		wantKind string
+	}{
+		{
+			name:     "nil links",
+			celLinks: nil,
+			want:     0,
+		},
+		{
+			name:     "empty links",
+			celLinks: []cel.Link{},
+			want:     0,
+		},
+		{
+			name: "link with kind field (Kubernetes events)",
+			celLinks: []cel.Link{
+				{
+					Marker: "Pod my-pod",
+					Resource: map[string]any{
+						"kind":      "Pod",
+						"name":      "my-pod",
+						"namespace": "default",
+						"uid":       "pod-123",
+						"apiGroup":  "",
+					},
+				},
+			},
+			want:     1,
+			wantKind: "Pod",
+		},
+		{
+			name: "link with resource field (Kubernetes audit objectRef)",
+			celLinks: []cel.Link{
+				{
+					Marker: "Deployment my-deployment",
+					Resource: map[string]any{
+						"resource":  "deployments",
+						"name":      "my-deployment",
+						"namespace": "default",
+						"uid":       "deploy-456",
+						"apiGroup":  "apps",
+					},
+				},
+			},
+			want:     1,
+			wantKind: "Deployment",
+		},
+		{
+			name: "link with both kind and resource (kind wins)",
+			celLinks: []cel.Link{
+				{
+					Marker: "Service my-service",
+					Resource: map[string]any{
+						"kind":      "Service",
+						"resource":  "services",
+						"name":      "my-service",
+						"namespace": "default",
+					},
+				},
+			},
+			want:     1,
+			wantKind: "Service",
+		},
+		{
+			name: "link with type field (actorRef)",
+			celLinks: []cel.Link{
+				{
+					Marker: "kubernetes-admin",
+					Resource: map[string]any{
+						"type": "user",
+						"name": "kubernetes-admin",
+					},
+				},
+			},
+			want:     1,
+			wantKind: "user",
+		},
+		{
+			name: "multiple links with mixed formats",
+			celLinks: []cel.Link{
+				{
+					Marker: "Pod my-pod",
+					Resource: map[string]any{
+						"kind": "Pod",
+						"name": "my-pod",
+					},
+				},
+				{
+					Marker: "Deployment my-deployment",
+					Resource: map[string]any{
+						"resource": "deployments",
+						"name":     "my-deployment",
+					},
+				},
+				{
+					Marker: "kubernetes-admin",
+					Resource: map[string]any{
+						"type": "user",
+						"name": "kubernetes-admin",
+					},
+				},
+			},
+			want:     3,
+			wantKind: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertLinks(tt.celLinks, mockResolver)
+			if err != nil {
+				t.Fatalf("ConvertLinks() returned error: %v", err)
+			}
+
+			if len(got) != tt.want {
+				t.Errorf("ConvertLinks() returned %d links, want %d", len(got), tt.want)
+				return
+			}
+
+			if tt.want > 0 && tt.wantKind != "" {
+				if got[0].Resource.Kind != tt.wantKind {
+					t.Errorf("ConvertLinks() first link Kind = %q, want %q", got[0].Resource.Kind, tt.wantKind)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertLinksErrorPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		celLinks  []cel.Link
+		resolver  KindResolver
+		wantErr   bool
+		wantErrIs error
+	}{
+		{
+			name: "resolver returns error",
+			celLinks: []cel.Link{
+				{
+					Marker: "unknown resource",
+					Resource: map[string]any{
+						"resource": "unknowns",
+						"apiGroup": "test.example.com",
+						"name":     "test-resource",
+					},
+				},
+			},
+			resolver: func(apiGroup, resource string) (string, error) {
+				return "", fmt.Errorf("unknown resource: %s", resource)
+			},
+			wantErr:   true,
+			wantErrIs: ErrKindResolution,
+		},
+		{
+			name: "resolver returns error for second link",
+			celLinks: []cel.Link{
+				{
+					Marker: "known resource",
+					Resource: map[string]any{
+						"kind": "Pod", // This has kind, so no resolution needed
+						"name": "my-pod",
+					},
+				},
+				{
+					Marker: "unknown resource",
+					Resource: map[string]any{
+						"resource": "unknowns",
+						"apiGroup": "test.example.com",
+						"name":     "test-resource",
+					},
+				},
+			},
+			resolver: func(apiGroup, resource string) (string, error) {
+				return "", fmt.Errorf("discovery failed: %s", resource)
+			},
+			wantErr:   true,
+			wantErrIs: ErrKindResolution,
+		},
+		{
+			name: "nil resolver with resource field returns no error",
+			celLinks: []cel.Link{
+				{
+					Marker: "no resolver",
+					Resource: map[string]any{
+						"resource": "deployments",
+						"apiGroup": "apps",
+						"name":     "my-deployment",
+					},
+				},
+			},
+			resolver: nil, // No resolver provided
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertLinks(tt.celLinks, tt.resolver)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ConvertLinks() expected error, got nil")
+					return
+				}
+				if tt.wantErrIs != nil && !errors.Is(err, tt.wantErrIs) {
+					t.Errorf("ConvertLinks() error = %v, want error wrapping %v", err, tt.wantErrIs)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("ConvertLinks() unexpected error: %v", err)
+				return
+			}
+
+			if len(got) != len(tt.celLinks) {
+				t.Errorf("ConvertLinks() returned %d links, want %d", len(got), len(tt.celLinks))
+			}
+		})
+	}
+}
+
+func TestExtractTenant(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     authnv1.UserInfo
+		wantType string
+		wantName string
+	}{
+		{
+			name:     "platform (no extra fields)",
+			user:     authnv1.UserInfo{},
+			wantType: "platform",
+			wantName: "",
+		},
+		{
+			name: "organization from parent fields",
+			user: authnv1.UserInfo{
+				Extra: map[string]authnv1.ExtraValue{
+					"iam.miloapis.com/parent-type": {"organization"},
+					"iam.miloapis.com/parent-name": {"acme-corp"},
+				},
+			},
+			wantType: "organization",
+			wantName: "acme-corp",
+		},
+		{
+			name: "project from parent fields",
+			user: authnv1.UserInfo{
+				Extra: map[string]authnv1.ExtraValue{
+					"iam.miloapis.com/parent-type": {"project"},
+					"iam.miloapis.com/parent-name": {"my-project"},
+				},
+			},
+			wantType: "project",
+			wantName: "my-project",
+		},
+		{
+			name: "organization from legacy field",
+			user: authnv1.UserInfo{
+				Extra: map[string]authnv1.ExtraValue{
+					"organization": {"legacy-org"},
+				},
+			},
+			wantType: "organization",
+			wantName: "legacy-org",
+		},
+		{
+			name: "project overrides organization",
+			user: authnv1.UserInfo{
+				Extra: map[string]authnv1.ExtraValue{
+					"organization": {"my-org"},
+					"project":      {"my-project"},
+				},
+			},
+			wantType: "project",
+			wantName: "my-project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractTenant(tt.user)
+			if got.Type != tt.wantType {
+				t.Errorf("ExtractTenant() Type = %q, want %q", got.Type, tt.wantType)
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("ExtractTenant() Name = %q, want %q", got.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestGetNestedString(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]any
+		keys []string
+		want string
+	}{
+		{
+			name: "single level",
+			m:    map[string]any{"key": "value"},
+			keys: []string{"key"},
+			want: "value",
+		},
+		{
+			name: "nested levels",
+			m: map[string]any{
+				"user": map[string]any{
+					"username": "alice",
+				},
+			},
+			keys: []string{"user", "username"},
+			want: "alice",
+		},
+		{
+			name: "deeply nested",
+			m: map[string]any{
+				"audit": map[string]any{
+					"objectRef": map[string]any{
+						"name": "my-resource",
+					},
+				},
+			},
+			keys: []string{"audit", "objectRef", "name"},
+			want: "my-resource",
+		},
+		{
+			name: "missing key",
+			m:    map[string]any{"key": "value"},
+			keys: []string{"missing"},
+			want: "",
+		},
+		{
+			name: "nil map",
+			m:    nil,
+			keys: []string{"key"},
+			want: "",
+		},
+		{
+			name: "empty keys",
+			m:    map[string]any{"key": "value"},
+			keys: []string{},
+			want: "",
+		},
+		{
+			name: "non-string value",
+			m:    map[string]any{"key": 123},
+			keys: []string{"key"},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetNestedString(tt.m, tt.keys...)
+			if got != tt.want {
+				t.Errorf("GetNestedString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/registry/activity/policy/storage.go
+++ b/internal/registry/activity/policy/storage.go
@@ -11,6 +11,7 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	"go.miloapis.com/activity/pkg/apis/activity"
 	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
 )
 
@@ -26,7 +27,7 @@ type ActivityPolicyStatusStorage struct {
 
 // New creates a new ActivityPolicy object.
 func (s *ActivityPolicyStatusStorage) New() runtime.Object {
-	return &v1alpha1.ActivityPolicy{}
+	return &activity.ActivityPolicy{}
 }
 
 // Destroy cleans up resources on shutdown.
@@ -65,9 +66,9 @@ func (c *policyTableConvertor) ConvertToTable(ctx context.Context, object runtim
 	}
 
 	switch t := object.(type) {
-	case *v1alpha1.ActivityPolicy:
+	case *activity.ActivityPolicy:
 		table.Rows = append(table.Rows, policyToTableRow(t))
-	case *v1alpha1.ActivityPolicyList:
+	case *activity.ActivityPolicyList:
 		for i := range t.Items {
 			table.Rows = append(table.Rows, policyToTableRow(&t.Items[i]))
 		}
@@ -77,7 +78,7 @@ func (c *policyTableConvertor) ConvertToTable(ctx context.Context, object runtim
 }
 
 // policyToTableRow converts an ActivityPolicy to a table row.
-func policyToTableRow(policy *v1alpha1.ActivityPolicy) metav1.TableRow {
+func policyToTableRow(policy *activity.ActivityPolicy) metav1.TableRow {
 	// Format API group - show "(core)" for empty string
 	apiGroup := policy.Spec.Resource.APIGroup
 	if apiGroup == "" {
@@ -117,8 +118,8 @@ func NewStorage(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*
 	statusStrategy := NewStatusStrategy(scheme)
 
 	store := &genericregistry.Store{
-		NewFunc:                   func() runtime.Object { return &v1alpha1.ActivityPolicy{} },
-		NewListFunc:               func() runtime.Object { return &v1alpha1.ActivityPolicyList{} },
+		NewFunc:                   func() runtime.Object { return &activity.ActivityPolicy{} },
+		NewListFunc:               func() runtime.Object { return &activity.ActivityPolicyList{} },
 		DefaultQualifiedResource:  v1alpha1.Resource("activitypolicies"),
 		SingularQualifiedResource: v1alpha1.Resource("activitypolicy"),
 

--- a/internal/registry/activity/policy/strategy.go
+++ b/internal/registry/activity/policy/strategy.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 
 	"go.miloapis.com/activity/internal/cel"
-	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
+	"go.miloapis.com/activity/pkg/apis/activity"
 )
 
 // activityPolicyStrategy implements behavior for ActivityPolicy resources.
@@ -52,28 +52,28 @@ func (s activityPolicyStrategy) NamespaceScoped() bool {
 
 // PrepareForCreate clears status and sets defaults before creation.
 func (s activityPolicyStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
-	policy := obj.(*v1alpha1.ActivityPolicy)
+	policy := obj.(*activity.ActivityPolicy)
 	// Clear status on creation - it will be set by the controller
-	policy.Status = v1alpha1.ActivityPolicyStatus{}
+	policy.Status = activity.ActivityPolicyStatus{}
 }
 
 // PrepareForUpdate preserves status when spec is updated.
 func (s activityPolicyStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
-	newPolicy := obj.(*v1alpha1.ActivityPolicy)
-	oldPolicy := old.(*v1alpha1.ActivityPolicy)
+	newPolicy := obj.(*activity.ActivityPolicy)
+	oldPolicy := old.(*activity.ActivityPolicy)
 	// Preserve status - only the status subresource can update it
 	newPolicy.Status = oldPolicy.Status
 }
 
 // Validate validates a new ActivityPolicy.
 func (s activityPolicyStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
-	policy := obj.(*v1alpha1.ActivityPolicy)
+	policy := obj.(*activity.ActivityPolicy)
 	return ValidateActivityPolicy(policy)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
 func (s activityPolicyStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
-	policy := obj.(*v1alpha1.ActivityPolicy)
+	policy := obj.(*activity.ActivityPolicy)
 	return warningsForPolicy(policy)
 }
 
@@ -94,8 +94,8 @@ func (s activityPolicyStrategy) Canonicalize(obj runtime.Object) {
 
 // ValidateUpdate validates an update to an ActivityPolicy.
 func (s activityPolicyStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	policy := obj.(*v1alpha1.ActivityPolicy)
-	oldPolicy := old.(*v1alpha1.ActivityPolicy)
+	policy := obj.(*activity.ActivityPolicy)
+	oldPolicy := old.(*activity.ActivityPolicy)
 
 	allErrs := ValidateActivityPolicy(policy)
 
@@ -114,18 +114,18 @@ func (s activityPolicyStrategy) ValidateUpdate(ctx context.Context, obj, old run
 
 // WarningsOnUpdate returns warnings for the update of the given object.
 func (s activityPolicyStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
-	policy := obj.(*v1alpha1.ActivityPolicy)
+	policy := obj.(*activity.ActivityPolicy)
 	return warningsForPolicy(policy)
 }
 
 // ValidateActivityPolicy validates an ActivityPolicy and returns field errors.
-func ValidateActivityPolicy(policy *v1alpha1.ActivityPolicy) field.ErrorList {
+func ValidateActivityPolicy(policy *activity.ActivityPolicy) field.ErrorList {
 	return ValidateActivityPolicySpec(&policy.Spec, field.NewPath("spec"))
 }
 
 // ValidateActivityPolicySpec validates an ActivityPolicySpec and returns field errors.
 // The specPath parameter allows customizing the field path for error messages.
-func ValidateActivityPolicySpec(spec *v1alpha1.ActivityPolicySpec, specPath *field.Path) field.ErrorList {
+func ValidateActivityPolicySpec(spec *activity.ActivityPolicySpec, specPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Validate required resource fields
@@ -155,7 +155,7 @@ func ValidateActivityPolicySpec(spec *v1alpha1.ActivityPolicySpec, specPath *fie
 }
 
 // warningsForPolicy returns warnings for an ActivityPolicy.
-func warningsForPolicy(policy *v1alpha1.ActivityPolicy) []string {
+func warningsForPolicy(policy *activity.ActivityPolicy) []string {
 	var warnings []string
 	if len(policy.Spec.AuditRules) == 0 && len(policy.Spec.EventRules) == 0 {
 		warnings = append(warnings, "policy has no rules defined and will have no effect")
@@ -164,7 +164,7 @@ func warningsForPolicy(policy *v1alpha1.ActivityPolicy) []string {
 }
 
 // validatePolicyRule validates a single ActivityPolicyRule.
-func validatePolicyRule(rule v1alpha1.ActivityPolicyRule, path *field.Path, ruleType cel.PolicyRuleType) field.ErrorList {
+func validatePolicyRule(rule activity.ActivityPolicyRule, path *field.Path, ruleType cel.PolicyRuleType) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Validate match expression
@@ -192,7 +192,7 @@ func validatePolicyRule(rule v1alpha1.ActivityPolicyRule, path *field.Path, rule
 
 // GetAttrs returns labels and fields of a given ActivityPolicy for filtering.
 func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
-	policy, ok := obj.(*v1alpha1.ActivityPolicy)
+	policy, ok := obj.(*activity.ActivityPolicy)
 	if !ok {
 		return nil, nil, fmt.Errorf("given object is not an ActivityPolicy")
 	}
@@ -200,7 +200,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // SelectableFields returns the fields that can be used in field selectors.
-func SelectableFields(policy *v1alpha1.ActivityPolicy) fields.Set {
+func SelectableFields(policy *activity.ActivityPolicy) fields.Set {
 	return generic.ObjectMetaFieldsSet(&policy.ObjectMeta, false)
 }
 
@@ -223,8 +223,8 @@ func (s activityPolicyStatusStrategy) NamespaceScoped() bool {
 // PrepareForUpdate clears fields that are not allowed to be set by end users on status update.
 // Only status changes are allowed; spec changes are reverted.
 func (s activityPolicyStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
-	newPolicy := obj.(*v1alpha1.ActivityPolicy)
-	oldPolicy := old.(*v1alpha1.ActivityPolicy)
+	newPolicy := obj.(*activity.ActivityPolicy)
+	oldPolicy := old.(*activity.ActivityPolicy)
 	// Preserve spec, only allow status changes
 	newPolicy.Spec = oldPolicy.Spec
 	newPolicy.ObjectMeta.Labels = oldPolicy.ObjectMeta.Labels

--- a/internal/registry/activity/policy/strategy_test.go
+++ b/internal/registry/activity/policy/strategy_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
 
+	"go.miloapis.com/activity/pkg/apis/activity"
 	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
 )
 
@@ -238,7 +240,13 @@ func TestValidateActivityPolicy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := ValidateActivityPolicy(tt.policy)
+			// Convert v1alpha1 to internal type
+			internalPolicy := &activity.ActivityPolicy{}
+			if err := v1alpha1.Convert_v1alpha1_ActivityPolicy_To_activity_ActivityPolicy(tt.policy, internalPolicy, conversion.Scope(nil)); err != nil {
+				t.Fatalf("failed to convert policy: %v", err)
+			}
+
+			errs := ValidateActivityPolicy(internalPolicy)
 
 			if len(errs) != tt.wantErrs {
 				t.Errorf("expected %d errors, got %d: %v", tt.wantErrs, len(errs), errs)

--- a/internal/registry/activity/preview/storage_test.go
+++ b/internal/registry/activity/preview/storage_test.go
@@ -93,8 +93,12 @@ func TestPolicyPreviewStorage_Create_SingleAuditMatch(t *testing.T) {
 		t.Errorf("Expected Summary=%q, got %q", expectedSummary, activity.Spec.Summary)
 	}
 
-	if activity.Spec.Actor.Name != "user-alice-123" {
-		t.Errorf("Expected Actor.Name='user-alice-123', got %q", activity.Spec.Actor.Name)
+	if activity.Spec.Actor.Name != "alice@example.com" {
+		t.Errorf("Expected Actor.Name='alice@example.com', got %q", activity.Spec.Actor.Name)
+	}
+
+	if activity.Spec.Actor.UID != "user-alice-123" {
+		t.Errorf("Expected Actor.UID='user-alice-123', got %q", activity.Spec.Actor.UID)
 	}
 
 	if activity.Spec.ChangeSource != "human" {


### PR DESCRIPTION
## Summary

Enables automatic Activity generation from Kubernetes Events. When something happens in your cluster (pod crashes, deployments roll out, config changes), the processor translates these events into human-readable Activity summaries.

## What's New

### Event Processing Pipeline

Events flow through this pipeline:
```
K8s Events → Event Exporter → NATS → Activity Processor → Activities
```

The processor evaluates events against ActivityPolicy `eventRules` using CEL expressions to generate summaries like:
- "Pod api-server-xyz crashed with OOMKilled"
- "Deployment frontend rolled out successfully"
- "ConfigMap updated by alice@example.com"

### Dead Letter Queue

Failed events don't get lost—they go to a DLQ for later retry:
- Configurable retry policies
- Metrics for monitoring DLQ depth
- Manual inspection via NATS tooling

### K8s Event Exporter

New component that watches cluster events and publishes to NATS:
- Supports both core/v1 and events.k8s.io/v1 formats
- Exports metrics for monitoring event flow
- Deploys as a separate pod in activity-system

### Bug Fix

- Fixed ClickHouse table name in Vector config (`audit_logs` not `events`)

## Why This Matters

- **Unified Timeline**: Events and audit logs together in one Activity feed
- **Reliable Processing**: DLQ ensures no events are silently dropped
- **Customizable**: Write CEL rules to translate events your way
- **Observable**: Metrics for processing lag, errors, and throughput

## Test Plan
- [ ] Deploy to dev cluster
- [ ] Verify k8s-event-exporter pod is running
- [ ] Create a pod and verify event appears in Activity feed
- [ ] Verify DLQ metrics are exposed
- [ ] Test failure scenario and verify event lands in DLQ

## Dependencies

- Requires #66 (Events API) - ✅ Merged
- Requires #67 (Observability) - ✅ Merged

## Related

- Enhancement: https://github.com/datum-cloud/enhancements/issues/469

---
*Extracted from #61. This completes the event processing backend.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)