### PR TITLE
refactor(api): replace involvedObject with regarding field selectors

### DIFF
--- a/config/components/observability/alerts/generated/activity-recordings.yaml
+++ b/config/components/observability/alerts/generated/activity-recordings.yaml
@@ -1,116 +1,116 @@
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  labels:
-    app.kubernetes.io/part-of: activity
-    monitoring: "true"
-    prometheus: activity
-  name: activity-recordings
-  namespace: activity-system
-spec:
-  groups:
-    - interval: 30s
-      name: activity-recordings
-      rules:
-        - expr: |
-            sum(rate(apiserver_request_total{job="activity-apiserver"}[5m]))
-            by (verb, resource, code)
-          record: activity:request_rate:5m
-        - expr: |
-            sum(rate(apiserver_request_total{job="activity-apiserver"}[5m]))
-          record: activity:request_rate_total:5m
-        - expr: |
-            sum(rate(apiserver_request_total{job="activity-apiserver",code=~"5.."}[5m]))
-            /
-            sum(rate(apiserver_request_total{job="activity-apiserver"}[5m]))
-          record: activity:error_rate:5m
-        - expr: |
-            histogram_quantile(0.50,
-              sum(rate(apiserver_request_duration_seconds_bucket{job="activity-apiserver"}[5m]))
-              by (le)
-            )
-          record: activity:apiserver_request_duration:p50
-        - expr: |
-            histogram_quantile(0.95,
-              sum(rate(apiserver_request_duration_seconds_bucket{job="activity-apiserver"}[5m]))
-              by (le)
-            )
-          record: activity:apiserver_request_duration:p95
-        - expr: |
-            histogram_quantile(0.99,
-              sum(rate(apiserver_request_duration_seconds_bucket{job="activity-apiserver"}[5m]))
-              by (le)
-            )
-          record: activity:apiserver_request_duration:p99
-        - expr: |
-            histogram_quantile(0.50,
-              sum(rate(activity_clickhouse_query_duration_seconds_bucket{operation="total"}[5m]))
-              by (le)
-            )
-          record: activity:query_duration:p50
-        - expr: |
-            histogram_quantile(0.95,
-              sum(rate(activity_clickhouse_query_duration_seconds_bucket{operation="total"}[5m]))
-              by (le)
-            )
-          record: activity:query_duration:p95
-        - expr: |
-            histogram_quantile(0.99,
-              sum(rate(activity_clickhouse_query_duration_seconds_bucket{operation="total"}[5m]))
-              by (le)
-            )
-          record: activity:query_duration:p99
-        - expr: |
-            sum(rate(activity_clickhouse_query_total[5m]))
-            by (status)
-          record: activity:query_rate:5m
-        - expr: |
-            sum(rate(activity_clickhouse_query_errors_total[5m]))
-            by (error_type)
-          record: activity:clickhouse_error_rate:5m
-        - expr: |
-            sum(rate(vector_component_received_events_total{component_id="nats_audit_consumer",namespace="activity-system"}[5m]))
-          record: activity:vector_throughput:5m
-        - expr: |
-            sum(rate(vector_component_sent_events_total{component_id="clickhouse_audit_events",namespace="activity-system"}[5m]))
-          record: activity:vector_writes:5m
-        - expr: |
-            sum(rate(vector_component_received_events_total{component_id="nats_audit_consumer",namespace="activity-system"}[5m]))
-            -
-            sum(rate(vector_component_sent_events_total{component_id="clickhouse_audit_events",namespace="activity-system"}[5m]))
-          record: activity:pipeline_lag:5m
-        - expr: |
-            nats_consumer_num_pending{stream_name="AUDIT_EVENTS",consumer_name="clickhouse-ingest"}
-          record: activity:nats_consumer_lag
-        - expr: |
-            rate(nats_stream_total_messages{stream_name="AUDIT_EVENTS"}[5m])
-          record: activity:nats_message_rate:5m
-        - expr: |
-            sum(rate(container_cpu_usage_seconds_total{namespace="activity-system"}[5m]))
-            by (pod)
-            /
-            sum(container_spec_cpu_quota{namespace="activity-system"} / container_spec_cpu_period{namespace="activity-system"})
-            by (pod)
-          record: activity:cpu_utilization
-        - expr: |
-            sum(container_memory_working_set_bytes{namespace="activity-system"})
-            by (pod)
-            /
-            sum(container_spec_memory_limit_bytes{namespace="activity-system"})
-            by (pod)
-          record: activity:memory_utilization
-        - expr: |
-            sum(rate(vector_component_sent_events_total{component_id="clickhouse_k8s_events",namespace="activity-system"}[5m]))
-          record: activity:vector_writes_events:5m
-        - expr: |
-            avg(rate(chi_clickhouse_table_parts_rows{chi="activity-clickhouse", database="audit", table="k8s_events", active="1"}[5m]))
-          record: activity:clickhouse_events_insert_rate:5m
-        - expr: |
-            sum(rate(chi_clickhouse_event_InsertQueryTimeMicroseconds{chi="activity-clickhouse"}[5m]))
-            /
-            clamp_min(sum(rate(chi_clickhouse_event_InsertQuery{chi="activity-clickhouse"}[5m])), 0.001)
-            / 1000000
-          record: activity:clickhouse_events_insert_latency
-        - expr: |
-            sum(rate(event_exporter_events_published_total[5m]))
-          record: activity:event_exporter_throughput:5m
+"apiVersion": "monitoring.coreos.com/v1"
+"kind": "PrometheusRule"
+"metadata":
+  "labels":
+    "app.kubernetes.io/part-of": "activity"
+    "monitoring": "true"
+    "prometheus": "activity"
+  "name": "activity-recordings"
+  "namespace": "activity-system"
+"spec":
+  "groups":
+  - "interval": "30s"
+    "name": "activity-recordings"
+    "rules":
+    - "expr": |
+        sum(rate(apiserver_request_total{job="activity-apiserver"}[5m]))
+        by (verb, resource, code)
+      "record": "activity:request_rate:5m"
+    - "expr": |
+        sum(rate(apiserver_request_total{job="activity-apiserver"}[5m]))
+      "record": "activity:request_rate_total:5m"
+    - "expr": |
+        sum(rate(apiserver_request_total{job="activity-apiserver",code=~"5.."}[5m]))
+        /
+        sum(rate(apiserver_request_total{job="activity-apiserver"}[5m]))
+      "record": "activity:error_rate:5m"
+    - "expr": |
+        histogram_quantile(0.50,
+          sum(rate(apiserver_request_duration_seconds_bucket{job="activity-apiserver"}[5m]))
+          by (le)
+        )
+      "record": "activity:apiserver_request_duration:p50"
+    - "expr": |
+        histogram_quantile(0.95,
+          sum(rate(apiserver_request_duration_seconds_bucket{job="activity-apiserver"}[5m]))
+          by (le)
+        )
+      "record": "activity:apiserver_request_duration:p95"
+    - "expr": |
+        histogram_quantile(0.99,
+          sum(rate(apiserver_request_duration_seconds_bucket{job="activity-apiserver"}[5m]))
+          by (le)
+        )
+      "record": "activity:apiserver_request_duration:p99"
+    - "expr": |
+        histogram_quantile(0.50,
+          sum(rate(activity_clickhouse_query_duration_seconds_bucket{operation="total"}[5m]))
+          by (le)
+        )
+      "record": "activity:query_duration:p50"
+    - "expr": |
+        histogram_quantile(0.95,
+          sum(rate(activity_clickhouse_query_duration_seconds_bucket{operation="total"}[5m]))
+          by (le)
+        )
+      "record": "activity:query_duration:p95"
+    - "expr": |
+        histogram_quantile(0.99,
+          sum(rate(activity_clickhouse_query_duration_seconds_bucket{operation="total"}[5m]))
+          by (le)
+        )
+      "record": "activity:query_duration:p99"
+    - "expr": |
+        sum(rate(activity_clickhouse_query_total[5m]))
+        by (status)
+      "record": "activity:query_rate:5m"
+    - "expr": |
+        sum(rate(activity_clickhouse_query_errors_total[5m]))
+        by (error_type)
+      "record": "activity:clickhouse_error_rate:5m"
+    - "expr": |
+        sum(rate(vector_component_received_events_total{component_id="nats_audit_consumer",namespace="activity-system"}[5m]))
+      "record": "activity:vector_throughput:5m"
+    - "expr": |
+        sum(rate(vector_component_sent_events_total{component_id="clickhouse_audit_events",namespace="activity-system"}[5m]))
+      "record": "activity:vector_writes:5m"
+    - "expr": |
+        sum(rate(vector_component_received_events_total{component_id="nats_audit_consumer",namespace="activity-system"}[5m]))
+        -
+        sum(rate(vector_component_sent_events_total{component_id="clickhouse_audit_events",namespace="activity-system"}[5m]))
+      "record": "activity:pipeline_lag:5m"
+    - "expr": |
+        nats_consumer_num_pending{stream_name="AUDIT_EVENTS",consumer_name="clickhouse-ingest"}
+      "record": "activity:nats_consumer_lag"
+    - "expr": |
+        rate(nats_stream_total_messages{stream_name="AUDIT_EVENTS"}[5m])
+      "record": "activity:nats_message_rate:5m"
+    - "expr": |
+        sum(rate(container_cpu_usage_seconds_total{namespace="activity-system"}[5m]))
+        by (pod)
+        /
+        sum(container_spec_cpu_quota{namespace="activity-system"} / container_spec_cpu_period{namespace="activity-system"})
+        by (pod)
+      "record": "activity:cpu_utilization"
+    - "expr": |
+        sum(container_memory_working_set_bytes{namespace="activity-system"})
+        by (pod)
+        /
+        sum(container_spec_memory_limit_bytes{namespace="activity-system"})
+        by (pod)
+      "record": "activity:memory_utilization"
+    - "expr": |
+        sum(rate(vector_component_sent_events_total{component_id="clickhouse_k8s_events",namespace="activity-system"}[5m]))
+      "record": "activity:vector_writes_events:5m"
+    - "expr": |
+        avg(rate(chi_clickhouse_table_parts_rows{chi="activity-clickhouse", database="audit", table="k8s_events", active="1"}[5m]))
+      "record": "activity:clickhouse_events_insert_rate:5m"
+    - "expr": |
+        sum(rate(chi_clickhouse_event_InsertQueryTimeMicroseconds{chi="activity-clickhouse"}[5m]))
+        /
+        clamp_min(sum(rate(chi_clickhouse_event_InsertQuery{chi="activity-clickhouse"}[5m])), 0.001)
+        / 1000000
+      "record": "activity:clickhouse_events_insert_latency"
+    - "expr": |
+        sum(rate(event_exporter_events_published_total[5m]))
+      "record": "activity:event_exporter_throughput:5m"

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,7 @@ Package v1alpha1 contains API Schema definitions for the activity v1alpha1 API g
 
 
 
+
 #### Activity
 
 
@@ -513,7 +514,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `timeRange` _[FacetTimeRange](#facettimerange)_ | TimeRange limits the time window for facet aggregation.<br />If not specified, defaults to the last 7 days. |  |  |
-| `facets` _[FacetSpec](#facetspec) array_ | Facets specifies which fields to get distinct values for.<br />Each facet returns the top N values with counts.<br /><br />Supported fields:<br />  - involvedObject.kind: Resource kinds (Pod, Deployment, etc.)<br />  - involvedObject.namespace: Namespaces of involved objects<br />  - reason: Event reasons (Scheduled, Pulled, Created, etc.)<br />  - type: Event types (Normal, Warning)<br />  - source.component: Source components (kubelet, scheduler, etc.)<br />  - namespace: Event namespace |  |  |
+| `facets` _[FacetSpec](#facetspec) array_ | Facets specifies which fields to get distinct values for.<br />Each facet returns the top N values with counts.<br /><br />Supported fields:<br />  - regarding.kind: Resource kinds (Pod, Deployment, etc.)<br />  - regarding.namespace: Namespaces of regarding objects<br />  - reason: Event reasons (Scheduled, Pulled, Created, etc.)<br />  - type: Event types (Normal, Warning)<br />  - source.component: Source components (kubelet, scheduler, etc.)<br />  - namespace: Event namespace |  |  |
 
 
 #### EventFacetQueryStatus
@@ -598,7 +599,7 @@ _Appears in:_
 | `startTime` _string_ | StartTime is the beginning of your search window (inclusive).<br /><br />Format Options:<br />- Relative: "now-30d", "now-2h", "now-30m" (units: s, m, h, d, w)<br />  Use for dashboards and recurring queries - they adjust automatically.<br />- Absolute: "2024-01-01T00:00:00Z" (RFC3339 with timezone)<br />  Use for historical analysis of specific time periods.<br /><br />Maximum lookback is 60 days from now.<br /><br />Examples:<br />  "now-7d"                      → 7 days ago<br />  "2024-06-15T14:30:00-05:00"   → specific time with timezone offset |  |  |
 | `endTime` _string_ | EndTime is the end of your search window (exclusive).<br /><br />Uses the same formats as StartTime. Commonly "now" for the current moment.<br />Must be greater than StartTime.<br /><br />Examples:<br />  "now"                  → current time<br />  "2024-01-02T00:00:00Z" → specific end point |  |  |
 | `namespace` _string_ | Namespace limits results to events from a specific namespace.<br />Leave empty to query events across all namespaces. |  |  |
-| `fieldSelector` _string_ | FieldSelector filters events using standard Kubernetes field selector syntax.<br /><br />Supported Fields:<br />  metadata.name               - event name<br />  metadata.namespace          - event namespace<br />  metadata.uid                - event UID<br />  involvedObject.apiVersion   - involved resource API version<br />  involvedObject.kind         - involved resource kind (e.g., Pod, Deployment)<br />  involvedObject.namespace    - involved resource namespace<br />  involvedObject.name         - involved resource name<br />  involvedObject.uid          - involved resource UID<br />  involvedObject.fieldPath    - involved resource field path<br />  reason                      - event reason (e.g., FailedMount, Pulled)<br />  type                        - event type (Normal or Warning)<br />  source.component            - reporting component<br />  source.host                 - reporting host<br /><br />Operators: = (or ==), !=<br />Multiple conditions: comma-separated (all must match)<br /><br />Common Patterns:<br />  "type=Warning"                                  - Warning events only<br />  "involvedObject.kind=Pod"                       - Events for pods<br />  "reason=FailedMount"                            - Mount failure events<br />  "involvedObject.name=my-pod,type=Warning"       - Warnings for a specific pod |  |  |
+| `fieldSelector` _string_ | FieldSelector filters events using standard Kubernetes field selector syntax.<br /><br />Supported Fields:<br />  metadata.name               - event name<br />  metadata.namespace          - event namespace<br />  metadata.uid                - event UID<br />  regarding.apiVersion        - regarding resource API version<br />  regarding.kind              - regarding resource kind (e.g., Pod, Deployment)<br />  regarding.namespace         - regarding resource namespace<br />  regarding.name              - regarding resource name<br />  regarding.uid               - regarding resource UID<br />  regarding.fieldPath         - regarding resource field path<br />  reason                      - event reason (e.g., FailedMount, Pulled)<br />  type                        - event type (Normal or Warning)<br />  source.component            - reporting component<br />  source.host                 - reporting host<br />  reportingComponent          - reporting component (alias for source.component)<br />  reportingInstance           - reporting instance (alias for source.host)<br /><br />Operators: = (or ==), !=<br />Multiple conditions: comma-separated (all must match)<br /><br />Common Patterns:<br />  "type=Warning"                                  - Warning events only<br />  "regarding.kind=Pod"                            - Events for pods<br />  "reason=FailedMount"                            - Mount failure events<br />  "regarding.name=my-pod,type=Warning"            - Warnings for a specific pod |  |  |
 | `limit` _integer_ | Limit sets the maximum number of results per page.<br />Default: 100, Maximum: 1000.<br /><br />Use smaller values (10-50) for exploration, larger (500-1000) for data collection.<br />Use continue to fetch additional pages. |  |  |
 | `continue` _string_ | Continue is the pagination cursor for fetching additional pages.<br /><br />Leave empty for the first page. If status.continue is non-empty after a query,<br />copy that value here in a new query with identical parameters to get the next page.<br />Repeat until status.continue is empty.<br /><br />Important: Keep all other parameters (startTime, endTime, namespace, fieldSelector,<br />limit) identical across paginated requests. The cursor is opaque - copy it exactly<br />without modification. |  |  |
 
@@ -616,10 +617,30 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `results` _[Event](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#event-v1-core) array_ | Results contains matching Kubernetes Events, sorted newest-first.<br /><br />Each event follows the standard corev1.Event format with fields like:<br />  involvedObject.\{kind,name,namespace\}, reason, message, type,<br />  firstTimestamp, lastTimestamp, count, source.component<br /><br />Empty results? Try broadening your field selector or time range. |  |  |
+| `results` _[EventRecord](#eventrecord) array_ | Results contains matching Kubernetes Events, sorted newest-first.<br /><br />Each event follows the eventsv1.Event format with fields like:<br />  regarding.\{kind,name,namespace\}, reason, note, type,<br />  eventTime, series.count, reportingController<br /><br />Empty results? Try broadening your field selector or time range. |  |  |
 | `continue` _string_ | Continue is the pagination cursor.<br />Non-empty means more results are available - copy this to spec.continue for the next page.<br />Empty means you have all results. |  |  |
 | `effectiveStartTime` _string_ | EffectiveStartTime is the actual start time used for this query (RFC3339 format).<br /><br />When you use relative times like "now-7d", this shows the exact timestamp that was<br />calculated. Useful for understanding exactly what time range was queried, especially<br />for auditing, debugging, or recreating queries with absolute timestamps.<br /><br />Example: If you query with startTime="now-7d" at 2025-12-17T12:00:00Z,<br />this will be "2025-12-10T12:00:00Z". |  |  |
 | `effectiveEndTime` _string_ | EffectiveEndTime is the actual end time used for this query (RFC3339 format).<br /><br />When you use relative times like "now", this shows the exact timestamp that was<br />calculated. Useful for understanding exactly what time range was queried.<br /><br />Example: If you query with endTime="now" at 2025-12-17T12:00:00Z,<br />this will be "2025-12-17T12:00:00Z". |  |  |
+
+
+#### EventRecord
+
+
+
+EventRecord represents a Kubernetes Event returned in EventQuery results.
+This is a wrapper type registered under activity.miloapis.com/v1alpha1 that
+embeds the events.k8s.io/v1 Event to avoid OpenAPI GVK conflicts while
+preserving full event data.
+
+
+
+_Appears in:_
+- [EventQueryStatus](#eventquerystatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `event` _[Event](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#event-v1-events)_ | Event contains the full Kubernetes Event data in events.k8s.io/v1 format.<br />This includes fields like eventTime, regarding, note, type, reason,<br />reportingController, reportingInstance, series, and action. |  |  |
 
 
 #### FacetResult

--- a/internal/registry/activity/events/eventsv1_storage.go
+++ b/internal/registry/activity/events/eventsv1_storage.go
@@ -395,37 +395,24 @@ func (r *EventsV1REST) convertToStatusError(err error) error {
 }
 
 // parseFieldSelectorForWatchV1 extracts watch filter parameters from standard field selectors.
-// Note: For events.k8s.io/v1, field names use "regarding" instead of "involvedObject"
+// For events.k8s.io/v1, field names use "regarding" instead of "involvedObject"
 func parseFieldSelectorForWatchV1(selector fields.Selector, filter *eventwatch.EventsWatchFilter) {
 	if selector == nil || selector.Empty() {
 		return
 	}
 
-	// Check both regarding (v1) and involvedObject (corev1) field names for compatibility
 	if value, found := selector.RequiresExactMatch("regarding.kind"); found {
 		filter.InvolvedObjectKind = value
-	} else if value, found := selector.RequiresExactMatch("involvedObject.kind"); found {
-		filter.InvolvedObjectKind = value
 	}
-
 	if value, found := selector.RequiresExactMatch("regarding.namespace"); found {
 		filter.InvolvedObjectNamespace = value
-	} else if value, found := selector.RequiresExactMatch("involvedObject.namespace"); found {
-		filter.InvolvedObjectNamespace = value
 	}
-
 	if value, found := selector.RequiresExactMatch("regarding.name"); found {
 		filter.InvolvedObjectName = value
-	} else if value, found := selector.RequiresExactMatch("involvedObject.name"); found {
-		filter.InvolvedObjectName = value
 	}
-
 	if value, found := selector.RequiresExactMatch("regarding.uid"); found {
 		filter.InvolvedObjectUID = value
-	} else if value, found := selector.RequiresExactMatch("involvedObject.uid"); found {
-		filter.InvolvedObjectUID = value
 	}
-
 	if value, found := selector.RequiresExactMatch("reason"); found {
 		filter.Reason = value
 	}

--- a/internal/registry/activity/events/storage.go
+++ b/internal/registry/activity/events/storage.go
@@ -412,16 +412,16 @@ func parseFieldSelectorForWatch(selector fields.Selector, filter *eventwatch.Eve
 		return
 	}
 
-	if value, found := selector.RequiresExactMatch("involvedObject.kind"); found {
+	if value, found := selector.RequiresExactMatch("regarding.kind"); found {
 		filter.InvolvedObjectKind = value
 	}
-	if value, found := selector.RequiresExactMatch("involvedObject.namespace"); found {
+	if value, found := selector.RequiresExactMatch("regarding.namespace"); found {
 		filter.InvolvedObjectNamespace = value
 	}
-	if value, found := selector.RequiresExactMatch("involvedObject.name"); found {
+	if value, found := selector.RequiresExactMatch("regarding.name"); found {
 		filter.InvolvedObjectName = value
 	}
-	if value, found := selector.RequiresExactMatch("involvedObject.uid"); found {
+	if value, found := selector.RequiresExactMatch("regarding.uid"); found {
 		filter.InvolvedObjectUID = value
 	}
 	if value, found := selector.RequiresExactMatch("reason"); found {

--- a/internal/storage/events_fields.go
+++ b/internal/storage/events_fields.go
@@ -14,13 +14,13 @@ var EventsFieldSelectors = map[string]string{
 	"metadata.name":      "name",
 	"metadata.uid":       "uid",
 
-	// Involved object fields (most commonly used with field selectors)
-	"involvedObject.apiVersion": "involved_api_version",
-	"involvedObject.kind":       "involved_kind",
-	"involvedObject.namespace":  "involved_namespace",
-	"involvedObject.name":       "involved_name",
-	"involvedObject.uid":        "involved_uid",
-	"involvedObject.fieldPath":  "involved_field_path",
+	// Regarding object fields (events/v1)
+	"regarding.apiVersion": "involved_api_version",
+	"regarding.kind":       "involved_kind",
+	"regarding.namespace":  "involved_namespace",
+	"regarding.name":       "involved_name",
+	"regarding.uid":        "involved_uid",
+	"regarding.fieldPath":  "involved_field_path",
 
 	// Event classification
 	"reason": "reason",
@@ -44,7 +44,7 @@ var EventsFieldSelectorAliases = map[string]string{
 }
 
 // ResolveEventFieldSelector resolves a field selector key to a ClickHouse column name.
-// It handles both full paths (involvedObject.name) and aliases (namespace).
+// It handles both full paths (regarding.name) and aliases (namespace).
 // Returns an error if the field selector is not supported.
 func ResolveEventFieldSelector(field string) (string, error) {
 	// Check for alias first
@@ -64,7 +64,7 @@ func ResolveEventFieldSelector(field string) (string, error) {
 // ParseFieldSelector parses a Kubernetes field selector string and returns
 // a list of (column, operator, value) tuples for building WHERE clauses.
 // Supports both = (equality) and != (inequality) operators.
-// Example: "involvedObject.name=my-pod,type!=Warning"
+// Example: "regarding.name=my-pod,type!=Warning"
 func ParseFieldSelector(selector string) ([]FieldSelectorTerm, error) {
 	if selector == "" {
 		return nil, nil

--- a/internal/storage/events_fields_test.go
+++ b/internal/storage/events_fields_test.go
@@ -1,0 +1,140 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFieldSelector_RegardingFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		selector       string
+		expectedColumn string
+		expectedOp     FieldSelectorOp
+		expectedValue  string
+		wantErr        bool
+	}{
+		{
+			name:           "regarding.kind",
+			selector:       "regarding.kind=Pod",
+			expectedColumn: "involved_kind",
+			expectedOp:     FieldSelectorEqual,
+			expectedValue:  "Pod",
+			wantErr:        false,
+		},
+		{
+			name:           "regarding.namespace",
+			selector:       "regarding.namespace=default",
+			expectedColumn: "involved_namespace",
+			expectedOp:     FieldSelectorEqual,
+			expectedValue:  "default",
+			wantErr:        false,
+		},
+		{
+			name:           "regarding.name",
+			selector:       "regarding.name=my-pod",
+			expectedColumn: "involved_name",
+			expectedOp:     FieldSelectorEqual,
+			expectedValue:  "my-pod",
+			wantErr:        false,
+		},
+		{
+			name:           "regarding.uid",
+			selector:       "regarding.uid=123e4567-e89b-12d3-a456-426614174000",
+			expectedColumn: "involved_uid",
+			expectedOp:     FieldSelectorEqual,
+			expectedValue:  "123e4567-e89b-12d3-a456-426614174000",
+			wantErr:        false,
+		},
+		{
+			name:           "regarding.apiVersion",
+			selector:       "regarding.apiVersion=apps/v1",
+			expectedColumn: "involved_api_version",
+			expectedOp:     FieldSelectorEqual,
+			expectedValue:  "apps/v1",
+			wantErr:        false,
+		},
+		{
+			name:           "regarding.fieldPath",
+			selector:       "regarding.fieldPath=spec.containers{nginx}",
+			expectedColumn: "involved_field_path",
+			expectedOp:     FieldSelectorEqual,
+			expectedValue:  "spec.containers{nginx}",
+			wantErr:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			terms, err := ParseFieldSelector(tt.selector)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, terms, 1)
+
+			assert.Equal(t, tt.expectedColumn, terms[0].Column)
+			assert.Equal(t, tt.expectedOp, terms[0].Operator)
+			assert.Equal(t, tt.expectedValue, terms[0].Value)
+		})
+	}
+}
+
+
+func TestParseFieldSelector_RegardingWithMultipleFields(t *testing.T) {
+	selector := "regarding.kind=Pod,regarding.namespace=default,type=Warning"
+	terms, err := ParseFieldSelector(selector)
+	require.NoError(t, err)
+	require.Len(t, terms, 3)
+
+	assert.Equal(t, "involved_kind", terms[0].Column)
+	assert.Equal(t, "Pod", terms[0].Value)
+
+	assert.Equal(t, "involved_namespace", terms[1].Column)
+	assert.Equal(t, "default", terms[1].Value)
+
+	assert.Equal(t, "type", terms[2].Column)
+	assert.Equal(t, "Warning", terms[2].Value)
+}
+
+func TestParseFieldSelector_RegardingWithNotEqual(t *testing.T) {
+	selector := "regarding.kind!=ConfigMap"
+	terms, err := ParseFieldSelector(selector)
+	require.NoError(t, err)
+	require.Len(t, terms, 1)
+
+	assert.Equal(t, "involved_kind", terms[0].Column)
+	assert.Equal(t, FieldSelectorNotEqual, terms[0].Operator)
+	assert.Equal(t, "ConfigMap", terms[0].Value)
+}
+
+func TestResolveEventFieldSelector_RegardingFields(t *testing.T) {
+	tests := []struct {
+		field    string
+		expected string
+	}{
+		{"regarding.kind", "involved_kind"},
+		{"regarding.namespace", "involved_namespace"},
+		{"regarding.name", "involved_name"},
+		{"regarding.uid", "involved_uid"},
+		{"regarding.apiVersion", "involved_api_version"},
+		{"regarding.fieldPath", "involved_field_path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			column, err := ResolveEventFieldSelector(tt.field)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, column)
+		})
+	}
+}
+
+func TestResolveEventFieldSelector_UnsupportedRegardingField(t *testing.T) {
+	_, err := ResolveEventFieldSelector("regarding.unsupportedField")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported field selector")
+}

--- a/internal/storage/fields.go
+++ b/internal/storage/fields.go
@@ -115,12 +115,12 @@ func GetActivityFacetColumn(field string) (string, error) {
 // EventFacetFields defines the supported fields for Kubernetes Event facet queries.
 // Keys are API field paths (as used in queries), values are human-readable descriptions.
 var EventFacetFields = map[string]string{
-	"involvedObject.kind":      "The kind of resource the event is about (Pod, Deployment, etc.)",
-	"involvedObject.namespace": "The namespace of the involved object",
-	"reason":                   "The event reason (Scheduled, Pulled, Created, etc.)",
-	"type":                     "The event type (Normal, Warning)",
-	"source.component":         "The component that generated the event (kubelet, scheduler, etc.)",
-	"namespace":                "The namespace of the event itself",
+	"regarding.kind":      "The kind of resource the event is about (Pod, Deployment, etc.)",
+	"regarding.namespace": "The namespace of the regarding object",
+	"reason":              "The event reason (Scheduled, Pulled, Created, etc.)",
+	"type":                "The event type (Normal, Warning)",
+	"source.component":    "The component that generated the event (kubelet, scheduler, etc.)",
+	"namespace":           "The namespace of the event itself",
 }
 
 // IsValidEventFacetField checks if a field is supported for event faceting.
@@ -136,12 +136,12 @@ func EventFacetFieldNames() []string {
 
 // eventFacetColumnMapping maps API field paths to ClickHouse column names for events.
 var eventFacetColumnMapping = map[string]string{
-	"involvedObject.kind":      "involved_kind",
-	"involvedObject.namespace": "involved_namespace",
-	"reason":                   "reason",
-	"type":                     "type",
-	"source.component":         "source_component",
-	"namespace":                "namespace",
+	"regarding.kind":      "involved_kind",
+	"regarding.namespace": "involved_namespace",
+	"reason":              "reason",
+	"type":                "type",
+	"source.component":    "source_component",
+	"namespace":           "namespace",
 }
 
 // GetEventFacetColumn returns the ClickHouse column name for an event facet field.

--- a/pkg/apis/activity/v1alpha1/register.go
+++ b/pkg/apis/activity/v1alpha1/register.go
@@ -65,13 +65,13 @@ func EventFieldLabelConversionFunc(label, value string) (string, string, error) 
 		"metadata.uid":
 		return label, value, nil
 
-	// Involved object fields (commonly used with field selectors)
-	case "involvedObject.apiVersion",
-		"involvedObject.kind",
-		"involvedObject.namespace",
-		"involvedObject.name",
-		"involvedObject.uid",
-		"involvedObject.fieldPath":
+	// Regarding object fields (commonly used with field selectors)
+	case "regarding.apiVersion",
+		"regarding.kind",
+		"regarding.namespace",
+		"regarding.name",
+		"regarding.uid",
+		"regarding.fieldPath":
 		return label, value, nil
 
 	// Event classification
@@ -100,12 +100,12 @@ var SupportedEventFieldSelectors = []string{
 	"metadata.name",
 	"metadata.namespace",
 	"metadata.uid",
-	"involvedObject.apiVersion",
-	"involvedObject.kind",
-	"involvedObject.namespace",
-	"involvedObject.name",
-	"involvedObject.uid",
-	"involvedObject.fieldPath",
+	"regarding.apiVersion",
+	"regarding.kind",
+	"regarding.namespace",
+	"regarding.name",
+	"regarding.uid",
+	"regarding.fieldPath",
 	"reason",
 	"type",
 	"source.component",

--- a/pkg/apis/activity/v1alpha1/types_eventfacetquery.go
+++ b/pkg/apis/activity/v1alpha1/types_eventfacetquery.go
@@ -26,7 +26,7 @@ import (
 //	  timeRange:
 //	    start: "now-7d"
 //	  facets:
-//	    - field: involvedObject.kind
+//	    - field: regarding.kind
 //	      limit: 10
 //	    - field: reason
 //	    - field: type
@@ -50,8 +50,8 @@ type EventFacetQuerySpec struct {
 	// Each facet returns the top N values with counts.
 	//
 	// Supported fields:
-	//   - involvedObject.kind: Resource kinds (Pod, Deployment, etc.)
-	//   - involvedObject.namespace: Namespaces of involved objects
+	//   - regarding.kind: Resource kinds (Pod, Deployment, etc.)
+	//   - regarding.namespace: Namespaces of regarding objects
 	//   - reason: Event reasons (Scheduled, Pulled, Created, etc.)
 	//   - type: Event types (Normal, Warning)
 	//   - source.component: Source components (kubelet, scheduler, etc.)

--- a/pkg/apis/activity/v1alpha1/types_eventquery.go
+++ b/pkg/apis/activity/v1alpha1/types_eventquery.go
@@ -87,25 +87,27 @@ type EventQuerySpec struct {
 	//   metadata.name               - event name
 	//   metadata.namespace          - event namespace
 	//   metadata.uid                - event UID
-	//   involvedObject.apiVersion   - involved resource API version
-	//   involvedObject.kind         - involved resource kind (e.g., Pod, Deployment)
-	//   involvedObject.namespace    - involved resource namespace
-	//   involvedObject.name         - involved resource name
-	//   involvedObject.uid          - involved resource UID
-	//   involvedObject.fieldPath    - involved resource field path
+	//   regarding.apiVersion        - regarding resource API version
+	//   regarding.kind              - regarding resource kind (e.g., Pod, Deployment)
+	//   regarding.namespace         - regarding resource namespace
+	//   regarding.name              - regarding resource name
+	//   regarding.uid               - regarding resource UID
+	//   regarding.fieldPath         - regarding resource field path
 	//   reason                      - event reason (e.g., FailedMount, Pulled)
 	//   type                        - event type (Normal or Warning)
 	//   source.component            - reporting component
 	//   source.host                 - reporting host
+	//   reportingComponent          - reporting component (alias for source.component)
+	//   reportingInstance           - reporting instance (alias for source.host)
 	//
 	// Operators: = (or ==), !=
 	// Multiple conditions: comma-separated (all must match)
 	//
 	// Common Patterns:
 	//   "type=Warning"                                  - Warning events only
-	//   "involvedObject.kind=Pod"                       - Events for pods
+	//   "regarding.kind=Pod"                            - Events for pods
 	//   "reason=FailedMount"                            - Mount failure events
-	//   "involvedObject.name=my-pod,type=Warning"       - Warnings for a specific pod
+	//   "regarding.name=my-pod,type=Warning"            - Warnings for a specific pod
 	//
 	// +optional
 	FieldSelector string `json:"fieldSelector,omitempty"`

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -54,6 +54,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"go.miloapis.com/activity/pkg/apis/activity/v1alpha1.EventQueryList":            schema_pkg_apis_activity_v1alpha1_EventQueryList(ref),
 		"go.miloapis.com/activity/pkg/apis/activity/v1alpha1.EventQuerySpec":            schema_pkg_apis_activity_v1alpha1_EventQuerySpec(ref),
 		"go.miloapis.com/activity/pkg/apis/activity/v1alpha1.EventQueryStatus":          schema_pkg_apis_activity_v1alpha1_EventQueryStatus(ref),
+		"go.miloapis.com/activity/pkg/apis/activity/v1alpha1.EventRecord":               schema_pkg_apis_activity_v1alpha1_EventRecord(ref),
 		"go.miloapis.com/activity/pkg/apis/activity/v1alpha1.FacetResult":               schema_pkg_apis_activity_v1alpha1_FacetResult(ref),
 		"go.miloapis.com/activity/pkg/apis/activity/v1alpha1.FacetSpec":                 schema_pkg_apis_activity_v1alpha1_FacetSpec(ref),
 		"go.miloapis.com/activity/pkg/apis/activity/v1alpha1.FacetTimeRange":            schema_pkg_apis_activity_v1alpha1_FacetTimeRange(ref),
@@ -1694,7 +1695,7 @@ func schema_pkg_apis_activity_v1alpha1_EventFacetQuery(ref common.ReferenceCallb
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "EventFacetQuery is an ephemeral resource for getting distinct field values from Kubernetes Events. Use this to power autocomplete, filter dropdowns, and faceted search in UIs.\n\nThe query returns counts for each distinct value, allowing you to show both available options and their frequency.\n\nExample:\n\n\tapiVersion: activity.miloapis.com/v1alpha1\n\tkind: EventFacetQuery\n\tmetadata:\n\t  name: get-facets\n\tspec:\n\t  timeRange:\n\t    start: \"now-7d\"\n\t  facets:\n\t    - field: involvedObject.kind\n\t      limit: 10\n\t    - field: reason\n\t    - field: type",
+				Description: "EventFacetQuery is an ephemeral resource for getting distinct field values from Kubernetes Events. Use this to power autocomplete, filter dropdowns, and faceted search in UIs.\n\nThe query returns counts for each distinct value, allowing you to show both available options and their frequency.\n\nExample:\n\n\tapiVersion: activity.miloapis.com/v1alpha1\n\tkind: EventFacetQuery\n\tmetadata:\n\t  name: get-facets\n\tspec:\n\t  timeRange:\n\t    start: \"now-7d\"\n\t  facets:\n\t    - field: regarding.kind\n\t      limit: 10\n\t    - field: reason\n\t    - field: type",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
@@ -1759,7 +1760,7 @@ func schema_pkg_apis_activity_v1alpha1_EventFacetQuerySpec(ref common.ReferenceC
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Facets specifies which fields to get distinct values for. Each facet returns the top N values with counts.\n\nSupported fields:\n  - involvedObject.kind: Resource kinds (Pod, Deployment, etc.)\n  - involvedObject.namespace: Namespaces of involved objects\n  - reason: Event reasons (Scheduled, Pulled, Created, etc.)\n  - type: Event types (Normal, Warning)\n  - source.component: Source components (kubelet, scheduler, etc.)\n  - namespace: Event namespace",
+							Description: "Facets specifies which fields to get distinct values for. Each facet returns the top N values with counts.\n\nSupported fields:\n  - regarding.kind: Resource kinds (Pod, Deployment, etc.)\n  - regarding.namespace: Namespaces of regarding objects\n  - reason: Event reasons (Scheduled, Pulled, Created, etc.)\n  - type: Event types (Normal, Warning)\n  - source.component: Source components (kubelet, scheduler, etc.)\n  - namespace: Event namespace",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -1943,7 +1944,7 @@ func schema_pkg_apis_activity_v1alpha1_EventQuerySpec(ref common.ReferenceCallba
 					},
 					"fieldSelector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "FieldSelector filters events using standard Kubernetes field selector syntax.\n\nSupported Fields:\n  metadata.name               - event name\n  metadata.namespace          - event namespace\n  metadata.uid                - event UID\n  involvedObject.apiVersion   - involved resource API version\n  involvedObject.kind         - involved resource kind (e.g., Pod, Deployment)\n  involvedObject.namespace    - involved resource namespace\n  involvedObject.name         - involved resource name\n  involvedObject.uid          - involved resource UID\n  involvedObject.fieldPath    - involved resource field path\n  reason                      - event reason (e.g., FailedMount, Pulled)\n  type                        - event type (Normal or Warning)\n  source.component            - reporting component\n  source.host                 - reporting host\n\nOperators: = (or ==), != Multiple conditions: comma-separated (all must match)\n\nCommon Patterns:\n  \"type=Warning\"                                  - Warning events only\n  \"involvedObject.kind=Pod\"                       - Events for pods\n  \"reason=FailedMount\"                            - Mount failure events\n  \"involvedObject.name=my-pod,type=Warning\"       - Warnings for a specific pod",
+							Description: "FieldSelector filters events using standard Kubernetes field selector syntax.\n\nSupported Fields:\n  metadata.name               - event name\n  metadata.namespace          - event namespace\n  metadata.uid                - event UID\n  regarding.apiVersion        - regarding resource API version\n  regarding.kind              - regarding resource kind (e.g., Pod, Deployment)\n  regarding.namespace         - regarding resource namespace\n  regarding.name              - regarding resource name\n  regarding.uid               - regarding resource UID\n  regarding.fieldPath         - regarding resource field path\n  reason                      - event reason (e.g., FailedMount, Pulled)\n  type                        - event type (Normal or Warning)\n  source.component            - reporting component\n  source.host                 - reporting host\n  reportingComponent          - reporting component (alias for source.component)\n  reportingInstance           - reporting instance (alias for source.host)\n\nOperators: = (or ==), != Multiple conditions: comma-separated (all must match)\n\nCommon Patterns:\n  \"type=Warning\"                                  - Warning events only\n  \"regarding.kind=Pod\"                            - Events for pods\n  \"reason=FailedMount\"                            - Mount failure events\n  \"regarding.name=my-pod,type=Warning\"            - Warnings for a specific pod",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1983,13 +1984,13 @@ func schema_pkg_apis_activity_v1alpha1_EventQueryStatus(ref common.ReferenceCall
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Results contains matching Kubernetes Events, sorted newest-first.\n\nEach event follows the standard corev1.Event format with fields like:\n  involvedObject.{kind,name,namespace}, reason, message, type,\n  firstTimestamp, lastTimestamp, count, source.component\n\nEmpty results? Try broadening your field selector or time range.",
+							Description: "Results contains matching Kubernetes Events, sorted newest-first.\n\nEach event follows the eventsv1.Event format with fields like:\n  regarding.{kind,name,namespace}, reason, note, type,\n  eventTime, series.count, reportingController\n\nEmpty results? Try broadening your field selector or time range.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref(corev1.Event{}.OpenAPIModelName()),
+										Ref:     ref("go.miloapis.com/activity/pkg/apis/activity/v1alpha1.EventRecord"),
 									},
 								},
 							},
@@ -2020,7 +2021,50 @@ func schema_pkg_apis_activity_v1alpha1_EventQueryStatus(ref common.ReferenceCall
 			},
 		},
 		Dependencies: []string{
-			corev1.Event{}.OpenAPIModelName()},
+			"go.miloapis.com/activity/pkg/apis/activity/v1alpha1.EventRecord"},
+	}
+}
+
+func schema_pkg_apis_activity_v1alpha1_EventRecord(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "EventRecord represents a Kubernetes Event returned in EventQuery results. This is a wrapper type registered under activity.miloapis.com/v1alpha1 that embeds the events.k8s.io/v1 Event to avoid OpenAPI GVK conflicts while preserving full event data.",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Default: map[string]interface{}{},
+							Ref:     ref(metav1.ObjectMeta{}.OpenAPIModelName()),
+						},
+					},
+					"event": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Event contains the full Kubernetes Event data in events.k8s.io/v1 format. This includes fields like eventTime, regarding, note, type, reason, reportingController, reportingInstance, series, and action.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/api/events/v1.Event"),
+						},
+					},
+				},
+				Required: []string{"event"},
+			},
+		},
+		Dependencies: []string{
+			"k8s.io/api/events/v1.Event", metav1.ObjectMeta{}.OpenAPIModelName()},
 	}
 }
 

--- a/pkg/mcp/tools/tools.go
+++ b/pkg/mcp/tools/tools.go
@@ -1315,11 +1315,11 @@ type QueryEventsArgs struct {
 	// Namespace limits results to events from a specific namespace.
 	Namespace string `json:"namespace,omitempty"`
 
-	// InvolvedObjectKind filters by the kind of the involved object.
-	InvolvedObjectKind string `json:"involvedObjectKind,omitempty"`
+	// RegardingKind filters by the kind of the regarding object.
+	RegardingKind string `json:"regardingKind,omitempty"`
 
-	// InvolvedObjectName filters by the name of the involved object.
-	InvolvedObjectName string `json:"involvedObjectName,omitempty"`
+	// RegardingName filters by the name of the regarding object.
+	RegardingName string `json:"regardingName,omitempty"`
 
 	// Reason filters by event reason.
 	Reason string `json:"reason,omitempty"`
@@ -1342,11 +1342,11 @@ func (p *ToolProvider) handleQueryEvents(ctx context.Context, req *mcp.CallToolR
 
 	// Build field selector for filtering
 	var fieldSelectors []string
-	if args.InvolvedObjectKind != "" {
-		fieldSelectors = append(fieldSelectors, fmt.Sprintf("involvedObject.kind=%s", args.InvolvedObjectKind))
+	if args.RegardingKind != "" {
+		fieldSelectors = append(fieldSelectors, fmt.Sprintf("regarding.kind=%s", args.RegardingKind))
 	}
-	if args.InvolvedObjectName != "" {
-		fieldSelectors = append(fieldSelectors, fmt.Sprintf("involvedObject.name=%s", args.InvolvedObjectName))
+	if args.RegardingName != "" {
+		fieldSelectors = append(fieldSelectors, fmt.Sprintf("regarding.name=%s", args.RegardingName))
 	}
 	if args.Reason != "" {
 		fieldSelectors = append(fieldSelectors, fmt.Sprintf("reason=%s", args.Reason))
@@ -1394,9 +1394,9 @@ func (p *ToolProvider) handleQueryEvents(ctx context.Context, req *mcp.CallToolR
 			"message":   event.Note,
 		}
 
-		// eventsv1.Event uses Regarding instead of InvolvedObject
+		// eventsv1.Event uses Regarding
 		if event.Regarding.Name != "" || event.Regarding.Kind != "" {
-			eventMap["involvedObject"] = map[string]any{
+			eventMap["regarding"] = map[string]any{
 				"kind":      event.Regarding.Kind,
 				"name":      event.Regarding.Name,
 				"namespace": event.Regarding.Namespace,

--- a/ui/e2e/helpers/api-mocks.ts
+++ b/ui/e2e/helpers/api-mocks.ts
@@ -1,0 +1,650 @@
+import type { Page, Route } from '@playwright/test';
+import type { ActivityPolicyList, ActivityPolicy, PolicyPreview, Event } from '../../src/types';
+
+/**
+ * API mock helpers for E2E tests
+ * Provides reusable functions to mock ActivityPolicy and related API endpoints
+ */
+
+/**
+ * Options for mocking API responses
+ */
+export interface MockApiOptions {
+  /** Delay response in milliseconds (useful for testing loading states) */
+  delay?: number;
+  /** Return an error response */
+  error?: {
+    status: number;
+    message: string;
+  };
+}
+
+/**
+ * Mock GET /activitypolicies endpoint
+ * @param page - Playwright page instance
+ * @param policyList - Mock policy list data to return (optional)
+ * @param options - Mock options (delay, error)
+ */
+export async function mockPolicyListAPI(
+  page: Page,
+  policyList?: ActivityPolicyList,
+  options?: MockApiOptions
+) {
+  await page.route('**/activitypolicies', async (route: Route) => {
+    // Only intercept GET requests
+    if (route.request().method() !== 'GET') {
+      return route.continue();
+    }
+
+    if (options?.delay) {
+      await new Promise(resolve => setTimeout(resolve, options.delay));
+    }
+
+    if (options?.error) {
+      return route.fulfill({
+        status: options.error.status,
+        json: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: options.error.message,
+          code: options.error.status,
+        },
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      json: policyList || { items: [] },
+    });
+  });
+}
+
+/**
+ * Mock GET /activitypolicies/:name endpoint
+ * @param page - Playwright page instance
+ * @param name - Policy name to mock
+ * @param policy - Mock policy data to return (optional)
+ * @param options - Mock options (delay, error)
+ */
+export async function mockPolicyDetailAPI(
+  page: Page,
+  name: string,
+  policy?: ActivityPolicy,
+  options?: MockApiOptions
+) {
+  await page.route(`**/activitypolicies/${name}`, async (route: Route) => {
+    // Only intercept GET requests
+    if (route.request().method() !== 'GET') {
+      return route.continue();
+    }
+
+    if (options?.delay) {
+      await new Promise(resolve => setTimeout(resolve, options.delay));
+    }
+
+    if (options?.error) {
+      return route.fulfill({
+        status: options.error.status,
+        json: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: options.error.message,
+          code: options.error.status,
+        },
+      });
+    }
+
+    if (!policy) {
+      return route.fulfill({
+        status: 404,
+        json: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: `activitypolicies "${name}" not found`,
+          code: 404,
+        },
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      json: policy,
+    });
+  });
+}
+
+/**
+ * Mock POST /activitypolicies endpoint (create)
+ * @param page - Playwright page instance
+ * @param options - Mock options (delay, error)
+ */
+export async function mockPolicyCreateAPI(
+  page: Page,
+  options?: MockApiOptions
+) {
+  await page.route('**/activitypolicies', async (route: Route) => {
+    // Only intercept POST requests
+    if (route.request().method() !== 'POST') {
+      return route.continue();
+    }
+
+    if (options?.delay) {
+      await new Promise(resolve => setTimeout(resolve, options.delay));
+    }
+
+    if (options?.error) {
+      return route.fulfill({
+        status: options.error.status,
+        json: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: options.error.message,
+          code: options.error.status,
+        },
+      });
+    }
+
+    // Echo back the request body as the created resource
+    const requestBody = route.request().postDataJSON();
+    return route.fulfill({
+      status: 201,
+      json: {
+        ...requestBody,
+        metadata: {
+          ...requestBody.metadata,
+          resourceVersion: '1',
+          creationTimestamp: new Date().toISOString(),
+        },
+        status: {
+          conditions: [
+            {
+              type: 'Ready',
+              status: 'True',
+              lastTransitionTime: new Date().toISOString(),
+              reason: 'AllRulesCompiled',
+              message: 'All rules compiled successfully',
+            },
+          ],
+          observedGeneration: 1,
+        },
+      },
+    });
+  });
+}
+
+/**
+ * Mock PUT /activitypolicies/:name endpoint (update)
+ * @param page - Playwright page instance
+ * @param name - Policy name to mock
+ * @param options - Mock options (delay, error)
+ */
+export async function mockPolicyUpdateAPI(
+  page: Page,
+  name: string,
+  options?: MockApiOptions
+) {
+  await page.route(`**/activitypolicies/${name}`, async (route: Route) => {
+    // Only intercept PUT requests
+    if (route.request().method() !== 'PUT') {
+      return route.continue();
+    }
+
+    if (options?.delay) {
+      await new Promise(resolve => setTimeout(resolve, options.delay));
+    }
+
+    if (options?.error) {
+      return route.fulfill({
+        status: options.error.status,
+        json: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: options.error.message,
+          code: options.error.status,
+        },
+      });
+    }
+
+    // Echo back the request body as the updated resource
+    const requestBody = route.request().postDataJSON();
+    return route.fulfill({
+      status: 200,
+      json: {
+        ...requestBody,
+        metadata: {
+          ...requestBody.metadata,
+          resourceVersion: String(Number(requestBody.metadata.resourceVersion || '1') + 1),
+        },
+        status: {
+          conditions: [
+            {
+              type: 'Ready',
+              status: 'True',
+              lastTransitionTime: new Date().toISOString(),
+              reason: 'AllRulesCompiled',
+              message: 'All rules compiled successfully',
+            },
+          ],
+          observedGeneration: requestBody.metadata.generation || 1,
+        },
+      },
+    });
+  });
+}
+
+/**
+ * Mock DELETE /activitypolicies/:name endpoint
+ * @param page - Playwright page instance
+ * @param name - Policy name to mock
+ * @param options - Mock options (delay, error)
+ */
+export async function mockPolicyDeleteAPI(
+  page: Page,
+  name: string,
+  options?: MockApiOptions
+) {
+  await page.route(`**/activitypolicies/${name}`, async (route: Route) => {
+    // Only intercept DELETE requests
+    if (route.request().method() !== 'DELETE') {
+      return route.continue();
+    }
+
+    if (options?.delay) {
+      await new Promise(resolve => setTimeout(resolve, options.delay));
+    }
+
+    if (options?.error) {
+      return route.fulfill({
+        status: options.error.status,
+        json: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: options.error.message,
+          code: options.error.status,
+        },
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      json: {
+        kind: 'Status',
+        apiVersion: 'v1',
+        status: 'Success',
+        message: `activitypolicies "${name}" deleted`,
+      },
+    });
+  });
+}
+
+/**
+ * Mock POST /policypreviews endpoint
+ * @param page - Playwright page instance
+ * @param result - Mock preview result (optional)
+ * @param options - Mock options (delay, error)
+ */
+export async function mockPolicyPreviewAPI(
+  page: Page,
+  result?: PolicyPreview,
+  options?: MockApiOptions
+) {
+  await page.route('**/policypreviews', async (route: Route) => {
+    if (options?.delay) {
+      await new Promise(resolve => setTimeout(resolve, options.delay));
+    }
+
+    if (options?.error) {
+      return route.fulfill({
+        status: options.error.status,
+        json: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: options.error.message,
+          code: options.error.status,
+        },
+      });
+    }
+
+    const defaultResult: PolicyPreview = {
+      apiVersion: 'activity.miloapis.com/v1alpha1',
+      kind: 'PolicyPreview',
+      spec: route.request().postDataJSON().spec,
+      status: {
+        results: [],
+        activities: [],
+      },
+    };
+
+    return route.fulfill({
+      status: 200,
+      json: result || defaultResult,
+    });
+  });
+}
+
+/**
+ * Mock POST /auditlogqueries endpoint
+ * @param page - Playwright page instance
+ * @param events - Mock events to return (optional)
+ * @param options - Mock options (delay, error)
+ */
+export async function mockAuditLogQueryAPI(
+  page: Page,
+  events?: Event[],
+  options?: MockApiOptions
+) {
+  await page.route('**/auditlogqueries', async (route: Route) => {
+    if (options?.delay) {
+      await new Promise(resolve => setTimeout(resolve, options.delay));
+    }
+
+    if (options?.error) {
+      return route.fulfill({
+        status: options.error.status,
+        json: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: options.error.message,
+          code: options.error.status,
+        },
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      json: {
+        apiVersion: 'activity.miloapis.com/v1alpha1',
+        kind: 'AuditLogQuery',
+        spec: route.request().postDataJSON().spec,
+        status: {
+          results: events || [],
+        },
+      },
+    });
+  });
+}
+
+/**
+ * Activity data for mocking activity queries
+ */
+export interface MockActivity {
+  metadata: {
+    name: string;
+    uid?: string;
+    creationTimestamp?: string;
+  };
+  spec: {
+    summary: string;
+    changeSource: 'human' | 'system';
+    actor?: {
+      name: string;
+      type: string;
+    };
+    resource?: {
+      apiGroup: string;
+      kind: string;
+      name: string;
+      namespace?: string;
+    };
+    timestamp?: string;
+  };
+}
+
+/**
+ * Mock POST /activityqueries endpoint
+ * @param page - Playwright page instance
+ * @param activities - Mock activities to return (optional)
+ * @param options - Mock options (delay, error)
+ */
+export async function mockActivityQueryAPI(
+  page: Page,
+  activities?: MockActivity[],
+  options?: MockApiOptions
+) {
+  await page.route('**/activityqueries', async (route: Route) => {
+    if (options?.delay) {
+      await new Promise(resolve => setTimeout(resolve, options.delay));
+    }
+
+    if (options?.error) {
+      return route.fulfill({
+        status: options.error.status,
+        json: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: options.error.message,
+          code: options.error.status,
+        },
+      });
+    }
+
+    const request = route.request().postDataJSON();
+    const changeSourceFilter = request?.spec?.changeSource;
+
+    // Filter activities by changeSource if specified
+    let filteredActivities = activities || [];
+    if (changeSourceFilter && activities) {
+      filteredActivities = activities.filter(a => a.spec.changeSource === changeSourceFilter);
+    }
+
+    return route.fulfill({
+      status: 200,
+      json: {
+        apiVersion: 'activity.miloapis.com/v1alpha1',
+        kind: 'ActivityQuery',
+        spec: request?.spec || {},
+        status: {
+          results: filteredActivities,
+        },
+      },
+    });
+  });
+}
+
+/**
+ * Mock K8s event data for mocking event queries
+ */
+export interface MockK8sEvent {
+  metadata: {
+    name: string;
+    namespace: string;
+    uid?: string;
+    creationTimestamp?: string;
+  };
+  involvedObject: {
+    apiVersion: string;
+    kind: string;
+    name: string;
+    namespace?: string;
+  };
+  reason: string;
+  message: string;
+  type: 'Normal' | 'Warning';
+  source?: {
+    component: string;
+  };
+  firstTimestamp?: string;
+  lastTimestamp?: string;
+  count?: number;
+}
+
+/**
+ * Mock POST /eventqueries endpoint
+ * @param page - Playwright page instance
+ * @param events - Mock events to return (optional)
+ * @param options - Mock options (delay, error)
+ */
+export async function mockEventQueryAPI(
+  page: Page,
+  events?: MockK8sEvent[],
+  options?: MockApiOptions
+) {
+  await page.route('**/eventqueries', async (route: Route) => {
+    if (options?.delay) {
+      await new Promise(resolve => setTimeout(resolve, options.delay));
+    }
+
+    if (options?.error) {
+      return route.fulfill({
+        status: options.error.status,
+        json: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: options.error.message,
+          code: options.error.status,
+        },
+      });
+    }
+
+    const request = route.request().postDataJSON();
+
+    return route.fulfill({
+      status: 200,
+      json: {
+        apiVersion: 'activity.miloapis.com/v1alpha1',
+        kind: 'EventQuery',
+        spec: request?.spec || {},
+        status: {
+          results: events || [],
+        },
+      },
+    });
+  });
+}
+
+/**
+ * Facet data for mocking facet queries
+ */
+export interface MockFacetValue {
+  value: string;
+  count: number;
+}
+
+export interface MockFacets {
+  [field: string]: MockFacetValue[];
+}
+
+/**
+ * Mock POST /eventfacetqueries endpoint
+ * @param page - Playwright page instance
+ * @param facets - Mock facets to return (optional)
+ * @param options - Mock options (delay, error)
+ */
+export async function mockEventFacetQueryAPI(
+  page: Page,
+  facets?: MockFacets,
+  options?: MockApiOptions
+) {
+  await page.route('**/eventfacetqueries', async (route: Route) => {
+    if (options?.delay) {
+      await new Promise(resolve => setTimeout(resolve, options.delay));
+    }
+
+    if (options?.error) {
+      return route.fulfill({
+        status: options.error.status,
+        json: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: options.error.message,
+          code: options.error.status,
+        },
+      });
+    }
+
+    const request = route.request().postDataJSON();
+    const defaultFacets: MockFacets = {
+      'regarding.kind': [
+        { value: 'Pod', count: 45 },
+        { value: 'Deployment', count: 23 },
+        { value: 'Service', count: 12 },
+        { value: 'ConfigMap', count: 8 },
+      ],
+      reason: [
+        { value: 'Scheduled', count: 30 },
+        { value: 'Pulled', count: 25 },
+        { value: 'Created', count: 20 },
+        { value: 'Started', count: 18 },
+        { value: 'FailedScheduling', count: 5 },
+      ],
+      'regarding.namespace': [
+        { value: 'default', count: 50 },
+        { value: 'kube-system', count: 30 },
+        { value: 'monitoring', count: 15 },
+      ],
+      'source.component': [
+        { value: 'kubelet', count: 40 },
+        { value: 'kube-scheduler', count: 25 },
+        { value: 'deployment-controller', count: 15 },
+      ],
+    };
+
+    return route.fulfill({
+      status: 200,
+      json: {
+        apiVersion: 'activity.miloapis.com/v1alpha1',
+        kind: 'EventFacetQuery',
+        spec: request?.spec || {},
+        status: {
+          facets: facets || defaultFacets,
+        },
+      },
+    });
+  });
+}
+
+/**
+ * Mock POST /activityfacetqueries endpoint
+ * @param page - Playwright page instance
+ * @param facets - Mock facets to return (optional)
+ * @param options - Mock options (delay, error)
+ */
+export async function mockActivityFacetQueryAPI(
+  page: Page,
+  facets?: MockFacets,
+  options?: MockApiOptions
+) {
+  await page.route('**/activityfacetqueries', async (route: Route) => {
+    if (options?.delay) {
+      await new Promise(resolve => setTimeout(resolve, options.delay));
+    }
+
+    if (options?.error) {
+      return route.fulfill({
+        status: options.error.status,
+        json: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: options.error.message,
+          code: options.error.status,
+        },
+      });
+    }
+
+    const request = route.request().postDataJSON();
+
+    return route.fulfill({
+      status: 200,
+      json: {
+        apiVersion: 'activity.miloapis.com/v1alpha1',
+        kind: 'ActivityFacetQuery',
+        spec: request?.spec || {},
+        status: {
+          facets: facets || {},
+        },
+      },
+    });
+  });
+}

--- a/ui/e2e/helpers/form-helpers.ts
+++ b/ui/e2e/helpers/form-helpers.ts
@@ -1,0 +1,74 @@
+import type { Page, Locator } from '@playwright/test';
+
+/**
+ * Helper functions for interacting with shadcn/ui form components in E2E tests
+ */
+
+/**
+ * Fill a Select component (dropdown) with a custom value
+ * This handles the pattern where you:
+ * 1. Click the select trigger to open dropdown
+ * 2. Click "Enter custom value..." option
+ * 3. Fill the input that appears
+ */
+export async function fillSelectWithCustomValue(
+  page: Page,
+  triggerLocator: Locator,
+  value: string
+) {
+  // Click trigger to open dropdown
+  await triggerLocator.click();
+  await page.waitForTimeout(200);
+
+  // Click "Enter custom value..." option
+  await page.getByRole('option', { name: /Enter custom value/i }).click();
+  await page.waitForTimeout(200);
+
+  // Wait for the input to appear and be visible
+  const input = page.locator('input[type="text"]:visible').last();
+  await input.waitFor({ state: 'visible', timeout: 2000 });
+
+  // Fill the input
+  await input.fill(value);
+}
+
+/**
+ * Fill API Group field in PolicyResourceForm
+ * Handles the Select -> Custom input pattern
+ */
+export async function fillApiGroup(page: Page, apiGroup: string) {
+  // Find the API Group select trigger
+  const selectTrigger = page.locator('label:has-text("API Group")').locator('..').locator('[role="combobox"]').first();
+  await fillSelectWithCustomValue(page, selectTrigger, apiGroup);
+}
+
+/**
+ * Fill Kind field in PolicyResourceForm
+ * Handles the Select -> Custom input pattern
+ */
+export async function fillKind(page: Page, kind: string) {
+  // Find the Kind select trigger
+  const selectTrigger = page.locator('label:has-text("Kind")').locator('..').locator('[role="combobox"]').first();
+  await fillSelectWithCustomValue(page, selectTrigger, kind);
+}
+
+/**
+ * Fill resource details (API Group + Kind) in policy editor
+ */
+export async function fillResourceDetails(page: Page, apiGroup: string, kind: string) {
+  await fillApiGroup(page, apiGroup);
+  // Wait for API Group change to propagate and Kind select to become enabled
+  await page.waitForTimeout(300);
+  await fillKind(page, kind);
+}
+
+/**
+ * Click a rule card to open edit dialog
+ * Rules are displayed as clickable cards in PolicyRuleListItem
+ */
+export async function clickRuleToEdit(page: Page, ruleName: string) {
+  // Find the rule by name and click the Edit button
+  const ruleCard = page.locator(`text=${ruleName}`).locator('..').locator('..');
+  const editButton = ruleCard.getByRole('button', { name: /Edit rule/i });
+  await editButton.click();
+}

--- a/ui/e2e/helpers/monaco.ts
+++ b/ui/e2e/helpers/monaco.ts
@@ -1,0 +1,112 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Type text into a Monaco editor OR fallback textarea
+ * Monaco editors don't support standard page.fill() because they use complex DOM structure.
+ * This helper detects whether Monaco loaded or if we're using the fallback textarea,
+ * and uses the appropriate method to fill the content.
+ */
+export async function fillMonacoEditor(page: Page, testId: string, text: string) {
+  // Wait for the editor container to be visible
+  const editor = page.getByTestId(testId);
+  await editor.waitFor({ state: 'visible', timeout: 10000 });
+
+  // Wait for Monaco to load or timeout (component has 2 second timeout to fallback)
+  // We'll wait up to 8 seconds to be safe (Monaco can be slow in CI)
+  await page.waitForFunction(
+    (testId) => {
+      const container = document.querySelector(`[data-testid="${testId}"]`);
+      if (!container) return false;
+
+      // Check for loading state
+      const isLoading = container.textContent?.includes('Loading editor...');
+      if (isLoading) return false; // Still loading
+
+      // Check if Monaco loaded (has textarea.inputarea)
+      const hasMonaco = container.querySelector('textarea.inputarea') !== null;
+      if (hasMonaco) return true;
+
+      // Check if fallback textarea exists
+      const hasFallback = container.querySelector('textarea') !== null;
+      if (hasFallback) return true;
+
+      return false;
+    },
+    testId,
+    { timeout: 8000 } // Wait up to 8 seconds for Monaco or fallback
+  );
+
+  // Now determine what type of editor we have
+  const monacoTextarea = editor.locator('textarea.inputarea');
+  const fallbackTextarea = editor.locator('textarea').first();
+  const hasMonaco = (await monacoTextarea.count()) > 0;
+
+  if (hasMonaco) {
+    // Monaco editor detected - use keyboard input
+    await editor.click();
+    await page.waitForTimeout(100);
+
+    // Select all and replace
+    await page.keyboard.press('Meta+A');
+    await page.keyboard.type(text, { delay: 5 });
+  } else {
+    // Fallback textarea - use standard fill
+    await fallbackTextarea.fill(text);
+  }
+}
+
+/**
+ * Get the value from a Monaco editor OR fallback textarea
+ */
+export async function getMonacoEditorValue(page: Page, testId: string): Promise<string> {
+  const editor = page.getByTestId(testId);
+
+  // Wait for editor to be ready (same logic as fillMonacoEditor)
+  try {
+    await page.waitForFunction(
+      (testId) => {
+        const container = document.querySelector(`[data-testid="${testId}"]`);
+        if (!container) return false;
+
+        const isLoading = container.textContent?.includes('Loading editor...');
+        if (isLoading) return false;
+
+        const hasMonaco = container.querySelector('textarea.inputarea') !== null;
+        const hasFallback = container.querySelector('textarea') !== null;
+
+        return hasMonaco || hasFallback;
+      },
+      testId,
+      { timeout: 8000 }
+    );
+  } catch (e) {
+    // Log what we found for debugging
+    const content = await editor.textContent();
+    throw new Error(`Editor not ready for test-id ${testId}. Content: ${content}`);
+  }
+
+  // Check if we have Monaco or fallback
+  const monacoLines = editor.locator('.view-line');
+  const monacoTextarea = editor.locator('textarea.inputarea');
+  const fallbackTextarea = editor.locator('textarea').first();
+
+  const hasMonaco = (await monacoTextarea.count()) > 0;
+
+  if (hasMonaco) {
+    // Monaco renders content in .view-line elements
+    const lines = await monacoLines.allTextContents();
+    return lines.join('\n').trim();
+  } else {
+    // Fallback textarea
+    return await fallbackTextarea.inputValue();
+  }
+}
+
+/**
+ * Check if a Monaco editor has a specific value
+ * Useful for assertions in tests
+ */
+export async function expectMonacoEditorValue(page: Page, testId: string, expectedValue: string) {
+  const actualValue = await getMonacoEditorValue(page, testId);
+  return actualValue === expectedValue;
+}

--- a/ui/src/hooks/useEventFacets.ts
+++ b/ui/src/hooks/useEventFacets.ts
@@ -59,7 +59,7 @@ export function useEventFacets(
     setError(null);
 
     try {
-      // EventFacetQuery supports these fields: involvedObject.kind, involvedObject.namespace,
+      // EventFacetQuery supports these fields: regarding.kind, regarding.namespace,
       // namespace, reason, source.component, type
       const result = await client.queryEventFacets({
         timeRange: {
@@ -67,18 +67,18 @@ export function useEventFacets(
           end: timeRange.end,
         },
         facets: [
-          { field: 'involvedObject.kind', limit: 50 },
+          { field: 'regarding.kind', limit: 50 },
           { field: 'reason', limit: 50 },
           { field: 'type', limit: 5 },
           { field: 'source.component', limit: 50 },
-          { field: 'involvedObject.namespace', limit: 50 },
+          { field: 'regarding.namespace', limit: 50 },
         ],
       });
 
       const facets = result.status?.facets || [];
 
       // Extract involved object kinds
-      const kindFacet = facets.find((f) => f.field === 'involvedObject.kind');
+      const kindFacet = facets.find((f) => f.field === 'regarding.kind');
       setInvolvedKinds(kindFacet?.values || []);
 
       // Extract reasons
@@ -94,7 +94,7 @@ export function useEventFacets(
       setSourceComponents(componentFacet?.values || []);
 
       // Extract namespaces from involved objects
-      const namespaceFacet = facets.find((f) => f.field === 'involvedObject.namespace');
+      const namespaceFacet = facets.find((f) => f.field === 'regarding.namespace');
       setNamespaces(namespaceFacet?.values || []);
 
       lastFetchedRef.current = cacheKey;

--- a/ui/src/hooks/useEventsFeed.ts
+++ b/ui/src/hooks/useEventsFeed.ts
@@ -111,37 +111,37 @@ function buildFieldSelector(filters: EventsFeedFilters): string | undefined {
   // Involved object API group filter (multi-select)
   if (filters.involvedApiGroups && filters.involvedApiGroups.length > 0) {
     if (filters.involvedApiGroups.length === 1) {
-      selectors.push(`involvedObject.apiVersion=${filters.involvedApiGroups[0]}`);
+      selectors.push(`regarding.apiVersion=${filters.involvedApiGroups[0]}`);
     } else {
       // Kubernetes field selectors don't support OR, so we'll handle this client-side
       // Just use the first one for server-side filtering
-      selectors.push(`involvedObject.apiVersion=${filters.involvedApiGroups[0]}`);
+      selectors.push(`regarding.apiVersion=${filters.involvedApiGroups[0]}`);
     }
   }
 
   // Involved object kind filter (multi-select)
   if (filters.involvedKinds && filters.involvedKinds.length > 0) {
     if (filters.involvedKinds.length === 1) {
-      selectors.push(`involvedObject.kind=${filters.involvedKinds[0]}`);
+      selectors.push(`regarding.kind=${filters.involvedKinds[0]}`);
     } else {
       // Kubernetes field selectors don't support OR, so we'll handle this client-side
       // Just use the first one for server-side filtering
-      selectors.push(`involvedObject.kind=${filters.involvedKinds[0]}`);
+      selectors.push(`regarding.kind=${filters.involvedKinds[0]}`);
     }
   }
 
   // Involved object name filter
   if (filters.involvedName) {
-    selectors.push(`involvedObject.name=${filters.involvedName}`);
+    selectors.push(`regarding.name=${filters.involvedName}`);
   }
 
   // Namespace filter (multi-select)
   if (filters.namespaces && filters.namespaces.length > 0) {
     if (filters.namespaces.length === 1) {
-      selectors.push(`involvedObject.namespace=${filters.namespaces[0]}`);
+      selectors.push(`regarding.namespace=${filters.namespaces[0]}`);
     } else {
       // Use first namespace for server-side filter
-      selectors.push(`involvedObject.namespace=${filters.namespaces[0]}`);
+      selectors.push(`regarding.namespace=${filters.namespaces[0]}`);
     }
   }
 

--- a/ui/src/types/k8s-event.ts
+++ b/ui/src/types/k8s-event.ts
@@ -119,7 +119,7 @@ export interface K8sEventList {
 export interface K8sEventListParams {
   /** Namespace to list events from (empty for all namespaces) */
   namespace?: string;
-  /** Field selector for filtering (e.g., "involvedObject.name=my-pod") */
+  /** Field selector for filtering (e.g., "regarding.name=my-pod") */
   fieldSelector?: string;
   /** Label selector for filtering */
   labelSelector?: string;
@@ -177,32 +177,32 @@ export interface EventFilterField {
 
 /**
  * Available filter fields for Kubernetes Events
- * These map to field selectors supported by the API (core/v1 Event)
+ * These map to field selectors supported by the API (events.k8s.io/v1)
  */
 export const EVENT_FILTER_FIELDS: EventFilterField[] = [
   {
-    name: 'involvedObject.kind',
+    name: 'regarding.kind',
     type: 'string',
     description: 'Kind of the object this event is about',
     examples: [
-      'involvedObject.kind=Pod',
-      'involvedObject.kind=Deployment',
+      'regarding.kind=Pod',
+      'regarding.kind=Deployment',
     ],
   },
   {
-    name: 'involvedObject.name',
+    name: 'regarding.name',
     type: 'string',
     description: 'Name of the object this event is about',
     examples: [
-      'involvedObject.name=my-pod',
+      'regarding.name=my-pod',
     ],
   },
   {
-    name: 'involvedObject.namespace',
+    name: 'regarding.namespace',
     type: 'string',
     description: 'Namespace of the object this event is about',
     examples: [
-      'involvedObject.namespace=default',
+      'regarding.namespace=default',
     ],
   },
   {
@@ -247,11 +247,11 @@ export const EVENT_FILTER_FIELDS: EventFilterField[] = [
 
 /**
  * Event facet fields available for querying
- * These are the fields supported by EventFacetQuery (core/v1 Event)
+ * These are the fields supported by EventFacetQuery (events.k8s.io/v1)
  */
 export const EVENT_FACET_FIELDS = [
-  'involvedObject.kind',
-  'involvedObject.namespace',
+  'regarding.kind',
+  'regarding.namespace',
   'reason',
   'type',
   'source.component',


### PR DESCRIPTION
## Summary
Updates event field selectors to use the modern `regarding.*` syntax instead of the deprecated `involvedObject.*` syntax.

## User Impact
- Event queries now use `regarding.kind` instead of `involvedObject.kind`
- Event facet filters updated accordingly
- Existing queries using `involvedObject.*` will need to be updated

## Stack
PR 1 of 7 — can be merged independently.

🤖 Generated with [Claude Code](https://claude.ai/code)