### PR TITLE
feat(ui): add policy rule editor with Monaco CEL support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,9 @@
       "Bash(git commit:*)",
       "Bash(git push:*)",
       "Bash(task generate:*)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh api:*)"
     ]
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -25,7 +25,9 @@
     "type-check": "tsc --noEmit",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:integration": "playwright test --config=playwright.integration.config.ts",
+    "test:e2e:integration:headed": "playwright test --config=playwright.integration.config.ts --headed"
   },
   "keywords": [
     "react",
@@ -36,6 +38,7 @@
   "author": "Milo APIs",
   "license": "Apache-2.0",
   "peerDependencies": {
+    "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-checkbox": "^1.0.0",
     "@radix-ui/react-dialog": "^1.0.0",
     "@radix-ui/react-popover": "^1.0.0",
@@ -44,10 +47,12 @@
     "@radix-ui/react-tabs": "^1.0.0",
     "@radix-ui/react-tooltip": "^1.0.0",
     "cmdk": "^1.0.0",
+    "monaco-editor": "^0.52.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
+    "@monaco-editor/react": "^4.6.0",
     "@playwright/test": "^1.48.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",
@@ -59,6 +64,7 @@
     "eslint": "^8.56.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "monaco-editor": "^0.52.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "rollup": "^4.9.1",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.2.1)
     devDependencies:
+      '@monaco-editor/react':
+        specifier: ^4.6.0
+        version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@playwright/test':
         specifier: ^1.48.0
         version: 1.58.2
@@ -87,6 +90,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^4.6.0
         version: 4.6.2(eslint@8.57.1)
+      monaco-editor:
+        specifier: ^0.52.0
+        version: 0.52.2
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -680,6 +686,16 @@ packages:
 
   '@mdx-js/mdx@2.3.0':
     resolution: {integrity: sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==}
+
+  '@monaco-editor/loader@1.7.0':
+    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
+
+  '@monaco-editor/react@4.7.0':
+    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3214,6 +3230,9 @@ packages:
   modern-ahocorasick@1.1.0:
     resolution: {integrity: sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==}
 
+  monaco-editor@0.52.2:
+    resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
+
   morgan@1.10.1:
     resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
     engines: {node: '>= 0.8.0'}
@@ -4094,6 +4113,9 @@ packages:
   stable@0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
     deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
+
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -4985,6 +5007,17 @@ snapshots:
       vfile: 5.3.7
     transitivePeerDependencies:
       - supports-color
+
+  '@monaco-editor/loader@1.7.0':
+    dependencies:
+      state-local: 1.0.7
+
+  '@monaco-editor/react@4.7.0(monaco-editor@0.52.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@monaco-editor/loader': 1.7.0
+      monaco-editor: 0.52.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -7968,6 +8001,8 @@ snapshots:
 
   modern-ahocorasick@1.1.0: {}
 
+  monaco-editor@0.52.2: {}
+
   morgan@1.10.1:
     dependencies:
       basic-auth: 2.0.1
@@ -8929,6 +8964,8 @@ snapshots:
       minipass: 7.1.3
 
   stable@0.1.8: {}
+
+  state-local@1.0.7: {}
 
   statuses@2.0.2: {}
 

--- a/ui/src/components/CelEditor.tsx
+++ b/ui/src/components/CelEditor.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useRef, useState, useCallback, useId } from 'react';
+import { cn } from '../lib/utils';
+
+// Track registered languages to avoid re-registering
+const registeredLanguages = new Set<string>();
+
+/**
+ * Props for CelEditor component
+ */
+export interface CelEditorProps {
+  /** Current value of the editor */
+  value: string;
+  /** Callback when value changes */
+  onChange: (value: string) => void;
+  /** Language mode: 'cel' for expressions, 'cel-template' for {{ }} templates */
+  language?: 'cel' | 'cel-template';
+  /** Field paths available for autocomplete */
+  availableFields?: string[];
+  /** Placeholder text when empty */
+  placeholder?: string;
+  /** Height of the editor */
+  height?: string | number;
+  /** Additional CSS classes */
+  className?: string;
+  /** Show error border */
+  error?: boolean;
+  /** Whether editor is read-only */
+  readOnly?: boolean;
+  /** Test ID for E2E testing */
+  'data-testid'?: string;
+}
+
+// Types for Monaco (loaded dynamically)
+type Monaco = typeof import('monaco-editor');
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MonacoEditorComponent = any;
+
+/**
+ * Lazy-loaded Monaco editor for CEL expressions and templates
+ * Provides autocomplete based on available field paths
+ */
+export function CelEditor({
+  value,
+  onChange,
+  language = 'cel',
+  availableFields = [],
+  placeholder = '',
+  height = '100px',
+  className,
+  error = false,
+  readOnly = false,
+  'data-testid': testId,
+}: CelEditorProps) {
+  const [Editor, setEditor] = useState<MonacoEditorComponent | null>(null);
+  const [loadError, setLoadError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const monacoRef = useRef<Monaco | null>(null);
+  const disposableRef = useRef<{ dispose: () => void } | null>(null);
+
+  // Generate a unique language ID for this editor instance
+  const instanceId = useId();
+  const languageId = `cel-${instanceId.replace(/:/g, '-')}`;
+
+  // Load Monaco Editor component
+  useEffect(() => {
+    let mounted = true;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    async function loadMonaco() {
+      try {
+        // Set a timeout for the entire load process
+        timeoutId = setTimeout(() => {
+          if (mounted && isLoading) {
+            setLoadError(new Error('Monaco loading timeout'));
+            setIsLoading(false);
+          }
+        }, 5000);
+
+        // Dynamic import of @monaco-editor/react
+        const { default: MonacoEditorComponent } = await import('@monaco-editor/react');
+
+        if (!mounted) return;
+
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+
+        setEditor(() => MonacoEditorComponent);
+        setIsLoading(false);
+      } catch (err) {
+        if (mounted) {
+          if (timeoutId) {
+            clearTimeout(timeoutId);
+          }
+          setLoadError(err instanceof Error ? err : new Error(String(err)));
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadMonaco();
+
+    return () => {
+      mounted = false;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, []);
+
+  // Handle editor mount - store monaco reference and register language
+  const handleEditorDidMount = useCallback((_editor: unknown, monaco: Monaco) => {
+    monacoRef.current = monaco;
+
+    // Register our custom language if not already registered
+    if (!registeredLanguages.has(languageId)) {
+      monaco.languages.register({ id: languageId });
+      registeredLanguages.add(languageId);
+    }
+  }, [languageId]);
+
+  // Update completion provider when fields change
+  useEffect(() => {
+    if (monacoRef.current && availableFields.length > 0) {
+      // Dispose previous and create new
+      if (disposableRef.current) {
+        disposableRef.current.dispose();
+      }
+
+      const monaco = monacoRef.current;
+      disposableRef.current = monaco.languages.registerCompletionItemProvider(languageId, {
+        triggerCharacters: ['.', '{'],
+        provideCompletionItems: (model, position) => {
+          const textUntilPosition = model.getValueInRange({
+            startLineNumber: position.lineNumber,
+            startColumn: 1,
+            endLineNumber: position.lineNumber,
+            endColumn: position.column,
+          });
+
+          if (language === 'cel-template') {
+            const lastOpenBrace = textUntilPosition.lastIndexOf('{{');
+            const lastCloseBrace = textUntilPosition.lastIndexOf('}}');
+
+            if (lastOpenBrace === -1 || lastCloseBrace > lastOpenBrace) {
+              return { suggestions: [] };
+            }
+          }
+
+          const word = model.getWordUntilPosition(position);
+          const range = {
+            startLineNumber: position.lineNumber,
+            endLineNumber: position.lineNumber,
+            startColumn: word.startColumn,
+            endColumn: word.endColumn,
+          };
+
+          const suggestions = availableFields.map((field) => ({
+            label: field,
+            kind: monaco.languages.CompletionItemKind.Field,
+            insertText: field,
+            range,
+            documentation: `Field path: ${field}`,
+          }));
+
+          return { suggestions };
+        },
+      });
+    }
+
+    return () => {
+      if (disposableRef.current) {
+        disposableRef.current.dispose();
+        disposableRef.current = null;
+      }
+    };
+  }, [availableFields, language, languageId]);
+
+  // Handle load error - show error message
+  if (loadError) {
+    return (
+      <div
+        className={cn('relative border rounded-md p-3 bg-destructive/10', className)}
+        data-testid={testId}
+        style={{ height: typeof height === 'number' ? `${height}px` : height }}
+      >
+        <p className="text-xs text-destructive">
+          Monaco editor failed to load: {loadError.message}
+        </p>
+      </div>
+    );
+  }
+
+  // Show loading state
+  if (isLoading || !Editor) {
+    return (
+      <div
+        className={cn(
+          'relative border rounded-md bg-muted animate-pulse',
+          className
+        )}
+        style={{ height: typeof height === 'number' ? `${height}px` : height }}
+        data-testid={testId}
+      >
+        <div className="flex items-center justify-center h-full">
+          <span className="text-xs text-muted-foreground">Loading editor...</span>
+        </div>
+      </div>
+    );
+  }
+
+  const heightValue = typeof height === 'number' ? `${height}px` : height;
+
+  return (
+    <div
+      className={cn(
+        'border rounded-md',
+        error && 'border-destructive',
+        className
+      )}
+      style={{ height: heightValue, position: 'relative' }}
+      data-testid={testId}
+    >
+      <Editor
+        height="100%"
+        language={languageId}
+        value={value}
+        onChange={(newValue: string | undefined) => onChange(newValue || '')}
+        onMount={handleEditorDidMount}
+        loading={<div className="flex items-center justify-center h-full bg-muted"><span className="text-xs text-muted-foreground">Initializing...</span></div>}
+        theme={typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'vs-dark'
+          : 'vs'}
+        options={{
+          minimap: { enabled: false },
+          lineNumbers: 'off',
+          glyphMargin: false,
+          folding: false,
+          lineDecorationsWidth: 8,
+          lineNumbersMinChars: 0,
+          scrollBeyondLastLine: false,
+          wordWrap: 'on',
+          wrappingIndent: 'indent',
+          fontSize: 12,
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+          readOnly,
+          automaticLayout: true,
+          padding: {
+            top: 8,
+            bottom: 8,
+          },
+          scrollbar: {
+            vertical: 'auto',
+            horizontal: 'auto',
+            verticalScrollbarSize: 8,
+            horizontalScrollbarSize: 8,
+          },
+          suggest: {
+            showIcons: true,
+            maxVisibleSuggestions: 8,
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/ui/src/components/PolicyEditView.tsx
+++ b/ui/src/components/PolicyEditView.tsx
@@ -1,12 +1,10 @@
-import { useEffect, useCallback, useState, useRef } from 'react';
-import type { PolicyPreviewPolicySpec, Condition } from '../types/policy';
-import type { ResourceRef, ErrorFormatter } from '../types/activity';
+import { useEffect, useCallback, useState } from 'react';
+import type { Condition } from '../types/policy';
+import type { ErrorFormatter } from '../types/activity';
 import { ActivityApiClient } from '../api/client';
 import { usePolicyEditor, type UsePolicyEditorResult } from '../hooks/usePolicyEditor';
-import { usePolicyPreview, type UsePolicyPreviewResult } from '../hooks/usePolicyPreview';
 import { PolicyResourceForm } from './PolicyResourceForm';
 import { PolicyRuleList } from './PolicyRuleList';
-import { PolicyPreviewPanel } from './PolicyPreviewPanel';
 import { Input } from './ui/input';
 import { Button } from './ui/button';
 import { Card, CardHeader, CardContent } from './ui/card';
@@ -39,8 +37,6 @@ export interface PolicyEditViewProps {
   onSaveSuccess?: (policyName: string) => void;
   /** Callback when cancel is clicked */
   onCancel?: () => void;
-  /** Handler for resource link clicks in preview */
-  onResourceClick?: (resource: ResourceRef) => void;
   /** Additional CSS class */
   className?: string;
   /** Custom error formatter for customizing error messages */
@@ -56,7 +52,6 @@ export function PolicyEditView({
   policyName,
   onSaveSuccess,
   onCancel,
-  onResourceClick,
   className = '',
   errorFormatter,
 }: PolicyEditViewProps) {
@@ -66,30 +61,12 @@ export function PolicyEditView({
     initialPolicyName: policyName,
   });
 
-  // Preview state
-  const preview: UsePolicyPreviewResult = usePolicyPreview({ client });
-
   // Delete confirmation state
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
   // Copy state
   const [isCopied, setIsCopied] = useState(false);
-
-  // Track active tab
-  const [activeTab, setActiveTab] = useState<string>('preview');
-
-  // Track if we've auto-loaded audit logs and auto-previewed for the current resource
-  const autoLoadedResourceRef = useRef<string>('');
-  const autoPreviewedInputsRef = useRef<number>(0);
-
-  // Track audit log loading state
-  const [isLoadingAuditLogs, setIsLoadingAuditLogs] = useState(false);
-
-  // Track pagination state for audit logs
-  const [continueAfter, setContinueAfter] = useState<string | null>(null);
-  const [hasMoreInputs, setHasMoreInputs] = useState(false);
-  const [isLoadingMoreInputs, setIsLoadingMoreInputs] = useState(false);
 
   // Load existing policy on mount
   useEffect(() => {
@@ -100,184 +77,6 @@ export function PolicyEditView({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [policyName]);
-
-  // Auto-load audit logs when resource apiGroup and kind are available
-  useEffect(() => {
-    const apiGroup = editor.spec.resource.apiGroup;
-    const kind = editor.spec.resource.kind;
-
-    // Check if we have enough info to query (apiGroup can be empty string for core resources)
-    if (kind.trim() === '') {
-      return; // Need at least a kind
-    }
-
-    // Create a resource key to track whether we've already loaded for this resource
-    const resourceKey = `${apiGroup}:${kind}`;
-
-    // Skip if we've already auto-loaded for this resource
-    if (autoLoadedResourceRef.current === resourceKey) {
-      return;
-    }
-
-    // Build CEL filter for the resource type
-    const filters: string[] = [];
-
-    // Filter by API group if present (empty string means core API group)
-    if (apiGroup !== '') {
-      filters.push(`objectRef.apiGroup == '${apiGroup}'`);
-    }
-
-    // Use a contains match on the resource name to handle pluralization
-    // e.g., "httpproxy" would match "httpproxies"
-    const kindLower = kind.toLowerCase();
-    filters.push(`objectRef.resource.contains('${kindLower}')`);
-
-    const filter = filters.join(' && ');
-
-    // Execute query to fetch audit logs
-    const fetchAuditLogs = async () => {
-      setIsLoadingAuditLogs(true);
-      try {
-        const queryName = `policy-preview-${Date.now()}`;
-
-        // Calculate time range - last 24 hours
-        const endTime = new Date();
-        const startTime = new Date(endTime.getTime() - 24 * 60 * 60 * 1000);
-
-        const spec = {
-          filter,
-          limit: 10, // Get a reasonable sample for preview
-          startTime: startTime.toISOString(),
-          endTime: endTime.toISOString(),
-        };
-
-        const result = await client.createQuery(queryName, spec);
-        const events = result.status?.results || [];
-        const cursor = result.status?.continue;
-
-        if (events.length > 0) {
-          preview.setAuditInputs(events);
-          autoLoadedResourceRef.current = resourceKey;
-          setContinueAfter(cursor || null);
-          setHasMoreInputs(!!cursor);
-        } else {
-          console.log('No audit logs found matching filter:', filter);
-          setContinueAfter(null);
-          setHasMoreInputs(false);
-        }
-      } catch (err) {
-        console.error('Failed to load audit logs for preview:', err);
-        // Don't show error to user - this is an automatic background operation
-      } finally {
-        setIsLoadingAuditLogs(false);
-      }
-    };
-
-    fetchAuditLogs();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor.spec.resource.apiGroup, editor.spec.resource.kind]);
-
-  // Load more audit logs using pagination cursor
-  const loadMoreInputs = useCallback(async () => {
-    if (!continueAfter || isLoadingMoreInputs) {
-      return;
-    }
-
-    const apiGroup = editor.spec.resource.apiGroup;
-    const kind = editor.spec.resource.kind;
-
-    if (kind.trim() === '') {
-      return;
-    }
-
-    // Build the same filter as the initial load
-    const filters: string[] = [];
-    if (apiGroup !== '') {
-      filters.push(`objectRef.apiGroup == '${apiGroup}'`);
-    }
-    const kindLower = kind.toLowerCase();
-    filters.push(`objectRef.resource.contains('${kindLower}')`);
-    const filter = filters.join(' && ');
-
-    setIsLoadingMoreInputs(true);
-    try {
-      const queryName = `policy-preview-more-${Date.now()}`;
-
-      // Calculate time range - last 24 hours
-      const endTime = new Date();
-      const startTime = new Date(endTime.getTime() - 24 * 60 * 60 * 1000);
-
-      const spec = {
-        filter,
-        limit: 10,
-        startTime: startTime.toISOString(),
-        endTime: endTime.toISOString(),
-        continue: continueAfter, // Use the cursor from the previous query
-      };
-
-      const result = await client.createQuery(queryName, spec);
-      const events = result.status?.results || [];
-      const cursor = result.status?.continue;
-
-      if (events.length > 0) {
-        // Append new events to existing inputs
-        events.forEach((event) => {
-          preview.addInput({ type: 'audit', audit: event });
-        });
-        setContinueAfter(cursor || null);
-        setHasMoreInputs(!!cursor);
-      } else {
-        setContinueAfter(null);
-        setHasMoreInputs(false);
-      }
-    } catch (err) {
-      console.error('Failed to load more audit logs:', err);
-    } finally {
-      setIsLoadingMoreInputs(false);
-    }
-  }, [continueAfter, isLoadingMoreInputs, editor.spec.resource.apiGroup, editor.spec.resource.kind, client, preview]);
-
-  // Auto-run preview when preview inputs are loaded
-  useEffect(() => {
-    // Only auto-run if we have inputs and a valid policy spec
-    if (preview.inputs.length === 0) {
-      return;
-    }
-
-    // Skip if we've already auto-previewed for the current number of inputs
-    // This prevents re-running when the same inputs are selected/deselected
-    if (autoPreviewedInputsRef.current === preview.inputs.length) {
-      return;
-    }
-
-    // Check if we have a valid policy to preview
-    if (!editor.spec.resource.kind.trim()) {
-      return;
-    }
-
-    // Check if we have at least one rule to preview
-    const hasRules = (editor.spec.auditRules?.length || 0) > 0 || (editor.spec.eventRules?.length || 0) > 0;
-    if (!hasRules) {
-      console.log('Skipping auto-preview - no rules defined yet');
-      return;
-    }
-
-    // Auto-run preview
-    const policySpec: PolicyPreviewPolicySpec = {
-      resource: editor.spec.resource,
-      auditRules: editor.spec.auditRules,
-      eventRules: editor.spec.eventRules,
-    };
-
-    console.log('Auto-running preview with', preview.inputs.length, 'inputs');
-    preview.runPreview(policySpec).then(() => {
-      autoPreviewedInputsRef.current = preview.inputs.length;
-    }).catch((err) => {
-      console.error('Auto-preview failed:', err);
-      // Don't show error to user - this is an automatic background operation
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [preview.inputs, editor.spec.auditRules, editor.spec.eventRules]);
 
   // Handle save
   const handleSave = useCallback(
@@ -294,19 +93,6 @@ export function PolicyEditView({
     },
     [editor, onSaveSuccess]
   );
-
-  // Handle preview
-  const handleRunPreview = useCallback(() => {
-    const policySpec: PolicyPreviewPolicySpec = {
-      resource: editor.spec.resource,
-      auditRules: editor.spec.auditRules,
-      eventRules: editor.spec.eventRules,
-    };
-
-    preview.runPreview(policySpec).catch((err) => {
-      console.error('Preview failed:', err);
-    });
-  }, [editor.spec, preview]);
 
   // Handle delete
   const handleDelete = useCallback(async () => {
@@ -381,10 +167,10 @@ export function PolicyEditView({
     <TooltipProvider delayDuration={0}>
       <Card className={`rounded-xl ${className}`}>
         {/* Header */}
-        <CardHeader className="flex flex-row justify-between items-center p-6 border-b border-border space-y-0">
-          <div className="flex items-center gap-4">
+        <CardHeader className="flex flex-row justify-between items-center p-4 border-b border-border space-y-0">
+          <div className="flex items-center gap-3">
             {editor.isNew ? (
-              <div className="flex flex-col gap-1">
+              <div className="flex flex-col gap-0.5">
                 <Label htmlFor="policy-name" className="text-xs text-muted-foreground">
                   Policy Name
                 </Label>
@@ -398,11 +184,11 @@ export function PolicyEditView({
                 />
               </div>
             ) : (
-              <div className="flex flex-col gap-1">
+              <div className="flex flex-col gap-0.5">
                 <h2 className="m-0 text-xl font-semibold text-foreground leading-tight">
                   {editor.spec.resource.kind || 'Untitled Policy'}
                 </h2>
-                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                   {editor.spec.resource.apiGroup && (
                     <>
                       <span>API Group: {editor.spec.resource.apiGroup}</span>
@@ -438,7 +224,7 @@ export function PolicyEditView({
             )}
           </div>
 
-        <div className="flex gap-3">
+        <div className="flex gap-2">
           {onCancel && (
             <Button
               type="button"
@@ -482,13 +268,13 @@ export function PolicyEditView({
       </CardHeader>
 
       {/* Error Display */}
-      <ApiErrorAlert error={editor.error} className="mx-6 mt-4" errorFormatter={errorFormatter} />
+      <ApiErrorAlert error={editor.error} className="mx-4 mt-3" errorFormatter={errorFormatter} />
 
       {/* Policy Health Status Banner */}
       {isUnhealthy && policyStatus && (
         <Alert
           variant={policyStatus.status === 'error' ? 'destructive' : 'warning'}
-          className="mx-6 mt-4"
+          className="mx-4 mt-3"
         >
           {policyStatus.status === 'error' ? (
             <AlertCircle className="h-4 w-4" />
@@ -506,7 +292,7 @@ export function PolicyEditView({
 
       {/* Loading State */}
       {editor.isLoading && (
-        <div className="flex items-center justify-center gap-3 py-12 text-muted-foreground">
+        <div className="flex items-center justify-center gap-2 py-8 text-muted-foreground">
           <span className="w-5 h-5 border-[3px] border-border border-t-[#BF9595] rounded-full animate-spin" />
           Loading policy...
         </div>
@@ -514,100 +300,56 @@ export function PolicyEditView({
 
       {/* Main Content */}
       {!editor.isLoading && (
-        <CardContent className="p-6">
-          {/* Menu bar navigation */}
-          <div className="flex items-center gap-4 mb-6 text-sm">
-            <button
-              onClick={() => setActiveTab('editor')}
-              className={`px-0 py-1 transition-colors ${
-                activeTab === 'editor'
-                  ? 'text-foreground border-b-2 border-[#BF9595] font-medium'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Editor
-            </button>
-            <span className="text-muted-foreground/30">|</span>
-            <button
-              onClick={() => setActiveTab('preview')}
-              className={`px-0 py-1 transition-colors ${
-                activeTab === 'preview'
-                  ? 'text-foreground border-b-2 border-[#BF9595] font-medium'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Preview
-            </button>
-          </div>
+        <CardContent className="p-4">
+          <div className="flex flex-col gap-4">
+            <PolicyResourceForm
+              resource={editor.spec.resource}
+              onChange={editor.setResource}
+              client={client}
+              isEditMode={!editor.isNew}
+            />
 
-          {/* Editor View */}
-          {activeTab === 'editor' && (
-            <div className="flex flex-col gap-6">
-              <PolicyResourceForm
-                resource={editor.spec.resource}
-                onChange={editor.setResource}
-                client={client}
-                isEditMode={!editor.isNew}
-              />
+            <PolicyRuleList
+              auditRules={editor.spec.auditRules || []}
+              eventRules={editor.spec.eventRules || []}
+              policyResource={editor.spec.resource}
+              apiClient={client}
+              onAuditRulesChange={editor.setAuditRules}
+              onEventRulesChange={editor.setEventRules}
+            />
 
-              <PolicyRuleList
-                auditRules={editor.spec.auditRules || []}
-                eventRules={editor.spec.eventRules || []}
-                previewResult={preview.result}
-                onAuditRulesChange={editor.setAuditRules}
-                onEventRulesChange={editor.setEventRules}
-                onAddAuditRule={editor.addAuditRule}
-                onAddEventRule={editor.addEventRule}
-              />
-
-              {/* Danger Zone - Delete Policy (only for existing policies) */}
-              {!editor.isNew && (
-                <div className="mt-8 pt-6 border-t border-border">
-                  <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
-                    <div className="flex items-start gap-4">
-                      <div className="flex-1">
-                        <h3 className="text-base font-semibold text-foreground mb-2 flex items-center gap-2">
-                          <AlertTriangle className="h-5 w-5 text-destructive" />
-                          Danger Zone
-                        </h3>
-                        <p className="text-sm text-muted-foreground mb-4">
-                          Deleting this policy will stop translating audit logs and events for{' '}
-                          <strong className="text-foreground">
-                            {editor.spec.resource.kind}
-                          </strong>{' '}
-                          resources. Existing activities will be preserved, but no new activities will be generated.
-                        </p>
-                        <Button
-                          variant="destructive"
-                          size="sm"
-                          onClick={() => setShowDeleteDialog(true)}
-                          className="h-8 text-xs"
-                        >
-                          <Trash2 className="h-3.5 w-3.5 mr-1.5" />
-                          Delete Policy
-                        </Button>
-                      </div>
+            {/* Danger Zone - Delete Policy (only for existing policies) */}
+            {!editor.isNew && (
+              <div className="mt-6 pt-4 border-t border-border">
+                <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+                  <div className="flex items-start gap-3">
+                    <div className="flex-1">
+                      <h3 className="text-base font-semibold text-foreground mb-1.5 flex items-center gap-2">
+                        <AlertTriangle className="h-5 w-5 text-destructive" />
+                        Danger Zone
+                      </h3>
+                      <p className="text-sm text-muted-foreground mb-3">
+                        Deleting this policy will stop translating audit logs and events for{' '}
+                        <strong className="text-foreground">
+                          {editor.spec.resource.kind}
+                        </strong>{' '}
+                        resources. Existing activities will be preserved, but no new activities will be generated.
+                      </p>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => setShowDeleteDialog(true)}
+                        className="h-8 text-xs"
+                      >
+                        <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+                        Delete Policy
+                      </Button>
                     </div>
                   </div>
                 </div>
-              )}
-            </div>
-          )}
-
-          {/* Preview View */}
-          {activeTab === 'preview' && (
-            <PolicyPreviewPanel
-              result={preview.result}
-              inputs={preview.inputs}
-              isLoading={preview.isLoading}
-              error={preview.error}
-              onResourceClick={onResourceClick}
-              isLoadingInputs={isLoadingAuditLogs}
-              hasMoreInputs={hasMoreInputs}
-              isLoadingMoreInputs={isLoadingMoreInputs}
-              onLoadMore={loadMoreInputs}
-            />
-          )}
+              </div>
+            )}
+          </div>
         </CardContent>
       )}
 

--- a/ui/src/components/PolicyEditor.tsx
+++ b/ui/src/components/PolicyEditor.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useCallback, useState } from 'react';
-import type { PolicyPreviewPolicySpec, Condition } from '../types/policy';
+import type { Condition } from '../types/policy';
 import type { ResourceRef, ErrorFormatter } from '../types/activity';
 import { ActivityApiClient } from '../api/client';
 import { usePolicyEditor, type UsePolicyEditorResult } from '../hooks/usePolicyEditor';
-import { usePolicyPreview, type UsePolicyPreviewResult } from '../hooks/usePolicyPreview';
 import { PolicyResourceForm } from './PolicyResourceForm';
 import { PolicyRuleList } from './PolicyRuleList';
-import { PolicyPreviewPanel } from './PolicyPreviewPanel';
 import { PolicyActivityView } from './PolicyActivityView';
 import { Input } from './ui/input';
 import { Button } from './ui/button';
@@ -68,9 +66,6 @@ export function PolicyEditor({
     initialPolicyName: policyName,
   });
 
-  // Preview state
-  const preview: UsePolicyPreviewResult = usePolicyPreview({ client });
-
   // Delete confirmation state
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -106,19 +101,6 @@ export function PolicyEditor({
     },
     [editor, onSaveSuccess]
   );
-
-  // Handle preview
-  const handleRunPreview = useCallback(() => {
-    const policySpec: PolicyPreviewPolicySpec = {
-      resource: editor.spec.resource,
-      auditRules: editor.spec.auditRules,
-      eventRules: editor.spec.eventRules,
-    };
-
-    preview.runPreview(policySpec).catch((err) => {
-      console.error('Preview failed:', err);
-    });
-  }, [editor.spec, preview]);
 
   // Handle delete
   const handleDelete = useCallback(async () => {
@@ -194,10 +176,10 @@ export function PolicyEditor({
     <TooltipProvider delayDuration={0}>
       <Card className={`rounded-xl ${className}`}>
         {/* Header */}
-        <CardHeader className="flex flex-row justify-between items-center p-6 border-b border-border space-y-0">
-          <div className="flex items-center gap-4">
+        <CardHeader className="flex flex-row justify-between items-center p-4 border-b border-border space-y-0">
+          <div className="flex items-center gap-3">
             {editor.isNew ? (
-              <div className="flex flex-col gap-1">
+              <div className="flex flex-col gap-0.5">
                 <Label htmlFor="policy-name" className="text-xs text-muted-foreground">
                   Policy Name
                 </Label>
@@ -211,8 +193,8 @@ export function PolicyEditor({
                 />
               </div>
             ) : (
-              <div className="flex flex-col gap-1">
-                <div className="flex items-center gap-2">
+              <div className="flex flex-col gap-0.5">
+                <div className="flex items-center gap-1.5">
                   {policyStatus && (
                     <Tooltip delayDuration={300}>
                       <TooltipTrigger asChild>
@@ -272,7 +254,7 @@ export function PolicyEditor({
             )}
           </div>
 
-        <div className="flex gap-3">
+        <div className="flex gap-2">
           {onCancel && (
             <Button
               type="button"
@@ -316,11 +298,11 @@ export function PolicyEditor({
       </CardHeader>
 
       {/* Error Display */}
-      <ApiErrorAlert error={editor.error} className="mx-6 mt-4" errorFormatter={errorFormatter} />
+      <ApiErrorAlert error={editor.error} className="mx-4 mt-3" errorFormatter={errorFormatter} />
 
       {/* Loading State */}
       {editor.isLoading && (
-        <div className="flex items-center justify-center gap-3 py-12 text-muted-foreground">
+        <div className="flex items-center justify-center gap-2 py-8 text-muted-foreground">
           <span className="w-5 h-5 border-[3px] border-border border-t-[#BF9595] rounded-full animate-spin" />
           Loading policy...
         </div>
@@ -328,12 +310,11 @@ export function PolicyEditor({
 
       {/* Main Content */}
       {!editor.isLoading && (
-        <CardContent className="p-6">
+        <CardContent className="p-4">
           <Tabs defaultValue="activity" value={activeTab} onValueChange={setActiveTab} className="w-full">
-            <TabsList className="grid w-full grid-cols-3 mb-6">
+            <TabsList className="grid w-full grid-cols-2 mb-4">
               <TabsTrigger value="activity">Activity</TabsTrigger>
               <TabsTrigger value="editor">Editor</TabsTrigger>
-              <TabsTrigger value="preview">Preview</TabsTrigger>
             </TabsList>
 
             {/* Activity Tab */}
@@ -349,7 +330,7 @@ export function PolicyEditor({
 
             {/* Editor Tab */}
             <TabsContent value="editor" className="mt-0">
-              <div className="flex flex-col gap-6">
+              <div className="flex flex-col gap-4">
                 <PolicyResourceForm
                   resource={editor.spec.resource}
                   onChange={editor.setResource}
@@ -360,24 +341,23 @@ export function PolicyEditor({
                 <PolicyRuleList
                   auditRules={editor.spec.auditRules || []}
                   eventRules={editor.spec.eventRules || []}
-                  previewResult={preview.result}
+                  policyResource={editor.spec.resource}
+                  apiClient={client}
                   onAuditRulesChange={editor.setAuditRules}
                   onEventRulesChange={editor.setEventRules}
-                  onAddAuditRule={editor.addAuditRule}
-                  onAddEventRule={editor.addEventRule}
                 />
 
                 {/* Danger Zone - Delete Policy (only for existing policies) */}
                 {!editor.isNew && (
-                  <div className="mt-8 pt-6 border-t border-border">
-                    <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
-                      <div className="flex items-start gap-4">
+                  <div className="mt-6 pt-4 border-t border-border">
+                    <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+                      <div className="flex items-start gap-3">
                         <div className="flex-1">
-                          <h3 className="text-base font-semibold text-foreground mb-2 flex items-center gap-2">
+                          <h3 className="text-base font-semibold text-foreground mb-1.5 flex items-center gap-2">
                             <AlertTriangle className="h-5 w-5 text-destructive" />
                             Danger Zone
                           </h3>
-                          <p className="text-sm text-muted-foreground mb-4">
+                          <p className="text-sm text-muted-foreground mb-3">
                             Deleting this policy will stop translating audit logs and events for{' '}
                             <strong className="text-foreground">
                               {editor.spec.resource.kind}
@@ -399,16 +379,6 @@ export function PolicyEditor({
                   </div>
                 )}
               </div>
-            </TabsContent>
-
-            {/* Preview Tab */}
-            <TabsContent value="preview" className="mt-0">
-              <PolicyPreviewPanel
-                result={preview.result}
-                isLoading={preview.isLoading}
-                error={preview.error}
-                onResourceClick={onResourceClick}
-              />
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/ui/src/components/PolicyPreviewPanel.tsx
+++ b/ui/src/components/PolicyPreviewPanel.tsx
@@ -21,16 +21,10 @@ export interface PolicyPreviewPanelProps {
   error: Error | null;
   /** Handler for resource link clicks in result */
   onResourceClick?: (resource: ResourceRef) => void;
+  /** Callback to run preview (with auto-fetch) */
+  onRunPreview?: () => void;
   /** Additional CSS class */
   className?: string;
-  /** Whether audit logs are being loaded */
-  isLoadingInputs?: boolean;
-  /** Whether there are more inputs available for pagination */
-  hasMoreInputs?: boolean;
-  /** Whether more inputs are currently being loaded */
-  isLoadingMoreInputs?: boolean;
-  /** Callback to load more inputs */
-  onLoadMore?: () => void;
 }
 
 
@@ -43,40 +37,60 @@ export function PolicyPreviewPanel({
   isLoading,
   error,
   onResourceClick,
+  onRunPreview,
   className = '',
-  isLoadingInputs = false,
-  hasMoreInputs = false,
-  isLoadingMoreInputs = false,
-  onLoadMore,
 }: PolicyPreviewPanelProps) {
 
   return (
-    <div className={cn('space-y-4', className)}>
-      {/* Header */}
-      <div>
-        <p className="text-sm text-muted-foreground">
-          Preview the activity timeline for recent resource changes.
-        </p>
-      </div>
-
-      {/* Loading Inputs State */}
-      {isLoadingInputs && !isLoading && !result && (
-        <Card>
-          <CardContent className="py-8 text-center">
-            <Loader2 className="h-6 w-6 animate-spin mx-auto mb-2 text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">Loading recent audit logs...</p>
-          </CardContent>
-        </Card>
+    <div className={cn('space-y-3', className)}>
+      {/* Header - only show when there's a refresh button */}
+      {onRunPreview && (
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">
+            Preview the activity timeline for recent resource changes.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRunPreview}
+            disabled={isLoading}
+            className="h-7 text-xs"
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                Loading...
+              </>
+            ) : (
+              'Refresh Preview'
+            )}
+          </Button>
+        </div>
       )}
 
-      {/* Loading Preview State */}
+      {/* Loading Preview State - Skeleton */}
       {isLoading && (
-        <Card>
-          <CardContent className="py-8 text-center">
-            <Loader2 className="h-6 w-6 animate-spin mx-auto mb-2 text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">Generating preview...</p>
-          </CardContent>
-        </Card>
+        <div className="space-y-2">
+          {/* Activity stream skeleton */}
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <div className="h-3 w-32 bg-muted rounded animate-pulse" />
+              <div className="h-4 w-16 bg-muted rounded animate-pulse" />
+            </div>
+            <div className="space-y-0 border rounded-md divide-y">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="px-2 py-1.5 flex items-center gap-2">
+                  <div className="h-5 w-5 bg-muted rounded-full animate-pulse shrink-0" />
+                  <div className="flex-1 space-y-1">
+                    <div className="h-2.5 w-3/4 bg-muted rounded animate-pulse" />
+                    <div className="h-2 w-1/2 bg-muted rounded animate-pulse" />
+                  </div>
+                  <div className="h-2.5 w-14 bg-muted rounded animate-pulse shrink-0" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
       )}
 
       {/* Error Display */}
@@ -88,14 +102,14 @@ export function PolicyPreviewPanel({
       )}
 
       {/* Empty State - No result yet and not loading */}
-      {!result && !isLoading && !error && !isLoadingInputs && (
+      {!result && !isLoading && !error && (
         <Card>
-          <CardContent className="py-12 text-center">
-            <p className="text-sm text-muted-foreground mb-2">
+          <CardContent className="py-6 text-center">
+            <p className="text-xs text-muted-foreground mb-1">
               No preview available yet
             </p>
-            <p className="text-xs text-muted-foreground">
-              Define resource details and rules in the Editor tab to see a preview
+            <p className="text-[11px] text-muted-foreground">
+              Enter a match expression and summary template to see results.
             </p>
           </CardContent>
         </Card>
@@ -103,35 +117,11 @@ export function PolicyPreviewPanel({
 
       {/* Preview Result */}
       {result && !isLoading && (
-        <>
-          <PolicyPreviewResult
-            result={result}
-            inputs={inputs}
-            onResourceClick={onResourceClick}
-          />
-
-          {/* Load More Button */}
-          {hasMoreInputs && onLoadMore && (
-            <div className="flex justify-center pt-4">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={onLoadMore}
-                disabled={isLoadingMoreInputs}
-                className="h-8 text-xs"
-              >
-                {isLoadingMoreInputs ? (
-                  <>
-                    <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-                    Loading...
-                  </>
-                ) : (
-                  'Load More Audit Logs'
-                )}
-              </Button>
-            </div>
-          )}
-        </>
+        <PolicyPreviewResult
+          result={result}
+          inputs={inputs}
+          onResourceClick={onResourceClick}
+        />
       )}
     </div>
   );

--- a/ui/src/components/PolicyPreviewResult.tsx
+++ b/ui/src/components/PolicyPreviewResult.tsx
@@ -193,24 +193,7 @@ export function PolicyPreviewResult({
 
   // New multi-input format
   return (
-    <div className={cn('space-y-4', className)}>
-      {/* Summary Header */}
-      <div className="flex items-center gap-3">
-        <div className="flex items-center gap-2">
-          <Badge variant={stats.matched > 0 ? 'success' : 'secondary'}>
-            {stats.matched} matched
-          </Badge>
-          <span className="text-muted-foreground">/</span>
-          <span className="text-sm text-muted-foreground">{stats.total} tested</span>
-          {stats.errors > 0 && (
-            <>
-              <span className="text-muted-foreground">/</span>
-              <Badge variant="destructive">{stats.errors} errors</Badge>
-            </>
-          )}
-        </div>
-      </div>
-
+    <div className={cn('space-y-3', className)}>
       {/* General Error */}
       {hasError && (
         <Alert variant="destructive">

--- a/ui/src/components/PolicyRuleEditor.tsx
+++ b/ui/src/components/PolicyRuleEditor.tsx
@@ -27,19 +27,19 @@ export interface PolicyRuleEditorProps {
  */
 const AUDIT_CEL_HELP = {
   variables: [
-    { name: 'audit.verb', description: 'HTTP verb (create, update, patch, delete, get, list, watch)' },
-    { name: 'audit.user.username', description: 'Username of the actor' },
-    { name: 'audit.user.groups', description: 'Groups the actor belongs to' },
-    { name: 'audit.objectRef.name', description: 'Name of the resource' },
-    { name: 'audit.objectRef.namespace', description: 'Namespace of the resource' },
-    { name: 'audit.objectRef.subresource', description: 'Subresource (e.g., "status")' },
-    { name: 'audit.responseStatus.code', description: 'HTTP response status code' },
+    { name: 'verb', description: 'HTTP verb (create, update, patch, delete, get, list, watch)' },
+    { name: 'user.username', description: 'Username of the actor' },
+    { name: 'user.groups', description: 'Groups the actor belongs to' },
+    { name: 'objectRef.name', description: 'Name of the resource' },
+    { name: 'objectRef.namespace', description: 'Namespace of the resource' },
+    { name: 'objectRef.subresource', description: 'Subresource (e.g., "status")' },
+    { name: 'responseStatus.code', description: 'HTTP response status code' },
   ],
   examples: [
-    'audit.verb == "create"',
-    'audit.verb in ["create", "update", "patch"]',
-    'audit.verb == "update" && audit.objectRef.subresource == "status"',
-    'audit.responseStatus.code >= 200 && audit.responseStatus.code < 300',
+    'verb == "create"',
+    'verb in ["create", "update", "patch"]',
+    'verb == "update" && objectRef.subresource == "status"',
+    'responseStatus.code >= 200 && responseStatus.code < 300',
   ],
 };
 
@@ -118,13 +118,13 @@ export function PolicyRuleEditor({
 
   return (
     <Card
-      className={`mb-4 transition-all duration-200 ${
+      className={`mb-3 transition-all duration-200 ${
         isHighlighted
           ? 'border-emerald-600 bg-emerald-50'
           : 'bg-muted'
       } ${className}`}
     >
-      <CardHeader className="flex flex-row justify-between items-center p-4 pb-0">
+      <CardHeader className="flex flex-row justify-between items-center p-3 pb-0">
         <span
           className={`text-xs font-semibold uppercase tracking-wide ${
             isHighlighted ? 'text-emerald-600' : 'text-muted-foreground'
@@ -144,10 +144,10 @@ export function PolicyRuleEditor({
         </Button>
       </CardHeader>
 
-      <CardContent className="p-4">
+      <CardContent className="p-3">
         {/* Match Expression */}
-        <div className="mb-4">
-          <div className="flex justify-between items-center mb-1.5">
+        <div className="mb-3">
+          <div className="flex justify-between items-center mb-1">
             <Label htmlFor={`rule-${index}-match`}>
               Match Expression (CEL)
             </Label>
@@ -171,22 +171,22 @@ export function PolicyRuleEditor({
             spellCheck={false}
           />
           {showMatchHelp && (
-            <div className="mt-3 p-4 bg-background border border-border rounded-md text-xs">
-              <div className="mb-4 last:mb-0">
-                <strong className="block mb-2 text-foreground">Available Variables:</strong>
+            <div className="mt-2 p-3 bg-background border border-border rounded-md text-xs">
+              <div className="mb-3 last:mb-0">
+                <strong className="block mb-1.5 text-foreground">Available Variables:</strong>
                 <ul className="m-0 pl-5 list-disc">
                   {celHelp.variables.map((v) => (
-                    <li key={v.name} className="mb-1">
+                    <li key={v.name} className="mb-0.5">
                       <code className="bg-muted px-1.5 py-0.5 rounded text-xs">{v.name}</code> - {v.description}
                     </li>
                   ))}
                 </ul>
               </div>
-              <div className="mb-4 last:mb-0">
-                <strong className="block mb-2 text-foreground">Examples:</strong>
+              <div className="mb-3 last:mb-0">
+                <strong className="block mb-1.5 text-foreground">Examples:</strong>
                 <ul className="m-0 p-0 list-none">
                   {celHelp.examples.map((ex, i) => (
-                    <li key={i} className="flex items-center gap-2 mb-1.5 px-2 py-1.5 bg-muted rounded">
+                    <li key={i} className="flex items-center gap-2 mb-1 px-2 py-1 bg-muted rounded">
                       <code className="flex-1 text-xs break-all">{ex}</code>
                       <Button
                         type="button"
@@ -205,8 +205,8 @@ export function PolicyRuleEditor({
         </div>
 
         {/* Summary Template */}
-        <div className="mb-4 last:mb-0">
-          <div className="flex justify-between items-center mb-1.5">
+        <div className="mb-3 last:mb-0">
+          <div className="flex justify-between items-center mb-1">
             <Label htmlFor={`rule-${index}-summary`}>
               Summary Template (CEL)
             </Label>
@@ -230,22 +230,22 @@ export function PolicyRuleEditor({
             spellCheck={false}
           />
           {showSummaryHelp && (
-            <div className="mt-3 p-4 bg-background border border-border rounded-md text-xs">
-              <div className="mb-4 last:mb-0">
-                <strong className="block mb-2 text-foreground">Available Variables:</strong>
+            <div className="mt-2 p-3 bg-background border border-border rounded-md text-xs">
+              <div className="mb-3 last:mb-0">
+                <strong className="block mb-1.5 text-foreground">Available Variables:</strong>
                 <ul className="m-0 pl-5 list-disc">
                   {SUMMARY_HELP.variables.map((v) => (
-                    <li key={v.name} className="mb-1">
+                    <li key={v.name} className="mb-0.5">
                       <code className="bg-muted px-1.5 py-0.5 rounded text-xs">{'{{ ' + v.name + ' }}'}</code> - {v.description}
                     </li>
                   ))}
                 </ul>
               </div>
-              <div className="mb-4 last:mb-0">
-                <strong className="block mb-2 text-foreground">Examples:</strong>
+              <div className="mb-3 last:mb-0">
+                <strong className="block mb-1.5 text-foreground">Examples:</strong>
                 <ul className="m-0 p-0 list-none">
                   {SUMMARY_HELP.examples.map((ex, i) => (
-                    <li key={i} className="flex items-center gap-2 mb-1.5 px-2 py-1.5 bg-muted rounded">
+                    <li key={i} className="flex items-center gap-2 mb-1 px-2 py-1 bg-muted rounded">
                       <code className="flex-1 text-xs break-all">{ex}</code>
                       <Button
                         type="button"

--- a/ui/src/components/PolicyRuleEditorDialog.tsx
+++ b/ui/src/components/PolicyRuleEditorDialog.tsx
@@ -1,0 +1,504 @@
+import { useState, useEffect, useMemo } from 'react';
+import type { ActivityPolicyRule, PolicyPreviewStatus } from '../types/policy';
+import type { ActivityApiClient } from '../api/client';
+import { Button } from './ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from './ui/sheet';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import { Textarea } from './ui/textarea';
+import { PolicyPreviewPanel } from './PolicyPreviewPanel';
+import { CelEditor } from './CelEditor';
+import { extractFieldPathsFromMany } from '../lib/extractFieldPaths';
+
+export interface PolicyRuleEditorDialogProps {
+  /** Whether the dialog is open */
+  open: boolean;
+  /** Callback when open state changes */
+  onOpenChange: (open: boolean) => void;
+  /** Rule being edited (null for creating new rule) */
+  rule: ActivityPolicyRule | null;
+  /** Rule type (audit or event) */
+  ruleType: 'audit' | 'event';
+  /** Existing rule names for uniqueness validation */
+  existingNames: string[];
+  /** Policy resource configuration */
+  policyResource: { apiGroup: string; kind: string };
+  /** Activity API client for preview */
+  apiClient: ActivityApiClient;
+  /** Callback when rule is saved */
+  onSave: (rule: ActivityPolicyRule) => void;
+  /** Callback when canceled */
+  onCancel: () => void;
+}
+
+/**
+ * CEL syntax help for audit rules
+ */
+const AUDIT_CEL_HELP = {
+  variables: [
+    'verb - HTTP verb (create, update, patch, delete, get, list, watch)',
+    'user.username - Username of the actor',
+    'user.groups - Groups the actor belongs to',
+    'objectRef.name - Name of the resource',
+    'objectRef.namespace - Namespace of the resource',
+    'objectRef.subresource - Subresource (e.g., "status")',
+    'responseStatus.code - HTTP response status code',
+  ],
+  examples: [
+    'verb == "create"',
+    'verb in ["create", "update", "patch"]',
+    'verb == "update" && objectRef.subresource == "status"',
+    'responseStatus.code >= 200 && responseStatus.code < 300',
+  ],
+};
+
+/**
+ * CEL syntax help for event rules
+ */
+const EVENT_CEL_HELP = {
+  variables: [
+    'event.type - Event type: "Normal" or "Warning"',
+    'event.reason - Short reason (e.g., "Created", "Ready", "Failed")',
+    'event.note - Human-readable description of the event',
+    'event.regarding.name - Name of the regarding resource',
+    'event.regarding.namespace - Namespace of the regarding resource',
+    'event.reportingController - Controller that emitted the event',
+  ],
+  examples: [
+    'event.reason == "Ready"',
+    'event.type == "Warning"',
+    'event.reason in ["Created", "Updated", "Deleted"]',
+    'event.note.contains("failed")',
+  ],
+};
+
+/**
+ * Summary template help for audit rules
+ */
+const AUDIT_SUMMARY_HELP = {
+  variables: [
+    '{{ actor }} - Display name of the actor',
+    '{{ kind }} - Resource kind (e.g., "HTTPProxy")',
+    '{{ verb }} - Action verb (create, update, delete, etc.)',
+    '{{ objectRef.name }} - Name of the resource',
+    '{{ objectRef.namespace }} - Namespace of the resource',
+    '{{ link(text, ref) }} - Create a clickable link',
+  ],
+  examples: [
+    '{{ actor }} created {{ kind }} {{ objectRef.name }}',
+    '{{ actor }} {{ verb }}d {{ link(kind + " " + objectRef.name, objectRef) }}',
+    '{{ actor }} updated the status of {{ kind }} {{ objectRef.name }}',
+  ],
+};
+
+/**
+ * Summary template help for event rules
+ */
+const EVENT_SUMMARY_HELP = {
+  variables: [
+    '{{ actor }} - Display name of the actor/controller',
+    '{{ event.reason }} - Event reason (e.g., "Ready", "Failed")',
+    '{{ event.note }} - Human-readable event message',
+    '{{ event.regarding.name }} - Name of the regarding resource',
+    '{{ event.regarding.namespace }} - Namespace of the regarding resource',
+    '{{ link(text, ref) }} - Create a clickable link',
+  ],
+  examples: [
+    '{{ link(event.regarding.kind + " " + event.regarding.name, event.regarding) }} is now ready',
+    '{{ event.regarding.kind }} {{ event.regarding.name }} failed: {{ event.note }}',
+    '{{ actor }} reported {{ event.reason }} for {{ event.regarding.name }}',
+  ],
+};
+
+/**
+ * Validate DNS subdomain name (RFC 1123)
+ * Must consist of lowercase alphanumeric characters or '-',
+ * and must start and end with an alphanumeric character
+ */
+function isValidDNSSubdomain(name: string): boolean {
+  if (!name || name.length === 0 || name.length > 253) {
+    return false;
+  }
+  // Fixed pattern that allows single-character names
+  const pattern = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+  return pattern.test(name);
+}
+
+/**
+ * PolicyRuleEditorDialog provides a dialog interface for editing policy rules
+ */
+export function PolicyRuleEditorDialog({
+  open,
+  onOpenChange,
+  rule,
+  ruleType,
+  existingNames,
+  policyResource,
+  apiClient,
+  onSave,
+  onCancel,
+}: PolicyRuleEditorDialogProps) {
+  const isCreating = rule === null;
+
+  // Form state
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [match, setMatch] = useState('');
+  const [summary, setSummary] = useState('');
+
+  // Validation errors
+  const [nameError, setNameError] = useState('');
+  const [matchError, setMatchError] = useState('');
+  const [summaryError, setSummaryError] = useState('');
+
+  // Preview state
+  const [previewResult, setPreviewResult] = useState<PolicyPreviewStatus | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<Error | null>(null);
+
+  // Sample data for autocomplete (fetched once when dialog opens)
+  const [sampleData, setSampleData] = useState<unknown[]>([]);
+  const [sampleDataLoading, setSampleDataLoading] = useState(false);
+
+  // Extract field paths from sample data OR preview data for autocomplete
+  const availableFields = useMemo(() => {
+    // First try to use preview data if available
+    if (previewResult?.fetchedInputs && previewResult.fetchedInputs.length > 0) {
+      const dataObjects = previewResult.fetchedInputs.map(input => {
+        if (input.type === 'audit' && input.audit) {
+          return input.audit;
+        } else if (input.type === 'event' && input.event) {
+          return input.event;
+        }
+        return null;
+      }).filter(Boolean);
+
+      return extractFieldPathsFromMany(dataObjects);
+    }
+
+    // Fall back to sample data
+    if (sampleData.length > 0) {
+      return extractFieldPathsFromMany(sampleData);
+    }
+
+    return [];
+  }, [previewResult?.fetchedInputs, sampleData]);
+
+  // Initialize form when rule changes
+  useEffect(() => {
+    if (rule) {
+      setName(rule.name || '');
+      setDescription(rule.description || '');
+      setMatch(rule.match || '');
+      setSummary(rule.summary || '');
+    } else {
+      setName('');
+      setDescription('');
+      setMatch('');
+      setSummary('');
+    }
+    // Clear errors when dialog opens/closes or rule changes
+    setNameError('');
+    setMatchError('');
+    setSummaryError('');
+    setPreviewResult(null);
+    setPreviewError(null);
+  }, [rule, open]);
+
+  // Fetch sample data for autocomplete when dialog opens
+  useEffect(() => {
+    if (!open) {
+      setSampleData([]);
+      return;
+    }
+
+    let cancelled = false;
+    setSampleDataLoading(true);
+
+    async function fetchSampleData() {
+      try {
+        // Fetch sample data using a permissive match expression
+        const preview = await apiClient.createPolicyPreview({
+          policy: {
+            resource: policyResource,
+            auditRules: ruleType === 'audit' ? [{ name: 'sample', match: 'true', summary: 'sample' }] : undefined,
+            eventRules: ruleType === 'event' ? [{ name: 'sample', match: 'true', summary: 'sample' }] : undefined,
+          },
+          autoFetch: {
+            limit: 10,
+            timeRange: '7d',
+            sources: ruleType === 'audit' ? 'audit' : 'events',
+          },
+        });
+
+        if (cancelled) return;
+
+        // Extract data objects from fetched inputs
+        const dataObjects = (preview.status?.fetchedInputs || []).map(input => {
+          if (input.type === 'audit' && input.audit) return input.audit;
+          if (input.type === 'event' && input.event) return input.event;
+          return null;
+        }).filter(Boolean);
+
+        setSampleData(dataObjects);
+      } catch (err) {
+        // Silently fail - autocomplete just won't be available
+        console.warn('Failed to fetch sample data for autocomplete:', err);
+      } finally {
+        if (!cancelled) {
+          setSampleDataLoading(false);
+        }
+      }
+    }
+
+    fetchSampleData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, ruleType, policyResource, apiClient]);
+
+  // Live preview - debounced
+  useEffect(() => {
+    // Don't run preview if dialog is closed or fields are empty
+    if (!open || !match.trim() || !summary.trim()) {
+      setPreviewResult(null);
+      return;
+    }
+
+    const timer = setTimeout(async () => {
+      setPreviewLoading(true);
+      setPreviewError(null);
+
+      try {
+        // Create a preview using auto-fetch to get sample data from ClickHouse
+        const preview = await apiClient.createPolicyPreview({
+          policy: {
+            resource: policyResource,
+            auditRules: ruleType === 'audit' ? [{ name: name || 'preview', match, summary, description }] : undefined,
+            eventRules: ruleType === 'event' ? [{ name: name || 'preview', match, summary, description }] : undefined,
+          },
+          autoFetch: {
+            limit: 10,
+            timeRange: '7d',
+            sources: ruleType === 'audit' ? 'audit' : 'events',
+          },
+        });
+
+        setPreviewResult(preview.status || null);
+      } catch (err) {
+        setPreviewError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        setPreviewLoading(false);
+      }
+    }, 500); // Debounce 500ms
+
+    return () => clearTimeout(timer);
+  }, [open, match, summary, name, description, ruleType, policyResource, apiClient]);
+
+  const celHelp = ruleType === 'audit' ? AUDIT_CEL_HELP : EVENT_CEL_HELP;
+  const summaryHelp = ruleType === 'audit' ? AUDIT_SUMMARY_HELP : EVENT_SUMMARY_HELP;
+
+  // Validate form
+  const validate = (): boolean => {
+    let isValid = true;
+
+    // Validate name
+    if (!name.trim()) {
+      setNameError('Name is required');
+      isValid = false;
+    } else if (!isValidDNSSubdomain(name)) {
+      setNameError('Name must be lowercase alphanumeric and hyphens (e.g., "create-rule")');
+      isValid = false;
+    } else if (existingNames.includes(name) && (!rule || rule.name !== name)) {
+      setNameError('A rule with this name already exists');
+      isValid = false;
+    } else {
+      setNameError('');
+    }
+
+    // Validate match expression
+    if (!match.trim()) {
+      setMatchError('Match expression is required');
+      isValid = false;
+    } else {
+      setMatchError('');
+    }
+
+    // Validate summary
+    if (!summary.trim()) {
+      setSummaryError('Summary template is required');
+      isValid = false;
+    } else {
+      setSummaryError('');
+    }
+
+    return isValid;
+  };
+
+  // Handle save
+  const handleSave = () => {
+    if (!validate()) {
+      return;
+    }
+
+    const savedRule: ActivityPolicyRule = {
+      name: name.trim(),
+      description: description.trim() || undefined,
+      match: match.trim(),
+      summary: summary.trim(),
+    };
+
+    onSave(savedRule);
+    onOpenChange(false);
+  };
+
+  // Handle cancel
+  const handleCancel = () => {
+    onCancel();
+    onOpenChange(false);
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-2xl overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle className="text-base">
+            {isCreating ? 'Create' : 'Edit'} {ruleType === 'audit' ? 'Audit' : 'Event'} Rule
+          </SheetTitle>
+          <SheetDescription className="text-xs">
+            Define a rule to match {ruleType === 'audit' ? 'audit events' : 'Kubernetes events'} and generate activity summaries.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="py-3 text-sm flex-1 overflow-y-auto">
+          {/* Form fields - full width */}
+          <div className="space-y-3">
+            {/* Name */}
+            <div className="space-y-1">
+              <Label htmlFor="rule-name" className="text-xs font-medium">
+                Name <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="rule-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g., create-rule"
+                className={`h-8 text-sm ${nameError ? 'border-destructive' : ''}`}
+              />
+              {nameError && (
+                <p className="text-[11px] text-destructive">{nameError}</p>
+              )}
+              <p className="text-[11px] text-muted-foreground">
+                Lowercase alphanumeric and hyphens only
+              </p>
+            </div>
+
+            {/* Description */}
+            <div className="space-y-1">
+              <Label htmlFor="rule-description" className="text-xs font-medium">Description</Label>
+              <Textarea
+                id="rule-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Optional description"
+                rows={1}
+                className="resize-none text-sm"
+              />
+            </div>
+
+            {/* Match Expression */}
+            <div className="space-y-1">
+              <Label htmlFor="rule-match" className="text-xs font-medium">
+                Match Expression (CEL) <span className="text-destructive">*</span>
+              </Label>
+              <CelEditor
+                value={match}
+                onChange={setMatch}
+                language="cel"
+                availableFields={availableFields}
+                placeholder={celHelp.examples[0]}
+                height={80}
+                error={!!matchError}
+                data-testid="cel-editor-match"
+              />
+              {matchError && (
+                <p className="text-[11px] text-destructive">{matchError}</p>
+              )}
+              <details className="text-[11px]">
+                <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                  Available variables
+                </summary>
+                <ul className="mt-1 space-y-0.5 pl-3 list-disc text-muted-foreground">
+                  {celHelp.variables.map((v, i) => (
+                    <li key={i}>{v}</li>
+                  ))}
+                </ul>
+              </details>
+            </div>
+
+            {/* Summary Template */}
+            <div className="space-y-1">
+              <Label htmlFor="rule-summary" className="text-xs font-medium">
+                Summary Template <span className="text-destructive">*</span>
+              </Label>
+              <CelEditor
+                value={summary}
+                onChange={setSummary}
+                language="cel-template"
+                availableFields={availableFields}
+                placeholder={summaryHelp.examples[0]}
+                height={80}
+                error={!!summaryError}
+                data-testid="cel-editor-summary"
+              />
+              {summaryError && (
+                <p className="text-[11px] text-destructive">{summaryError}</p>
+              )}
+              <details className="text-[11px]">
+                <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                  Template variables
+                </summary>
+                <ul className="mt-1 space-y-0.5 pl-3 list-disc text-muted-foreground">
+                  {summaryHelp.variables.map((v, i) => (
+                    <li key={i}>{v}</li>
+                  ))}
+                </ul>
+              </details>
+            </div>
+          </div>
+
+          {/* Live preview - below the form */}
+          <div className="space-y-1 mt-4 pt-4 border-t">
+            <h3 className="text-xs font-medium">Live Preview</h3>
+            <p className="text-[11px] text-muted-foreground">
+              Preview updates as you type.
+            </p>
+            <PolicyPreviewPanel
+              result={previewResult}
+              inputs={[]}
+              isLoading={previewLoading}
+              error={previewError}
+            />
+          </div>
+        </div>
+
+        <SheetFooter className="mt-4 pt-4 border-t">
+          <Button variant="outline" size="sm" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleSave}>
+            {isCreating ? 'Create Rule' : 'Save Changes'}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/ui/src/components/PolicyRuleList.tsx
+++ b/ui/src/components/PolicyRuleList.tsx
@@ -1,5 +1,8 @@
-import type { ActivityPolicyRule, PolicyPreviewStatus } from '../types/policy';
-import { PolicyRuleEditor } from './PolicyRuleEditor';
+import { useState } from 'react';
+import type { ActivityPolicyRule } from '../types/policy';
+import type { ActivityApiClient } from '../api/client';
+import { PolicyRuleListItem } from './PolicyRuleListItem';
+import { PolicyRuleEditorDialog } from './PolicyRuleEditorDialog';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from './ui/tabs';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';
@@ -9,16 +12,14 @@ export interface PolicyRuleListProps {
   auditRules: ActivityPolicyRule[];
   /** Event rules */
   eventRules: ActivityPolicyRule[];
-  /** Preview result for highlighting matched rule */
-  previewResult?: PolicyPreviewStatus | null;
+  /** Policy resource configuration */
+  policyResource: { apiGroup: string; kind: string };
+  /** Activity API client for preview */
+  apiClient: ActivityApiClient;
   /** Callback when audit rules change */
   onAuditRulesChange: (rules: ActivityPolicyRule[]) => void;
   /** Callback when event rules change */
   onEventRulesChange: (rules: ActivityPolicyRule[]) => void;
-  /** Callback to add a new audit rule */
-  onAddAuditRule: () => void;
-  /** Callback to add a new event rule */
-  onAddEventRule: () => void;
   /** Additional CSS class */
   className?: string;
 }
@@ -29,154 +30,222 @@ export interface PolicyRuleListProps {
 export function PolicyRuleList({
   auditRules,
   eventRules,
-  previewResult,
+  policyResource,
+  apiClient,
   onAuditRulesChange,
   onEventRulesChange,
-  onAddAuditRule,
-  onAddEventRule,
   className = '',
 }: PolicyRuleListProps) {
-  // Determine which rule is highlighted from preview
-  const highlightedAuditIndex =
-    previewResult?.matched &&
-    previewResult.matchedRuleType === 'audit' &&
-    previewResult.matchedRuleIndex !== undefined
-      ? previewResult.matchedRuleIndex
-      : -1;
+  // Dialog state
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingRule, setEditingRule] = useState<ActivityPolicyRule | null>(null);
+  const [editingRuleIndex, setEditingRuleIndex] = useState<number | null>(null);
+  const [editingRuleType, setEditingRuleType] = useState<'audit' | 'event'>('audit');
 
-  const highlightedEventIndex =
-    previewResult?.matched &&
-    previewResult.matchedRuleType === 'event' &&
-    previewResult.matchedRuleIndex !== undefined
-      ? previewResult.matchedRuleIndex
-      : -1;
-
-  // Handle audit rule changes
-  const handleAuditRuleChange = (index: number, rule: ActivityPolicyRule) => {
-    const newRules = [...auditRules];
-    newRules[index] = rule;
-    onAuditRulesChange(newRules);
+  // Open dialog for creating new rule
+  const handleAddRule = (ruleType: 'audit' | 'event') => {
+    setEditingRule(null);
+    setEditingRuleIndex(null);
+    setEditingRuleType(ruleType);
+    setDialogOpen(true);
   };
 
-  const handleAuditRuleDelete = (index: number) => {
-    const newRules = auditRules.filter((_, i) => i !== index);
-    onAuditRulesChange(newRules);
+  // Open dialog for editing existing rule
+  const handleEditRule = (index: number, ruleType: 'audit' | 'event') => {
+    const rules = ruleType === 'audit' ? auditRules : eventRules;
+    setEditingRule(rules[index]);
+    setEditingRuleIndex(index);
+    setEditingRuleType(ruleType);
+    setDialogOpen(true);
   };
 
-  // Handle event rule changes
-  const handleEventRuleChange = (index: number, rule: ActivityPolicyRule) => {
-    const newRules = [...eventRules];
-    newRules[index] = rule;
-    onEventRulesChange(newRules);
+  // Save rule (create or update)
+  const handleSaveRule = (rule: ActivityPolicyRule) => {
+    if (editingRuleType === 'audit') {
+      if (editingRuleIndex === null) {
+        // Add new audit rule
+        onAuditRulesChange([...auditRules, rule]);
+      } else {
+        // Update existing audit rule
+        const newRules = [...auditRules];
+        newRules[editingRuleIndex] = rule;
+        onAuditRulesChange(newRules);
+      }
+    } else {
+      if (editingRuleIndex === null) {
+        // Add new event rule
+        onEventRulesChange([...eventRules, rule]);
+      } else {
+        // Update existing event rule
+        const newRules = [...eventRules];
+        newRules[editingRuleIndex] = rule;
+        onEventRulesChange(newRules);
+      }
+    }
   };
 
-  const handleEventRuleDelete = (index: number) => {
-    const newRules = eventRules.filter((_, i) => i !== index);
-    onEventRulesChange(newRules);
+  // Delete rule
+  const handleDeleteRule = (index: number, ruleType: 'audit' | 'event') => {
+    if (ruleType === 'audit') {
+      const newRules = auditRules.filter((_, i) => i !== index);
+      onAuditRulesChange(newRules);
+    } else {
+      const newRules = eventRules.filter((_, i) => i !== index);
+      onEventRulesChange(newRules);
+    }
   };
+
+  // Move rule up
+  const handleMoveUp = (index: number, ruleType: 'audit' | 'event') => {
+    if (index === 0) return;
+
+    const rules = ruleType === 'audit' ? [...auditRules] : [...eventRules];
+    [rules[index - 1], rules[index]] = [rules[index], rules[index - 1]];
+
+    if (ruleType === 'audit') {
+      onAuditRulesChange(rules);
+    } else {
+      onEventRulesChange(rules);
+    }
+  };
+
+  // Move rule down
+  const handleMoveDown = (index: number, ruleType: 'audit' | 'event') => {
+    const rules = ruleType === 'audit' ? auditRules : eventRules;
+    if (index >= rules.length - 1) return;
+
+    const newRules = [...rules];
+    [newRules[index], newRules[index + 1]] = [newRules[index + 1], newRules[index]];
+
+    if (ruleType === 'audit') {
+      onAuditRulesChange(newRules);
+    } else {
+      onEventRulesChange(newRules);
+    }
+  };
+
+  // Get existing rule names for validation
+  const existingNames = editingRuleType === 'audit'
+    ? auditRules.map(r => r.name || '').filter(Boolean)
+    : eventRules.map(r => r.name || '').filter(Boolean);
 
   return (
-    <div className={`bg-muted rounded-lg overflow-hidden ${className}`}>
-      <Tabs defaultValue="audit" className="w-full">
-        <TabsList className="w-full rounded-none border-b border-input bg-muted h-auto p-0">
-          <TabsTrigger
-            value="audit"
-            className="flex-1 gap-2 py-3 px-4 rounded-none data-[state=active]:bg-background data-[state=active]:border-b-2 data-[state=active]:border-[#BF9595] data-[state=active]:shadow-none"
-          >
-            Audit Rules
-            <Badge
-              variant="secondary"
-              className="data-[state=active]:bg-[#BF9595] data-[state=active]:text-white"
+    <>
+      <div className={`bg-muted rounded-lg overflow-hidden ${className}`}>
+        <Tabs defaultValue="audit" className="w-full">
+          <TabsList className="w-full rounded-none border-b border-input bg-muted h-auto p-0">
+            <TabsTrigger
+              value="audit"
+              className="flex-1 gap-1.5 py-1.5 px-2 text-xs rounded-none data-[state=active]:bg-background data-[state=active]:border-b-2 data-[state=active]:border-[#BF9595] data-[state=active]:shadow-none"
             >
-              {auditRules.length}
-            </Badge>
-            {highlightedAuditIndex >= 0 && (
-              <span className="text-emerald-600 font-bold" title="Rule matched in preview">
-                ✓
-              </span>
-            )}
-          </TabsTrigger>
-          <TabsTrigger
-            value="event"
-            className="flex-1 gap-2 py-3 px-4 rounded-none data-[state=active]:bg-background data-[state=active]:border-b-2 data-[state=active]:border-[#BF9595] data-[state=active]:shadow-none"
-          >
-            Event Rules
-            <Badge
-              variant="secondary"
-              className="data-[state=active]:bg-[#BF9595] data-[state=active]:text-white"
+              Audit Rules
+              <Badge
+                variant="secondary"
+                className="text-[10px] px-1.5 py-0 data-[state=active]:bg-[#BF9595] data-[state=active]:text-white"
+              >
+                {auditRules.length}
+              </Badge>
+            </TabsTrigger>
+            <TabsTrigger
+              value="event"
+              className="flex-1 gap-1.5 py-1.5 px-2 text-xs rounded-none data-[state=active]:bg-background data-[state=active]:border-b-2 data-[state=active]:border-[#BF9595] data-[state=active]:shadow-none"
             >
-              {eventRules.length}
-            </Badge>
-            {highlightedEventIndex >= 0 && (
-              <span className="text-emerald-600 font-bold" title="Rule matched in preview">
-                ✓
-              </span>
+              Event Rules
+              <Badge
+                variant="secondary"
+                className="text-[10px] px-1.5 py-0 data-[state=active]:bg-[#BF9595] data-[state=active]:text-white"
+              >
+                {eventRules.length}
+              </Badge>
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="audit" className="mt-0 p-2 bg-background">
+            <div className="space-y-1.5">
+              {auditRules.map((rule, index) => (
+                <PolicyRuleListItem
+                  key={rule.name}
+                  rule={rule}
+                  ruleType="audit"
+                  index={index}
+                  onEdit={() => handleEditRule(index, 'audit')}
+                  onDelete={() => handleDeleteRule(index, 'audit')}
+                  onMoveUp={() => handleMoveUp(index, 'audit')}
+                  onMoveDown={() => handleMoveDown(index, 'audit')}
+                  canMoveUp={index > 0}
+                  canMoveDown={index < auditRules.length - 1}
+                />
+              ))}
+            </div>
+            {auditRules.length === 0 && (
+              <div className="text-center py-4 px-4 text-muted-foreground text-xs">
+                <p className="mb-1">No audit rules defined.</p>
+                <p className="text-[11px]">
+                  Audit rules match API audit events and generate activity summaries.
+                </p>
+              </div>
             )}
-          </TabsTrigger>
-        </TabsList>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-full mt-2 border-2 border-dashed border-input bg-muted hover:bg-[#EFEFED] hover:border-[#BF9595] hover:text-foreground text-xs"
+              onClick={() => handleAddRule('audit')}
+            >
+              + Add Audit Rule
+            </Button>
+          </TabsContent>
 
-        <TabsContent value="audit" className="mt-0 p-4 bg-background">
-          {auditRules.map((rule, index) => (
-            <PolicyRuleEditor
-              key={index}
-              rule={rule}
-              index={index}
-              ruleType="audit"
-              isHighlighted={index === highlightedAuditIndex}
-              onChange={(newRule) => handleAuditRuleChange(index, newRule)}
-              onDelete={() => handleAuditRuleDelete(index)}
-            />
-          ))}
-          {auditRules.length === 0 && (
-            <div className="text-center py-8 px-8 text-muted-foreground">
-              <p className="mb-2">No audit rules defined.</p>
-              <p className="text-sm">
-                Audit rules match Kubernetes API audit events (create, update, delete, etc.)
-                and generate activity summaries.
-              </p>
+          <TabsContent value="event" className="mt-0 p-2 bg-background">
+            <div className="space-y-1.5">
+              {eventRules.map((rule, index) => (
+                <PolicyRuleListItem
+                  key={rule.name}
+                  rule={rule}
+                  ruleType="event"
+                  index={index}
+                  onEdit={() => handleEditRule(index, 'event')}
+                  onDelete={() => handleDeleteRule(index, 'event')}
+                  onMoveUp={() => handleMoveUp(index, 'event')}
+                  onMoveDown={() => handleMoveDown(index, 'event')}
+                  canMoveUp={index > 0}
+                  canMoveDown={index < eventRules.length - 1}
+                />
+              ))}
             </div>
-          )}
-          <Button
-            type="button"
-            variant="outline"
-            className="w-full py-3 mt-4 border-2 border-dashed border-input bg-muted hover:bg-[#EFEFED] hover:border-[#BF9595] hover:text-foreground"
-            onClick={onAddAuditRule}
-          >
-            + Add Audit Rule
-          </Button>
-        </TabsContent>
+            {eventRules.length === 0 && (
+              <div className="text-center py-4 px-4 text-muted-foreground text-xs">
+                <p className="mb-1">No event rules defined.</p>
+                <p className="text-[11px]">
+                  Event rules match Kubernetes Events and generate activity summaries.
+                </p>
+              </div>
+            )}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-full mt-2 border-2 border-dashed border-input bg-muted hover:bg-[#EFEFED] hover:border-[#BF9595] hover:text-foreground text-xs"
+              onClick={() => handleAddRule('event')}
+            >
+              + Add Event Rule
+            </Button>
+          </TabsContent>
+        </Tabs>
+      </div>
 
-        <TabsContent value="event" className="mt-0 p-4 bg-background">
-          {eventRules.map((rule, index) => (
-            <PolicyRuleEditor
-              key={index}
-              rule={rule}
-              index={index}
-              ruleType="event"
-              isHighlighted={index === highlightedEventIndex}
-              onChange={(newRule) => handleEventRuleChange(index, newRule)}
-              onDelete={() => handleEventRuleDelete(index)}
-            />
-          ))}
-          {eventRules.length === 0 && (
-            <div className="text-center py-8 px-8 text-muted-foreground">
-              <p className="mb-2">No event rules defined.</p>
-              <p className="text-sm">
-                Event rules match Kubernetes Events (Ready, Failed, Progressing, etc.)
-                and generate activity summaries from controller status updates.
-              </p>
-            </div>
-          )}
-          <Button
-            type="button"
-            variant="outline"
-            className="w-full py-3 mt-4 border-2 border-dashed border-input bg-muted hover:bg-[#EFEFED] hover:border-[#BF9595] hover:text-foreground"
-            onClick={onAddEventRule}
-          >
-            + Add Event Rule
-          </Button>
-        </TabsContent>
-      </Tabs>
-    </div>
+      {/* Rule Editor Dialog */}
+      <PolicyRuleEditorDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        rule={editingRule}
+        ruleType={editingRuleType}
+        existingNames={existingNames}
+        policyResource={policyResource}
+        apiClient={apiClient}
+        onSave={handleSaveRule}
+        onCancel={() => setDialogOpen(false)}
+      />
+    </>
   );
 }

--- a/ui/src/components/PolicyRuleListItem.tsx
+++ b/ui/src/components/PolicyRuleListItem.tsx
@@ -1,0 +1,134 @@
+import type { ActivityPolicyRule } from '../types/policy';
+import { Button } from './ui/button';
+import { Edit, Trash2, ChevronUp, ChevronDown } from 'lucide-react';
+
+export interface PolicyRuleListItemProps {
+  /** The rule being displayed */
+  rule: ActivityPolicyRule;
+  /** Rule type (audit or event) for context */
+  ruleType: 'audit' | 'event';
+  /** Rule index for display */
+  index: number;
+  /** Callback when edit button is clicked */
+  onEdit: () => void;
+  /** Callback when delete button is clicked */
+  onDelete: () => void;
+  /** Callback when move up button is clicked */
+  onMoveUp?: () => void;
+  /** Callback when move down button is clicked */
+  onMoveDown?: () => void;
+  /** Whether this rule can be moved up */
+  canMoveUp: boolean;
+  /** Whether this rule can be moved down */
+  canMoveDown: boolean;
+  /** Additional CSS class */
+  className?: string;
+}
+
+/**
+ * PolicyRuleListItem displays a single rule in a compact list format
+ * with inline edit, delete, and reordering controls
+ */
+export function PolicyRuleListItem({
+  rule,
+  ruleType,
+  index,
+  onEdit,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp,
+  canMoveDown,
+  className = '',
+}: PolicyRuleListItemProps) {
+  // Truncate match expression for display (max ~60 chars)
+  const truncatedMatch = rule.match.length > 60
+    ? `${rule.match.substring(0, 57)}...`
+    : rule.match;
+
+  return (
+    <div
+      className={`
+        flex items-center gap-2 p-2 rounded-md border transition-all duration-200
+        border-border bg-background hover:bg-muted/50
+        ${className}
+      `}
+    >
+      {/* Rule content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="font-medium text-xs text-foreground truncate">
+            {rule.name || `${ruleType === 'audit' ? 'Audit' : 'Event'} Rule #${index + 1}`}
+          </span>
+        </div>
+
+        {rule.description && (
+          <div className="text-[11px] text-muted-foreground mb-0.5 truncate">
+            {rule.description}
+          </div>
+        )}
+
+        <div className="text-[11px] font-mono text-muted-foreground truncate" title={rule.match}>
+          {truncatedMatch}
+        </div>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-1 shrink-0">
+        {/* Move up/down buttons */}
+        <div className="flex flex-col gap-0.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-5 w-5 p-0"
+            onClick={onMoveUp}
+            disabled={!canMoveUp}
+            title="Move up"
+            aria-label="Move rule up"
+          >
+            <ChevronUp className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-5 w-5 p-0"
+            onClick={onMoveDown}
+            disabled={!canMoveDown}
+            title="Move down"
+            aria-label="Move rule down"
+          >
+            <ChevronDown className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+
+        {/* Edit button */}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 text-muted-foreground hover:text-foreground hover:bg-muted"
+          onClick={onEdit}
+          title="Edit rule"
+          aria-label="Edit rule"
+        >
+          <Edit className="h-3.5 w-3.5" />
+        </Button>
+
+        {/* Delete button */}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 text-muted-foreground hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/50"
+          onClick={onDelete}
+          title="Delete rule"
+          aria-label="Delete rule"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/RulePreviewPanel.tsx
+++ b/ui/src/components/RulePreviewPanel.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState, useRef } from 'react';
+import type { ActivityPolicyRule, PolicyPreviewInput } from '../types/policy';
+import type { ActivityApiClient } from '../api/client';
+import type { K8sEvent } from '../types/k8s-event';
+import type { PolicyPreviewStatus } from '../types/policy';
+import { Card, CardContent } from './ui/card';
+import { Badge } from './ui/badge';
+import { Alert, AlertDescription } from './ui/alert';
+import { AlertCircle, CheckCircle, XCircle, Loader2 } from 'lucide-react';
+import { AuditLogFeedItem } from './AuditLogFeedItem';
+import { EventFeedItem } from './EventFeedItem';
+import { ActivityFeedSummary } from './ActivityFeedSummary';
+import { cn } from '../lib/utils';
+
+export interface RulePreviewPanelProps {
+  /** The rule to preview */
+  rule: ActivityPolicyRule;
+  /** Rule type (audit or event) */
+  ruleType: 'audit' | 'event';
+  /** Policy resource (apiGroup/kind) for fetching sample data */
+  policyResource: { apiGroup: string; kind: string };
+  /** API client for fetching data */
+  apiClient: ActivityApiClient;
+  /** Additional CSS class */
+  className?: string;
+}
+
+/**
+ * RulePreviewPanel shows live preview of a rule against sample data.
+ * Uses PolicyPreview API with auto-fetch to automatically load and test sample data.
+ */
+export function RulePreviewPanel({
+  rule,
+  ruleType,
+  policyResource,
+  apiClient,
+  className = '',
+}: RulePreviewPanelProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [samples, setSamples] = useState<PolicyPreviewInput[]>([]);
+  const [preview, setPreview] = useState<PolicyPreviewStatus | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Use ref to track the debounce timeout
+  const debounceTimerRef = useRef<number | null>(null);
+
+  // Re-run preview when rule changes (debounced)
+  useEffect(() => {
+    // Clear any existing timer
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    // Debounce the preview execution
+    debounceTimerRef.current = setTimeout(() => {
+      const runPreview = async () => {
+        setIsLoading(true);
+        setError(null);
+
+        try {
+          // Use auto-fetch to get sample data and run preview in one API call
+          const result = await apiClient.createPolicyPreview({
+            policy: {
+              resource: policyResource,
+              auditRules: ruleType === 'audit' ? [rule] : undefined,
+              eventRules: ruleType === 'event' ? [rule] : undefined,
+            },
+            autoFetch: {
+              limit: 10,
+              timeRange: '7d',
+              sources: ruleType === 'audit' ? 'audit' : 'events',
+            },
+          });
+
+          setPreview(result.status || null);
+
+          // Update samples from fetchedInputs so UI can display what was tested
+          if (result.status?.fetchedInputs) {
+            setSamples(result.status.fetchedInputs);
+          }
+        } catch (err) {
+          setError(err instanceof Error ? err : new Error('Failed to run preview'));
+        } finally {
+          setIsLoading(false);
+        }
+      };
+
+      runPreview();
+    }, 500);
+
+    // Cleanup
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [rule, ruleType, policyResource, apiClient]);
+
+  // Calculate statistics
+  const stats = {
+    total: samples.length,
+    matched: preview?.results?.filter((r) => r.matched).length || 0,
+    errors: preview?.results?.filter((r) => !!r.error).length || 0,
+  };
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {/* Loading State */}
+      {isLoading && (
+        <Card>
+          <CardContent className="py-8 text-center">
+            <Loader2 className="h-6 w-6 animate-spin mx-auto mb-2 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              Loading sample {ruleType === 'audit' ? 'audit logs' : 'events'} and testing rule...
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Error State */}
+      {error && !isLoading && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Empty State - No samples found */}
+      {!isLoading && samples.length === 0 && !error && (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <p className="text-sm text-muted-foreground mb-2">
+              No sample data found
+            </p>
+            <p className="text-xs text-muted-foreground">
+              No recent {ruleType === 'audit' ? 'audit logs' : 'events'} found for{' '}
+              {policyResource.apiGroup}/{policyResource.kind}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Preview Results */}
+      {!isLoading && preview && samples.length > 0 && (
+        <div className="space-y-4">
+          {/* Summary Header */}
+          <div className="flex items-center gap-3">
+            <Badge variant={stats.matched > 0 ? 'success' : 'secondary'}>
+              {stats.matched} matched
+            </Badge>
+            <span className="text-muted-foreground">/</span>
+            <span className="text-sm text-muted-foreground">{stats.total} tested</span>
+            {stats.errors > 0 && (
+              <>
+                <span className="text-muted-foreground">/</span>
+                <Badge variant="destructive">{stats.errors} errors</Badge>
+              </>
+            )}
+          </div>
+
+          {/* Sample Results */}
+          <Card>
+            <CardContent className="p-0">
+              <div className="divide-y divide-border">
+                {preview.results?.map((result, index) => {
+                  const input = samples[result.inputIndex];
+                  const isMatched = result.matched;
+                  const hasError = !!result.error;
+                  const activity = preview.activities?.[
+                    preview.activities.findIndex((_, idx) => idx === index)
+                  ];
+
+                  return (
+                    <div
+                      key={result.inputIndex}
+                      className={cn(
+                        'p-4 flex flex-col gap-3',
+                        hasError && 'bg-destructive/10'
+                      )}
+                    >
+                      {/* Sample Input */}
+                      {input?.type === 'audit' && input.audit && (
+                        <AuditLogFeedItem event={input.audit} compact={true} />
+                      )}
+                      {input?.type === 'event' && input.event && (
+                        <EventFeedItem
+                          event={input.event as K8sEvent}
+                          compact={true}
+                        />
+                      )}
+
+                      {/* Match Result */}
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2">
+                          {hasError ? (
+                            <Badge variant="destructive" className="gap-1">
+                              <XCircle className="h-3 w-3" />
+                              Error
+                            </Badge>
+                          ) : isMatched ? (
+                            <Badge variant="success" className="gap-1">
+                              <CheckCircle className="h-3 w-3" />
+                              Matched
+                            </Badge>
+                          ) : (
+                            <Badge variant="secondary" className="gap-1">
+                              <XCircle className="h-3 w-3" />
+                              No Match
+                            </Badge>
+                          )}
+                        </div>
+
+                        {/* Error Message */}
+                        {hasError && (
+                          <span className="text-xs text-destructive">{result.error}</span>
+                        )}
+                      </div>
+
+                      {/* Generated Summary */}
+                      {isMatched && activity && !hasError && (
+                        <div className="mt-2 p-3 rounded-md bg-muted">
+                          <p className="text-xs text-muted-foreground mb-1.5">
+                            Generated Summary:
+                          </p>
+                          <ActivityFeedSummary
+                            summary={activity.spec.summary}
+                            links={activity.spec.links}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* No Matches Warning */}
+          {stats.matched === 0 && stats.errors === 0 && (
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                This rule did not match any of the {stats.total} sample{stats.total !== 1 ? 's' : ''}.
+                Check your match expression.
+              </AlertDescription>
+            </Alert>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/40 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
     {...props}

--- a/ui/src/components/ui/sheet.tsx
+++ b/ui/src/components/ui/sheet.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+const Sheet = DialogPrimitive.Root;
+
+const SheetTrigger = DialogPrimitive.Trigger;
+
+const SheetClose = DialogPrimitive.Close;
+
+const SheetPortal = DialogPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-black/40 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  side?: 'top' | 'bottom' | 'left' | 'right';
+}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  SheetContentProps
+>(({ side = 'right', className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-300',
+        side === 'top' &&
+          'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        side === 'bottom' &&
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        side === 'left' &&
+          'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-xl',
+        side === 'right' &&
+          'inset-y-0 right-0 h-full w-full border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-2xl',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = DialogPrimitive.Content.displayName;
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-2 text-center sm:text-left',
+      className
+    )}
+    {...props}
+  />
+);
+SheetHeader.displayName = 'SheetHeader';
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className
+    )}
+    {...props}
+  />
+);
+SheetFooter.displayName = 'SheetFooter';
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold text-foreground', className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = DialogPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/ui/src/hooks/usePolicyEditor.ts
+++ b/ui/src/hooks/usePolicyEditor.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import type {
   ActivityPolicy,
   ActivityPolicySpec,
@@ -59,6 +59,10 @@ export interface UsePolicyEditorResult {
   removeAuditRule: (index: number) => void;
   /** Remove an event rule */
   removeEventRule: (index: number) => void;
+  /** Update a rule by name */
+  updateRuleByName: (ruleType: 'audit' | 'event', name: string, updates: Partial<ActivityPolicyRule>) => void;
+  /** Remove a rule by name */
+  removeRuleByName: (ruleType: 'audit' | 'event', name: string) => void;
   /** Save the policy (create or update) */
   save: (dryRun?: boolean) => Promise<ActivityPolicy>;
   /** Load an existing policy by name */
@@ -84,13 +88,33 @@ function createEmptySpec(): ActivityPolicySpec {
 }
 
 /**
- * Create an empty rule
+ * Generate a unique rule name
  */
-function createEmptyRule(): ActivityPolicyRule {
+function generateRuleName(ruleType: 'audit' | 'event', counter: number): string {
+  return `${ruleType}-rule-${counter}`;
+}
+
+/**
+ * Create an empty rule with a generated name
+ */
+function createEmptyRule(ruleType: 'audit' | 'event', counter: number): ActivityPolicyRule {
   return {
+    name: generateRuleName(ruleType, counter),
     match: '',
     summary: '',
   };
+}
+
+/**
+ * Ensure all rules have names, generating them if needed
+ */
+function ensureRuleNames(rules: ActivityPolicyRule[], ruleType: 'audit' | 'event'): ActivityPolicyRule[] {
+  return rules.map((rule, index) => {
+    if (!rule.name) {
+      return { ...rule, name: generateRuleName(ruleType, index + 1) };
+    }
+    return rule;
+  });
 }
 
 /**
@@ -119,6 +143,9 @@ export function usePolicyEditor({
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  // Rule name counters (persisted across the session)
+  const auditRuleCounter = useRef(1);
+  const eventRuleCounter = useRef(1);
 
   // Computed states
   const isNew = policy === null;
@@ -145,14 +172,14 @@ export function usePolicyEditor({
   const addAuditRule = useCallback(() => {
     setSpec((prev) => ({
       ...prev,
-      auditRules: [...(prev.auditRules || []), createEmptyRule()],
+      auditRules: [...(prev.auditRules || []), createEmptyRule('audit', auditRuleCounter.current++)],
     }));
   }, []);
 
   const addEventRule = useCallback(() => {
     setSpec((prev) => ({
       ...prev,
-      eventRules: [...(prev.eventRules || []), createEmptyRule()],
+      eventRules: [...(prev.eventRules || []), createEmptyRule('event', eventRuleCounter.current++)],
     }));
   }, []);
 
@@ -188,6 +215,38 @@ export function usePolicyEditor({
     }));
   }, []);
 
+  // Update rule by name
+  const updateRuleByName = useCallback(
+    (ruleType: 'audit' | 'event', ruleName: string, updates: Partial<ActivityPolicyRule>) => {
+      setSpec((prev) => {
+        const rulesKey = ruleType === 'audit' ? 'auditRules' : 'eventRules';
+        const rules = [...(prev[rulesKey] || [])];
+        const index = rules.findIndex((r) => r.name === ruleName);
+
+        if (index === -1) {
+          console.warn(`Rule with name "${ruleName}" not found in ${ruleType} rules`);
+          return prev;
+        }
+
+        rules[index] = { ...rules[index], ...updates };
+        return { ...prev, [rulesKey]: rules };
+      });
+    },
+    []
+  );
+
+  // Remove rule by name
+  const removeRuleByName = useCallback(
+    (ruleType: 'audit' | 'event', ruleName: string) => {
+      setSpec((prev) => {
+        const rulesKey = ruleType === 'audit' ? 'auditRules' : 'eventRules';
+        const rules = (prev[rulesKey] || []).filter((r) => r.name !== ruleName);
+        return { ...prev, [rulesKey]: rules };
+      });
+    },
+    []
+  );
+
   // Load an existing policy
   const load = useCallback(
     async (policyName: string) => {
@@ -196,10 +255,35 @@ export function usePolicyEditor({
 
       try {
         const result = await client.getPolicy(policyName);
+
+        // Ensure all rules have names (backward compatibility)
+        const specWithNames: ActivityPolicySpec = {
+          ...result.spec,
+          auditRules: result.spec.auditRules
+            ? ensureRuleNames(result.spec.auditRules, 'audit')
+            : [],
+          eventRules: result.spec.eventRules
+            ? ensureRuleNames(result.spec.eventRules, 'event')
+            : [],
+        };
+
+        // Update counters to avoid conflicts with loaded rules
+        const maxAuditIndex = (specWithNames.auditRules || []).reduce((max, rule) => {
+          const match = rule.name.match(/^audit-rule-(\d+)$/);
+          return match ? Math.max(max, parseInt(match[1], 10)) : max;
+        }, 0);
+        const maxEventIndex = (specWithNames.eventRules || []).reduce((max, rule) => {
+          const match = rule.name.match(/^event-rule-(\d+)$/);
+          return match ? Math.max(max, parseInt(match[1], 10)) : max;
+        }, 0);
+
+        auditRuleCounter.current = maxAuditIndex + 1;
+        eventRuleCounter.current = maxEventIndex + 1;
+
         setPolicy(result);
         setName(result.metadata?.name || policyName);
-        setSpec(result.spec);
-        setSavedSpec(result.spec);
+        setSpec(specWithNames);
+        setSavedSpec(specWithNames);
         setSavedName(result.metadata?.name || policyName);
       } catch (err) {
         setError(err instanceof Error ? err : new Error(String(err)));
@@ -269,6 +353,9 @@ export function usePolicyEditor({
     setSavedSpec(createEmptySpec());
     setSavedName('');
     setError(null);
+    // Reset counters when clearing
+    auditRuleCounter.current = 1;
+    eventRuleCounter.current = 1;
   }, []);
 
   return {
@@ -291,6 +378,8 @@ export function usePolicyEditor({
     updateEventRule,
     removeAuditRule,
     removeEventRule,
+    updateRuleByName,
+    removeRuleByName,
     save,
     load,
     reset,

--- a/ui/src/hooks/usePolicyPreview.ts
+++ b/ui/src/hooks/usePolicyPreview.ts
@@ -6,6 +6,7 @@ import type {
   PolicyPreviewPolicySpec,
   PolicyPreviewInputType,
   KubernetesEvent,
+  AutoFetchSpec,
 } from '../types/policy';
 import type { Event } from '../types';
 import { ActivityApiClient } from '../api/client';
@@ -51,6 +52,13 @@ export interface UsePolicyPreviewResult {
   /** Run the preview with selected inputs */
   runPreview: (
     policySpec: PolicyPreviewPolicySpec,
+    kindLabel?: string,
+    kindLabelPlural?: string
+  ) => Promise<PolicyPreviewStatus>;
+  /** Run the preview with auto-fetch (fetches sample data automatically) */
+  runPreviewWithAutoFetch: (
+    policySpec: PolicyPreviewPolicySpec,
+    autoFetch?: AutoFetchSpec,
     kindLabel?: string,
     kindLabelPlural?: string
   ) => Promise<PolicyPreviewStatus>;
@@ -301,6 +309,56 @@ export function usePolicyPreview({
     [client, getSelectedInputs]
   );
 
+  // Run the preview with auto-fetch
+  const runPreviewWithAutoFetch = useCallback(
+    async (
+      policySpec: PolicyPreviewPolicySpec,
+      autoFetch: AutoFetchSpec = { limit: 10, timeRange: '24h', sources: 'both' },
+      kindLabel?: string,
+      kindLabelPlural?: string
+    ): Promise<PolicyPreviewStatus> => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const spec: PolicyPreviewSpec = {
+          policy: policySpec,
+          autoFetch,
+          kindLabel,
+          kindLabelPlural,
+        };
+
+        const previewResult = await client.createPolicyPreview(spec);
+        const status = previewResult.status || {
+          activities: [],
+          results: [],
+          error: 'No status returned from server',
+        };
+
+        setResult(status);
+
+        // Update inputs from fetchedInputs so UI can display what was tested
+        if (status.fetchedInputs) {
+          setInputs(status.fetchedInputs);
+        }
+
+        return status;
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        setError(error);
+        setResult({
+          activities: [],
+          results: [],
+          error: error.message,
+        });
+        throw error;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [client, setInputs]
+  );
+
   // Clear the result
   const clearResult = useCallback(() => {
     setResult(null);
@@ -373,6 +431,7 @@ export function usePolicyPreview({
     setAuditInputs,
     setEventInputs,
     runPreview,
+    runPreviewWithAutoFetch,
     clearResult,
     reset,
     getSelectedInputs,

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -74,10 +74,18 @@ export { PolicyRuleList } from './components/PolicyRuleList';
 export type { PolicyRuleListProps } from './components/PolicyRuleList';
 export { PolicyRuleEditor } from './components/PolicyRuleEditor';
 export type { PolicyRuleEditorProps } from './components/PolicyRuleEditor';
+export { PolicyRuleEditorDialog } from './components/PolicyRuleEditorDialog';
+export type { PolicyRuleEditorDialogProps } from './components/PolicyRuleEditorDialog';
+export { PolicyRuleListItem } from './components/PolicyRuleListItem';
+export type { PolicyRuleListItemProps } from './components/PolicyRuleListItem';
 export { PolicyResourceForm } from './components/PolicyResourceForm';
 export type { PolicyResourceFormProps } from './components/PolicyResourceForm';
 export { SampleInputTemplates, AUDIT_TEMPLATES, EVENT_TEMPLATES } from './components/SampleInputTemplates';
 export type { SampleInputTemplatesProps } from './components/SampleInputTemplates';
+export { RulePreviewPanel } from './components/RulePreviewPanel';
+export type { RulePreviewPanelProps } from './components/RulePreviewPanel';
+export { CelEditor } from './components/CelEditor';
+export type { CelEditorProps } from './components/CelEditor';
 
 // UI Components (shadcn/ui based)
 export {
@@ -161,6 +169,7 @@ export type { TimeRangeDropdownProps, TimeRangePreset } from './components/ui/ti
 export { cn } from './lib/utils';
 export { ApiError, parseApiError, NetworkError, defaultErrorFormatter } from './lib/errors';
 export type { ApiErrorResponse } from './lib/errors';
+export { extractFieldPaths, extractFieldPathsFromMany } from './lib/extractFieldPaths';
 
 // Hooks - Audit Log Query (existing)
 export { useAuditLogQuery } from './hooks/useAuditLogQuery';
@@ -300,6 +309,7 @@ export type {
   PolicyPreviewInputType,
   PolicyPreviewStatus,
   PolicyPreviewPolicySpec,
+  AutoFetchSpec,
   KubernetesEvent,
   PolicyGroup,
   SampleInputTemplate,

--- a/ui/src/lib/extractFieldPaths.ts
+++ b/ui/src/lib/extractFieldPaths.ts
@@ -1,0 +1,133 @@
+/**
+ * Utility for extracting field paths from JSON objects
+ * Used to populate autocomplete suggestions in CEL editors
+ */
+
+/**
+ * Check if a key requires bracket notation (contains special characters)
+ */
+function requiresBracketNotation(key: string): boolean {
+  // Keys with dots, slashes, or other special characters need bracket notation
+  return /[.\/\-:]/.test(key) || /^\d/.test(key);
+}
+
+/**
+ * Build the CEL path for a key, using bracket notation when needed
+ */
+function buildPath(prefix: string, key: string): string {
+  if (requiresBracketNotation(key)) {
+    // Use bracket notation with quoted key: prefix["key"] or just ["key"]
+    return prefix ? `${prefix}["${key}"]` : `["${key}"]`;
+  }
+  // Use dot notation: prefix.key or just key
+  return prefix ? `${prefix}.${key}` : key;
+}
+
+/**
+ * Recursively extract all field paths from a JSON object
+ *
+ * @param obj - The object to extract paths from
+ * @param prefix - Current path prefix (for recursion)
+ * @param maxDepth - Maximum nesting depth to traverse (default: 5)
+ * @returns Array of CEL-compatible field paths (using bracket notation for special keys)
+ *
+ * @example
+ * extractFieldPaths({ objectRef: { name: "foo" }, annotations: { "k8s.io/key": "val" } })
+ * // Returns: ["objectRef.name", 'annotations["k8s.io/key"]']
+ */
+export function extractFieldPaths(
+  obj: unknown,
+  prefix = '',
+  maxDepth = 5
+): string[] {
+  const paths: string[] = [];
+
+  // Stop if we've reached max depth
+  if (maxDepth <= 0) {
+    return paths;
+  }
+
+  // Handle null/undefined
+  if (obj == null) {
+    return paths;
+  }
+
+  // Handle primitives (add the path itself)
+  if (typeof obj !== 'object') {
+    if (prefix) {
+      paths.push(prefix);
+    }
+    return paths;
+  }
+
+  // Handle arrays - sample the first element only
+  if (Array.isArray(obj)) {
+    if (obj.length > 0 && prefix) {
+      // Add the array path itself
+      paths.push(prefix);
+      // Recurse into first element
+      const firstElement = obj[0];
+      if (firstElement != null && typeof firstElement === 'object') {
+        const nestedPaths = extractFieldPaths(
+          firstElement,
+          prefix,
+          maxDepth - 1
+        );
+        paths.push(...nestedPaths);
+      }
+    }
+    return paths;
+  }
+
+  // Handle objects
+  const objAsRecord = obj as Record<string, unknown>;
+  for (const [key, value] of Object.entries(objAsRecord)) {
+    const currentPath = buildPath(prefix, key);
+
+    if (value == null) {
+      // Add null/undefined fields to the list
+      paths.push(currentPath);
+    } else if (typeof value === 'object') {
+      // Recurse into nested objects/arrays
+      const nestedPaths = extractFieldPaths(
+        value,
+        currentPath,
+        maxDepth - 1
+      );
+      paths.push(...nestedPaths);
+    } else {
+      // Primitive value - add the path
+      paths.push(currentPath);
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * Extract field paths from multiple objects and return unique sorted paths
+ *
+ * @param objects - Array of objects to extract paths from
+ * @param maxDepth - Maximum nesting depth to traverse (default: 5)
+ * @returns Sorted array of unique field paths
+ *
+ * @example
+ * extractFieldPathsFromMany([
+ *   { verb: "create", objectRef: { name: "foo" } },
+ *   { verb: "update", objectRef: { namespace: "bar" } }
+ * ])
+ * // Returns: ["objectRef.name", "objectRef.namespace", "verb"]
+ */
+export function extractFieldPathsFromMany(
+  objects: unknown[],
+  maxDepth = 5
+): string[] {
+  const allPaths = new Set<string>();
+
+  for (const obj of objects) {
+    const paths = extractFieldPaths(obj, '', maxDepth);
+    paths.forEach(path => allPaths.add(path));
+  }
+
+  return Array.from(allPaths).sort();
+}

--- a/ui/src/types/policy.ts
+++ b/ui/src/types/policy.ts
@@ -26,9 +26,13 @@ export interface ActivityPolicyResource {
  * Matches events and generates summaries
  */
 export interface ActivityPolicyRule {
+  /** Unique name for this rule within the policy */
+  name: string;
+  /** Optional human-readable description of what this rule does */
+  description?: string;
   /**
    * CEL expression to match events
-   * For audit rules: access via `audit.*` (e.g., `audit.verb == "create"`)
+   * For audit rules: use top-level fields (e.g., `verb == "create"`, `objectRef.namespace == "default"`)
    * For event rules: access via `event.*` (e.g., `event.reason == "Ready"`)
    */
   match: string;
@@ -198,13 +202,28 @@ export interface PolicyPreviewPolicySpec {
 }
 
 /**
+ * Auto-fetch configuration for PolicyPreview
+ * Mutually exclusive with manual inputs
+ */
+export interface AutoFetchSpec {
+  /** Maximum samples to fetch (default: 10, max: 50) */
+  limit?: number;
+  /** Time range to search (e.g., "1h", "24h", "7d") - default: "24h" */
+  timeRange?: string;
+  /** What to fetch: "audit", "events", or "both" - default: "both" */
+  sources?: 'audit' | 'events' | 'both';
+}
+
+/**
  * Specification for a PolicyPreview request
  */
 export interface PolicyPreviewSpec {
   /** The policy to test */
   policy: PolicyPreviewPolicySpec;
-  /** The inputs to test against (supports multiple) */
-  inputs: PolicyPreviewInput[];
+  /** The inputs to test against (supports multiple) - optional if autoFetch is set */
+  inputs?: PolicyPreviewInput[];
+  /** Auto-fetch spec - mutually exclusive with inputs */
+  autoFetch?: AutoFetchSpec;
   /** Optional kind label override */
   kindLabel?: string;
   /** Optional kind label plural override */
@@ -275,6 +294,8 @@ export interface PolicyPreviewStatus {
   results?: PolicyPreviewInputResult[];
   /** General error message if preview failed entirely */
   error?: string;
+  /** Auto-fetched inputs (populated when autoFetch is used) */
+  fetchedInputs?: PolicyPreviewInput[];
 
   // Legacy single-input fields (for backwards compatibility)
   /** @deprecated Use results[].matched */


### PR DESCRIPTION
## Summary
New rule editing experience with Monaco editor, CEL autocomplete, and live preview.

## User Impact
- Write match expressions with syntax highlighting and autocomplete
- See available fields from actual data (e.g., `audit.verb`, `audit.user.username`)
- Live preview shows which events would match as you type
- Bracket notation autocomplete for annotations (`annotations["key"]`)

## New Components
- CelEditor: Monaco-based editor with dynamic autocomplete
- PolicyRuleEditorDialog: Drawer interface with live preview
- Sheet: Consistent drawer component for editing

## Stack
PR 4 of 7 — depends on PR #75.

🤖 Generated with [Claude Code](https://claude.ai/code)