### PR TITLE
docs: update ActivityPolicy examples and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ observability/jsonnetfile.lock.json
 # Node.js
 node_modules/
 .pnpm-store/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,8 +277,8 @@ spec:
     apiGroup: networking.datumapis.com
     kind: HTTPProxy
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor }} created {{ link(kind + ' ' + audit.objectRef.name, audit.responseObject) }}"
+    - match: "verb == 'create'"
+      summary: "{{ actor }} created {{ link(kind + ' ' + objectRef.name, responseObject) }}"
 ```
 
 ## Stable Codebase Facts <!-- reference -->

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -653,3 +653,18 @@ tasks:
         echo "  - Review generated files"
         echo "  - Commit: git add pkg/ config/ docs/ && git commit -m 'chore: regenerate code and docs'"
     silent: true
+
+  # ============================================================
+  # E2E Testing with Chainsaw
+  # ============================================================
+  e2e:
+    desc: Run chainsaw e2e tests
+    cmds:
+      - chainsaw test test/e2e/ --config test/e2e/chainsaw-test.yaml
+    silent: false
+
+  e2e:named-rules:
+    desc: Run named rules e2e tests only
+    cmds:
+      - chainsaw test test/e2e/activitypolicy/named-rules/
+    silent: false

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -94,8 +94,8 @@ spec:
     apiGroup: networking.datumapis.com
     kind: HTTPProxy
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor }} created {{ link(kind + ' ' + audit.objectRef.name, audit.responseObject) }}"
+    - match: "verb == 'create'"
+      summary: "{{ actor }} created {{ link(kind + ' ' + objectRef.name, responseObject) }}"
 ```
 
 See [Activity Pipeline](./activity-pipeline.md) for details.

--- a/docs/architecture/activity-pipeline.md
+++ b/docs/architecture/activity-pipeline.md
@@ -66,14 +66,14 @@ spec:
     kind: HTTPProxy
 
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor }} created {{ link('HTTP proxy ' + audit.objectRef.name, audit.responseObject) }}"
+    - match: "verb == 'create'"
+      summary: "{{ actor }} created {{ link('HTTP proxy ' + objectRef.name, responseObject) }}"
 
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor }} deleted {{ link('HTTP proxy ' + audit.objectRef.name, audit.responseObject) }}"
+    - match: "verb == 'delete'"
+      summary: "{{ actor }} deleted {{ link('HTTP proxy ' + objectRef.name, responseObject) }}"
 
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor }} updated {{ link('HTTP proxy ' + audit.objectRef.name, audit.responseObject) }}"
+    - match: "verb in ['update', 'patch']"
+      summary: "{{ actor }} updated {{ link('HTTP proxy ' + objectRef.name, responseObject) }}"
 
   eventRules:
     - match: "event.reason == 'Programmed'"
@@ -106,7 +106,7 @@ The `link()` function creates clickable references in the portal:
 link(displayText, resourceRef)
 ```
 
-Example: `{{ link("HTTP Proxy " + audit.objectRef.name, audit.responseObject) }}`
+Example: `{{ link("HTTP Proxy " + objectRef.name, responseObject) }}`
 
 This produces "HTTP proxy api-gateway" in the summary and registers it as a
 clickable link to the resource.
@@ -136,7 +136,7 @@ Actors are resolved from different sources based on the activity origin:
 
 | Source | Resolution Method |
 |--------|-------------------|
-| Audit logs | Extract from `audit.user.username`, `audit.user.uid` |
+| Audit logs | Extract from `user.username`, `user.uid` |
 | Events with annotations | Use `activity.miloapis.com/actor-*` annotations |
 | Events from controllers | Map `event.reportingController` to a system actor |
 

--- a/examples/basic-kubernetes/apps.yaml
+++ b/examples/basic-kubernetes/apps.yaml
@@ -1,5 +1,8 @@
 # ActivityPolicies for apps Kubernetes API group
 # Resources: Deployment, ReplicaSet, StatefulSet, DaemonSet
+#
+# These policies only generate activities for write operations (create, update, patch, delete).
+# Read operations (get, list, watch) are excluded as they don't represent meaningful state changes.
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -11,18 +14,18 @@ spec:
     apiGroup: apps
     kind: Deployment
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} deployed {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed deployment {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch'] && audit.objectRef.subresource == 'scale'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} scaled {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch'] && audit.objectRef.subresource == 'status'"
-      summary: "{{ link(audit.objectRef.name, audit.objectRef) }} status changed"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified deployment {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} deployed {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'application' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'application' }}"
+    - name: scale
+      match: "verb in ['update', 'patch'] && has(objectRef.subresource) && objectRef.subresource == 'scale'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} scaled {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'application' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'application' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -34,16 +37,18 @@ spec:
     apiGroup: apps
     kind: ReplicaSet
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created replica set {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed replica set {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch'] && audit.objectRef.subresource == 'scale'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} scaled {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated replica set {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified replica set {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created replicas for {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'application' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed replicas for {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'application' }}"
+    - name: scale
+      match: "verb in ['update', 'patch'] && has(objectRef.subresource) && objectRef.subresource == 'scale'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} scaled {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'replicas' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated replicas for {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'application' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -55,16 +60,18 @@ spec:
     apiGroup: apps
     kind: StatefulSet
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created stateful set {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed stateful set {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch'] && audit.objectRef.subresource == 'scale'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} scaled {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated stateful set {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified stateful set {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} deployed stateful app {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed stateful app {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: scale
+      match: "verb in ['update', 'patch'] && has(objectRef.subresource) && objectRef.subresource == 'scale'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} scaled {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'stateful app' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated stateful app {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -76,11 +83,12 @@ spec:
     apiGroup: apps
     kind: DaemonSet
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created daemon set {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed daemon set {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated daemon set {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified daemon set {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} deployed cluster-wide service {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed cluster-wide service {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated cluster-wide service {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"

--- a/examples/basic-kubernetes/batch.yaml
+++ b/examples/basic-kubernetes/batch.yaml
@@ -1,5 +1,8 @@
 # ActivityPolicies for batch Kubernetes API group
 # Resources: Job, CronJob
+#
+# These policies only generate activities for write operations (create, update, patch, delete).
+# Read operations (get, list, watch) are excluded as they don't represent meaningful state changes.
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -11,16 +14,15 @@ spec:
     apiGroup: batch
     kind: Job
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} started job {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed job {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch'] && audit.objectRef.subresource == 'status'"
-      summary: "Job {{ link(audit.objectRef.name, audit.objectRef) }} status changed"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated job {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified job {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} started job {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} deleted job {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated job {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -32,11 +34,12 @@ spec:
     apiGroup: batch
     kind: CronJob
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created scheduled job {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed scheduled job {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated scheduled job {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified scheduled job {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created scheduled job {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} deleted scheduled job {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated scheduled job {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"

--- a/examples/basic-kubernetes/core.yaml
+++ b/examples/basic-kubernetes/core.yaml
@@ -1,5 +1,8 @@
 # ActivityPolicies for core Kubernetes API group
 # Resources: Pod, Service, ConfigMap, Secret, Namespace, ServiceAccount, PersistentVolumeClaim, PersistentVolume
+#
+# These policies only generate activities for write operations (create, update, patch, delete).
+# Read operations (get, list, watch) are excluded as they don't represent meaningful state changes.
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -11,18 +14,18 @@ spec:
     apiGroup: ""
     kind: Pod
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} started {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} stopped pod {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch'] && audit.objectRef.subresource == 'status'"
-      summary: "{{ link(audit.objectRef.name, audit.objectRef) }} status changed"
-    - match: "audit.verb == 'create' && audit.objectRef.subresource == 'eviction'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} evicted {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified pod {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: evict
+      match: "verb == 'create' && has(objectRef.subresource) && objectRef.subresource == 'eviction'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} evicted {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'pod' }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} started {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'pod' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} stopped {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'pod' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'pod' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -34,14 +37,15 @@ spec:
     apiGroup: ""
     kind: Service
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created service {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed service {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated service {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified service {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} exposed {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'service' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'service' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated {{ has(objectRef.name) ? link(objectRef.name, objectRef) : 'service' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -53,14 +57,15 @@ spec:
     apiGroup: ""
     kind: ConfigMap
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created config {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed config {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated config {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified config {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} added configuration {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed configuration {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} changed configuration {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -72,14 +77,15 @@ spec:
     apiGroup: ""
     kind: Secret
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created secret {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed secret {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated secret {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified secret {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} added secret {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed secret {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} changed secret {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -91,14 +97,15 @@ spec:
     apiGroup: ""
     kind: Namespace
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created namespace {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed namespace {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated namespace {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified namespace {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created workspace {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed workspace {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated workspace {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -110,14 +117,15 @@ spec:
     apiGroup: ""
     kind: ServiceAccount
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created service account {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed service account {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated service account {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified service account {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created identity {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed identity {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated identity {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -129,14 +137,15 @@ spec:
     apiGroup: ""
     kind: PersistentVolumeClaim
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} requested storage {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} released storage {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated storage claim {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified storage claim {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} requested storage {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} released storage {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated storage {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -148,11 +157,12 @@ spec:
     apiGroup: ""
     kind: PersistentVolume
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} provisioned storage {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed storage {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated storage {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified storage {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} provisioned storage {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed storage {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated storage {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"

--- a/examples/basic-kubernetes/events.yaml
+++ b/examples/basic-kubernetes/events.yaml
@@ -15,21 +15,29 @@ spec:
     apiGroup: ""
     kind: Pod
   eventRules:
-    - match: 'event.reason == "Scheduled"'
+    - name: scheduled
+      match: 'event.reason == "Scheduled"'
       summary: "{{ link(event.regarding.name, event.regarding) }} scheduled to node {{ event.note }}"
-    - match: 'event.reason == "Pulling"'
+    - name: pulling
+      match: 'event.reason == "Pulling"'
       summary: "Pulling image for {{ link(event.regarding.name, event.regarding) }}"
-    - match: 'event.reason == "Pulled"'
+    - name: pulled
+      match: 'event.reason == "Pulled"'
       summary: "Successfully pulled image for {{ link(event.regarding.name, event.regarding) }}"
-    - match: 'event.reason == "Created"'
+    - name: created
+      match: 'event.reason == "Created"'
       summary: "Created container in {{ link(event.regarding.name, event.regarding) }}"
-    - match: 'event.reason == "Started"'
+    - name: started
+      match: 'event.reason == "Started"'
       summary: "Started container in {{ link(event.regarding.name, event.regarding) }}"
-    - match: 'event.reason == "Killing"'
+    - name: killing
+      match: 'event.reason == "Killing"'
       summary: "Stopping container in {{ link(event.regarding.name, event.regarding) }}"
-    - match: 'event.reason == "BackOff"'
+    - name: backoff
+      match: 'event.reason == "BackOff"'
       summary: "{{ link(event.regarding.name, event.regarding) }} failed to start: {{ event.note }}"
-    - match: 'event.reason == "FailedScheduling"'
+    - name: failed-scheduling
+      match: 'event.reason == "FailedScheduling"'
       summary: "Failed to schedule {{ link(event.regarding.name, event.regarding) }}: {{ event.note }}"
 
 ---
@@ -42,13 +50,17 @@ spec:
     apiGroup: ""
     kind: Node
   eventRules:
-    - match: 'event.reason == "NodeReady"'
+    - name: node-ready
+      match: 'event.reason == "NodeReady"'
       summary: "Node {{ link(event.regarding.name, event.regarding) }} is ready"
-    - match: 'event.reason == "NodeNotReady"'
+    - name: node-not-ready
+      match: 'event.reason == "NodeNotReady"'
       summary: "Node {{ link(event.regarding.name, event.regarding) }} is not ready"
-    - match: 'event.reason == "NodeSchedulable"'
+    - name: node-schedulable
+      match: 'event.reason == "NodeSchedulable"'
       summary: "Node {{ link(event.regarding.name, event.regarding) }} is now schedulable"
-    - match: 'event.reason == "RegisteredNode"'
+    - name: registered-node
+      match: 'event.reason == "RegisteredNode"'
       summary: "Node {{ link(event.regarding.name, event.regarding) }} joined the cluster"
 
 ---
@@ -61,7 +73,9 @@ spec:
     apiGroup: "apps"
     kind: Deployment
   eventRules:
-    - match: 'event.reason == "ScalingReplicaSet"'
+    - name: scaling-replicaset
+      match: 'event.reason == "ScalingReplicaSet"'
       summary: "Scaling replica set for {{ link(event.regarding.name, event.regarding) }}"
-    - match: 'event.reason == "SuccessfulCreate"'
+    - name: successful-create
+      match: 'event.reason == "SuccessfulCreate"'
       summary: "Created replica set for {{ link(event.regarding.name, event.regarding) }}"

--- a/examples/basic-kubernetes/networking.yaml
+++ b/examples/basic-kubernetes/networking.yaml
@@ -1,5 +1,8 @@
 # ActivityPolicies for networking.k8s.io Kubernetes API group
 # Resources: Ingress
+#
+# These policies only generate activities for write operations (create, update, patch, delete).
+# Read operations (get, list, watch) are excluded as they don't represent meaningful state changes.
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -11,11 +14,12 @@ spec:
     apiGroup: networking.k8s.io
     kind: Ingress
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created ingress {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed ingress {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated ingress {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified ingress {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} exposed route {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed route {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated route {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"

--- a/examples/basic-kubernetes/rbac.yaml
+++ b/examples/basic-kubernetes/rbac.yaml
@@ -1,5 +1,8 @@
 # ActivityPolicies for rbac.authorization.k8s.io Kubernetes API group
 # Resources: ClusterRole, ClusterRoleBinding, Role, RoleBinding
+#
+# These policies only generate activities for write operations (create, update, patch, delete).
+# Read operations (get, list, watch) are excluded as they don't represent meaningful state changes.
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -11,14 +14,15 @@ spec:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created cluster role {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed cluster role {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated cluster role {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified cluster role {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} defined cluster-wide permissions {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed cluster-wide permissions {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} changed cluster-wide permissions {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -30,14 +34,15 @@ spec:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRoleBinding
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} granted cluster permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} revoked cluster permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated cluster permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified cluster permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} granted cluster-wide access {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} revoked cluster-wide access {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} changed cluster-wide access {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -49,14 +54,15 @@ spec:
     apiGroup: rbac.authorization.k8s.io
     kind: Role
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} created role {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed role {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated role {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified role {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} defined permissions {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} removed permissions {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} changed permissions {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
 
 ---
 apiVersion: activity.miloapis.com/v1alpha1
@@ -68,11 +74,12 @@ spec:
     apiGroup: rbac.authorization.k8s.io
     kind: RoleBinding
   auditRules:
-    - match: "audit.verb == 'create'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} granted permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb == 'delete'"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} revoked permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "audit.verb in ['update', 'patch']"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} updated permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
-    - match: "true"
-      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} modified permissions {{ link(audit.objectRef.name, audit.objectRef) }}"
+    - name: create
+      match: "verb == 'create'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} granted access {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: delete
+      match: "verb == 'delete'"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} revoked access {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"
+    - name: update
+      match: "verb in ['update', 'patch']"
+      summary: "{{ actor.startsWith('system:') ? 'System' : link(actor, actorRef) }} changed access {{ has(objectRef.name) ? link(objectRef.name, objectRef) : '' }}"

--- a/pkg/mcp/tools/integration_test.go
+++ b/pkg/mcp/tools/integration_test.go
@@ -221,8 +221,8 @@ func TestIntegration_PolicyPreview(t *testing.T) {
 				},
 				AuditRules: []v1alpha1.ActivityPolicyRule{
 					{
-						Match:   `audit.verb == "create"`,
-						Summary: "{{ actor }} created pod {{ audit.objectRef.name }}",
+						Match:   `verb == "create"`,
+						Summary: "{{ actor }} created pod {{ objectRef.name }}",
 					},
 				},
 			},

--- a/pkg/mcp/tools/tools_test.go
+++ b/pkg/mcp/tools/tools_test.go
@@ -277,7 +277,7 @@ func (m *mockActivityPolicyInterface) List(ctx context.Context, opts metav1.List
 				Spec: v1alpha1.ActivityPolicySpec{
 					Resource: v1alpha1.ActivityPolicyResource{APIGroup: "networking.datumapis.com", Kind: "HTTPProxy"},
 					AuditRules: []v1alpha1.ActivityPolicyRule{
-						{Match: "audit.verb == 'create'", Summary: "{{ actor }} created HTTPProxy"},
+						{Match: "verb == 'create'", Summary: "{{ actor }} created HTTPProxy"},
 					},
 				},
 				Status: v1alpha1.ActivityPolicyStatus{
@@ -1152,7 +1152,7 @@ func TestPreviewActivityPolicy(t *testing.T) {
 				Kind:     "HTTPProxy",
 			},
 			AuditRules: []v1alpha1.ActivityPolicyRule{
-				{Match: "audit.verb == 'create'", Summary: "{{ actor }} created HTTPProxy"},
+				{Match: "verb == 'create'", Summary: "{{ actor }} created HTTPProxy"},
 			},
 		},
 		Inputs: []v1alpha1.PolicyPreviewInput{


### PR DESCRIPTION
## Summary
Updated example ActivityPolicy manifests and documentation.

## What's Updated
- Kubernetes resource examples (Deployments, Pods, Services, etc.)
- RBAC policy examples
- Networking policy examples
- Batch job policy examples

## Stack
PR 7 of 7 — final PR in the stack. Depends on PR #78.

🤖 Generated with [Claude Code](https://claude.ai/code)