### PR TITLE
fix: rename reindex subject to avoid NATS stream conflict

### DIFF
--- a/config/components/nats-streams/clickhouse-reindex-consumer.yaml
+++ b/config/components/nats-streams/clickhouse-reindex-consumer.yaml
@@ -20,7 +20,7 @@ spec:
   replayPolicy: instant
 
   # Filter subject: all reindex activities
-  filterSubject: reindex.activities.>
+  filterSubject: activity_miloapis_com_reindex.>
 
   # Max delivery attempts: unlimited (-1)
   maxDeliver: -1

--- a/config/components/nats-streams/reindex-stream.yaml
+++ b/config/components/nats-streams/reindex-stream.yaml
@@ -8,9 +8,9 @@ spec:
   name: ACTIVITIES_REINDEX
 
   # Subjects for reindex activities
-  # Format: reindex.activities.<tenant_type>.<api_group>.<kind>
+  # Format: activity_miloapis_com_reindex.<tenant_type>.<api_group>.<kind>
   subjects:
-    - reindex.activities.>
+    - activity_miloapis_com_reindex.>
 
   # Retention policy: limits-based (time + size)
   retention: limits

--- a/config/components/vector-aggregator/vector-hr.yaml
+++ b/config/components/vector-aggregator/vector-hr.yaml
@@ -132,7 +132,7 @@ spec:
           url: nats://nats.nats-system.svc.cluster.local:4222
 
           # Subject filter for reindexed activities
-          subject: reindex.activities.>
+          subject: activity_miloapis_com_reindex.>
 
           # JetStream configuration
           jetstream:

--- a/internal/reindex/publisher.go
+++ b/internal/reindex/publisher.go
@@ -17,7 +17,7 @@ const (
 	ReindexStreamName = "ACTIVITIES_REINDEX"
 
 	// ReindexSubjectPrefix is the subject prefix for reindexed activities
-	ReindexSubjectPrefix = "reindex.activities"
+	ReindexSubjectPrefix = "activity_miloapis_com_reindex"
 
 	// Default retry configuration
 	defaultMaxRetries     = 3


### PR DESCRIPTION
## Summary
Rename reindex subject from `reindex.activities.>` to `activity_miloapis_com_reindex.>` to avoid conflict with search-system's `reindex.>` stream.

## Post-deploy
Delete the errored stream so it recreates with new subject:
```bash
kubectl delete stream activities-reindex -n activity-system
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)