### PR TITLE
fix: remove Job watch from ReindexJob controller

### DIFF
--- a/internal/controller/reindexjob_controller.go
+++ b/internal/controller/reindexjob_controller.go
@@ -460,9 +460,11 @@ func (r *ReindexJobReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentR
 	}
 	klog.InfoS("NATS stream verified", "stream", stream.Config.Name, "subjects", stream.Config.Subjects)
 
+	// Note: We don't use Owns(&batchv1.Job{}) because Jobs are created in the
+	// infrastructure cluster while the manager watches Milo. Instead, we poll
+	// for Job status using RequeueAfter in the reconcile loop.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.ReindexJob{}).
-		Owns(&batchv1.Job{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: maxConcurrentReconciles,
 		}).


### PR DESCRIPTION
## Problem

Controller-manager crashes in staging with:
```
no matches for kind "Job" in version "batch/v1"
```

The controller uses `Owns(&batchv1.Job{})` to watch Jobs, but the manager's client connects to Milo (which doesn't have Jobs). Jobs are created in the infrastructure cluster.

## Fix

Remove the `Owns` call. The controller already polls for Job status using `RequeueAfter: 5 * time.Second`, so it doesn't need the watch.

Trade-off: Up to 5 seconds latency when a Job completes (acceptable).

## Testing

- [x] Tests pass
- [ ] Deploy to staging and verify controller starts