### PR TITLE
fix: override OpenAPI GetDefinitionName for SSA compatibility

### DIFF
--- a/cmd/activity/main.go
+++ b/cmd/activity/main.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
+	openapiutil "k8s.io/kube-openapi/pkg/util"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	// Register JSON logging format
 	_ "k8s.io/component-base/logs/json/register"
@@ -273,11 +275,21 @@ func (o *ActivityServerOptions) Config() (*activityapiserver.Config, error) {
 	genericConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(openapi.GetOpenAPIDefinitions, namer)
 	genericConfig.OpenAPIV3Config.Info.Title = "Activity"
 	genericConfig.OpenAPIV3Config.Info.Version = version.Version
+	// Override GetDefinitionName to use REST-friendly naming for SSA compatibility.
+	// This ensures the OpenAPI schema names match what the TypeConverter expects.
+	genericConfig.OpenAPIV3Config.GetDefinitionName = func(name string) (string, spec.Extensions) {
+		friendlyName, extensions := namer.GetDefinitionName(name)
+		return openapiutil.ToRESTFriendlyName(friendlyName), extensions
+	}
 
 	// Configure OpenAPI v2
 	genericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.GetOpenAPIDefinitions, namer)
 	genericConfig.OpenAPIConfig.Info.Title = "Activity"
 	genericConfig.OpenAPIConfig.Info.Version = version.Version
+	genericConfig.OpenAPIConfig.GetDefinitionName = func(name string) (string, spec.Extensions) {
+		friendlyName, extensions := namer.GetDefinitionName(name)
+		return openapiutil.ToRESTFriendlyName(friendlyName), extensions
+	}
 
 	if err := o.RecommendedOptions.ApplyTo(genericConfig); err != nil {
 		return nil, fmt.Errorf("failed to apply recommended options: %w", err)


### PR DESCRIPTION
## Summary
- Override `GetDefinitionName` for both OpenAPI v2 and v3 configs to use `ToRESTFriendlyName`
- Ensures OpenAPI schema names are consistent with what the TypeConverter expects for Server-Side Apply operations
- Fixes SSA "no corresponding type" errors when applying ActivityPolicy resources through FluxCD

## Problem

When applying ActivityPolicy resources through FluxCD (which uses Server-Side Apply), the operation fails with:

```
ActivityPolicy/milo-system/dns.networking.miloapis.com-dnszone dry-run failed: failed to create manager for existing fields: failed to convert new object (/dns.networking.miloapis.com-dnszone; activity.miloapis.com/v1alpha1, Kind=ActivityPolicy) to smd typed: no corresponding type for activity.miloapis.com/v1alpha1, Kind=ActivityPolicy
```

## Root Cause

The Activity service's TypeConverter couldn't find the ActivityPolicy GVK in its schema map. After comparing with the working Search service, the key difference was that Search explicitly overrides `GetDefinitionName` for both OpenAPI configs while Activity relied on the default.

Explicitly overriding `GetDefinitionName` ensures consistent naming across all OpenAPI operations, which is critical because:
- `DefaultOpenAPIV3Config` pre-builds the `Definitions` map using `GetDefinitionName`
- Later, when building schemas, `GetDefinitionName` is called again to get the schema key and GVK extensions
- Without explicit override, there can be subtle inconsistencies in the processing pipeline

## Test plan
- [ ] Deploy to test environment and verify ActivityPolicy resources can be applied via FluxCD SSA
- [ ] Verify existing functionality still works (audit log queries, activity translation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)