### PR TITLE
fix: transform OpenAPI definition keys to REST-friendly format for SSA

### DIFF
--- a/cmd/activity/main.go
+++ b/cmd/activity/main.go
@@ -23,8 +23,6 @@ import (
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
-	openapiutil "k8s.io/kube-openapi/pkg/util"
-	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	// Register JSON logging format
 	_ "k8s.io/component-base/logs/json/register"
@@ -271,25 +269,20 @@ func (o *ActivityServerOptions) Config() (*activityapiserver.Config, error) {
 	// Set effective version to match the Kubernetes version we're built against.
 	genericConfig.EffectiveVersion = basecompatibility.NewEffectiveVersionFromString("1.34", "", "")
 
+	// Use GetOpenAPIDefinitionsWithRESTFriendlyKeys which transforms definition keys to
+	// match what the DefinitionNamer expects. This is required because:
+	// - openapi-gen generates keys using Go module paths (e.g., "go.miloapis.com/...")
+	// - DefinitionNamer uses scheme.ToOpenAPIDefinitionName() which returns REST-friendly names (e.g., "com.miloapis.go...")
+	// - Without matching keys, GVK extensions aren't added and SSA fails with "no corresponding type"
 	namer := apiopenapi.NewDefinitionNamer(activityapiserver.Scheme)
-	genericConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(openapi.GetOpenAPIDefinitions, namer)
+	genericConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(openapi.GetOpenAPIDefinitionsWithRESTFriendlyKeys, namer)
 	genericConfig.OpenAPIV3Config.Info.Title = "Activity"
 	genericConfig.OpenAPIV3Config.Info.Version = version.Version
-	// Override GetDefinitionName to use REST-friendly naming for SSA compatibility.
-	// This ensures the OpenAPI schema names match what the TypeConverter expects.
-	genericConfig.OpenAPIV3Config.GetDefinitionName = func(name string) (string, spec.Extensions) {
-		friendlyName, extensions := namer.GetDefinitionName(name)
-		return openapiutil.ToRESTFriendlyName(friendlyName), extensions
-	}
 
 	// Configure OpenAPI v2
-	genericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.GetOpenAPIDefinitions, namer)
+	genericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.GetOpenAPIDefinitionsWithRESTFriendlyKeys, namer)
 	genericConfig.OpenAPIConfig.Info.Title = "Activity"
 	genericConfig.OpenAPIConfig.Info.Version = version.Version
-	genericConfig.OpenAPIConfig.GetDefinitionName = func(name string) (string, spec.Extensions) {
-		friendlyName, extensions := namer.GetDefinitionName(name)
-		return openapiutil.ToRESTFriendlyName(friendlyName), extensions
-	}
 
 	if err := o.RecommendedOptions.ApplyTo(genericConfig); err != nil {
 		return nil, fmt.Errorf("failed to apply recommended options: %w", err)

--- a/cmd/activity/openapi_test.go
+++ b/cmd/activity/openapi_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"testing"
+
+	apiopenapi "k8s.io/apiserver/pkg/endpoints/openapi"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	activityapiserver "go.miloapis.com/activity/internal/apiserver"
+	"go.miloapis.com/activity/pkg/generated/openapi"
+)
+
+// TestOpenAPIGVKExtensions verifies that OpenAPI schemas include x-kubernetes-group-version-kind
+// extensions required for Server-Side Apply (SSA) to work correctly.
+//
+// This is a regression test for the SSA failure:
+// "no corresponding type for activity.miloapis.com/v1alpha1, Kind=ActivityPolicy"
+//
+// Root cause: The openapi-gen tool generates definition keys using Go module paths
+// (e.g., "go.miloapis.com/activity/..."), but the DefinitionNamer in k8s.io/apiserver v0.35+
+// uses scheme.ToOpenAPIDefinitionName() which returns REST-friendly names
+// (e.g., "com.miloapis.go.activity..."). This mismatch caused GVK extensions to not be added.
+//
+// Fix: GetOpenAPIDefinitionsWithRESTFriendlyKeys transforms keys to match the namer's format.
+func TestOpenAPIGVKExtensions(t *testing.T) {
+	// Build the DefinitionNamer using the same scheme as the API server
+	namer := apiopenapi.NewDefinitionNamer(activityapiserver.Scheme)
+
+	// Get OpenAPI definitions using the REST-friendly key wrapper (as used in production)
+	defs := openapi.GetOpenAPIDefinitionsWithRESTFriendlyKeys(func(path string) spec.Ref {
+		return spec.Ref{}
+	})
+
+	// Test cases for types that need GVK extensions for SSA
+	// Keys are in REST-friendly format (as used by the wrapper and DefinitionNamer)
+	testCases := []struct {
+		restFriendlyKey string
+		expectedGroup   string
+		expectedKind    string
+	}{
+		{
+			restFriendlyKey: "com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityPolicy",
+			expectedGroup:   "activity.miloapis.com",
+			expectedKind:    "ActivityPolicy",
+		},
+		{
+			restFriendlyKey: "com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityPolicyList",
+			expectedGroup:   "activity.miloapis.com",
+			expectedKind:    "ActivityPolicyList",
+		},
+		{
+			restFriendlyKey: "com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ReindexJob",
+			expectedGroup:   "activity.miloapis.com",
+			expectedKind:    "ReindexJob",
+		},
+		{
+			restFriendlyKey: "com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ReindexJobList",
+			expectedGroup:   "activity.miloapis.com",
+			expectedKind:    "ReindexJobList",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.restFriendlyKey, func(t *testing.T) {
+			// Verify type is in OpenAPI definitions (using REST-friendly key)
+			if _, ok := defs[tc.restFriendlyKey]; !ok {
+				t.Fatalf("Type %q not found in OpenAPI definitions", tc.restFriendlyKey)
+			}
+
+			// Get definition name and extensions from namer (using REST-friendly key)
+			_, extensions := namer.GetDefinitionName(tc.restFriendlyKey)
+
+			// Verify GVK extension is present
+			if extensions == nil {
+				t.Fatalf("No extensions returned for %q - GVK extension missing! "+
+					"This will cause SSA to fail with 'no corresponding type' error", tc.restFriendlyKey)
+			}
+
+			gvkExt, ok := extensions["x-kubernetes-group-version-kind"]
+			if !ok {
+				t.Fatalf("x-kubernetes-group-version-kind extension not found for %q", tc.restFriendlyKey)
+			}
+
+			// Verify GVK contains expected values
+			gvks, ok := gvkExt.([]interface{})
+			if !ok {
+				t.Fatalf("GVK extension is not an array: %T", gvkExt)
+			}
+
+			found := false
+			for _, gvk := range gvks {
+				gvkMap, ok := gvk.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if gvkMap["group"] == tc.expectedGroup &&
+					gvkMap["version"] == "v1alpha1" &&
+					gvkMap["kind"] == tc.expectedKind {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("Expected GVK {group: %q, version: v1alpha1, kind: %q} not found in extensions: %v",
+					tc.expectedGroup, tc.expectedKind, gvkExt)
+			}
+		})
+	}
+}
+
+// TestDefinitionNamerHasActivityTypes verifies that the DefinitionNamer has entries
+// for all Activity API types. This catches issues where types aren't registered
+// correctly in the scheme.
+func TestDefinitionNamerHasActivityTypes(t *testing.T) {
+	namer := apiopenapi.NewDefinitionNamer(activityapiserver.Scheme)
+
+	// Check that the namer returns non-nil extensions for Activity types
+	// Keys must be in REST-friendly format (as returned by scheme.ToOpenAPIDefinitionName)
+	types := []string{
+		"com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityPolicy",
+		"com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityPolicyList",
+		"com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ReindexJob",
+		"com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ReindexJobList",
+		"com.miloapis.go.activity.pkg.apis.activity.v1alpha1.Activity",
+		"com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityList",
+	}
+
+	for _, typePath := range types {
+		_, extensions := namer.GetDefinitionName(typePath)
+		if extensions == nil {
+			t.Errorf("DefinitionNamer returned nil extensions for %q - "+
+				"type may not be registered in scheme correctly", typePath)
+		}
+	}
+}

--- a/pkg/generated/openapi/definitions.go
+++ b/pkg/generated/openapi/definitions.go
@@ -1,0 +1,51 @@
+package openapi
+
+import (
+	common "k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/util"
+	spec "k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// GetOpenAPIDefinitionsWithRESTFriendlyKeys wraps the generated GetOpenAPIDefinitions
+// and transforms all definition keys to REST-friendly format.
+//
+// This is required because:
+// 1. The openapi-gen tool generates definition keys using Go module paths (e.g., "go.miloapis.com/activity/...")
+// 2. The DefinitionNamer in k8s.io/apiserver v0.35+ uses scheme.ToOpenAPIDefinitionName() which returns REST-friendly names (e.g., "com.miloapis.go.activity...")
+// 3. When GetDefinitionName is called during OpenAPI schema building, the keys don't match
+// 4. This causes GVK extensions (x-kubernetes-group-version-kind) to not be added
+// 5. Without GVK extensions, Server-Side Apply (SSA) fails with "no corresponding type" errors
+//
+// By transforming keys to REST-friendly format, we ensure the keys match what the DefinitionNamer expects.
+func GetOpenAPIDefinitionsWithRESTFriendlyKeys(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
+	originalDefs := GetOpenAPIDefinitions(ref)
+	transformedDefs := make(map[string]common.OpenAPIDefinition, len(originalDefs))
+
+	for key, def := range originalDefs {
+		// Transform the key to REST-friendly format
+		// e.g., "go.miloapis.com/activity/pkg/apis/activity/v1alpha1.ActivityPolicy"
+		// becomes "com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityPolicy"
+		restFriendlyKey := util.ToRESTFriendlyName(key)
+		transformedDefs[restFriendlyKey] = def
+	}
+
+	// Also add the missing definition for unstructured.Unstructured which is a
+	// special Kubernetes type that does not carry +k8s:openapi-gen markers.
+	// This is needed when types reference unstructured objects.
+	unstructuredKey := util.ToRESTFriendlyName("k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured")
+	transformedDefs[unstructuredKey] = common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Unstructured represents a Kubernetes resource as an arbitrary JSON object.",
+				Type:        []string{"object"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-preserve-unknown-fields": true,
+				},
+			},
+		},
+	}
+
+	return transformedDefs
+}


### PR DESCRIPTION
## Summary
- Fixes Server-Side Apply (SSA) failures when applying ActivityPolicy resources through FluxCD/kustomize
- Root cause: Key format mismatch between openapi-gen (Go module paths) and DefinitionNamer (REST-friendly names)
- Solution: Create `GetOpenAPIDefinitionsWithRESTFriendlyKeys` wrapper that transforms keys to match what the namer expects

## Root Cause Analysis

The `openapi-gen` tool generates definition keys using Go module paths:
```
go.miloapis.com/activity/pkg/apis/activity/v1alpha1.ActivityPolicy
```

But the `DefinitionNamer` in k8s.io/apiserver v0.35+ uses `scheme.ToOpenAPIDefinitionName()` which returns REST-friendly names:
```
com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityPolicy
```

When `GetDefinitionName` is called during OpenAPI schema building, the keys don't match what the namer expects, so GVK extensions (`x-kubernetes-group-version-kind`) are not added. Without these extensions, the TypeConverter can't find types by GVK, causing SSA to fail with:
```
no corresponding type for activity.miloapis.com/v1alpha1, Kind=ActivityPolicy
```

## Changes
- `pkg/generated/openapi/definitions.go`: New wrapper that transforms keys to REST-friendly format
- `cmd/activity/main.go`: Use the new wrapper for OpenAPI configuration
- `cmd/activity/openapi_test.go`: Regression test to ensure GVK extensions are present

## Test plan
- [x] Unit tests verify GVK extensions are present for ActivityPolicy, ReindexJob
- [ ] Deploy to staging and verify SSA works for ActivityPolicy resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)