### PR TITLE
fix: OpenAPI SSA compatibility for ActivityPolicy resources

### DIFF
--- a/cmd/activity/main.go
+++ b/cmd/activity/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -23,6 +24,9 @@ import (
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
+	openapicommon "k8s.io/kube-openapi/pkg/common"
+	openapiutil "k8s.io/kube-openapi/pkg/util"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	// Register JSON logging format
 	_ "k8s.io/component-base/logs/json/register"
@@ -269,20 +273,58 @@ func (o *ActivityServerOptions) Config() (*activityapiserver.Config, error) {
 	// Set effective version to match the Kubernetes version we're built against.
 	genericConfig.EffectiveVersion = basecompatibility.NewEffectiveVersionFromString("1.34", "", "")
 
-	// Use GetOpenAPIDefinitionsWithRESTFriendlyKeys which transforms definition keys to
-	// match what the DefinitionNamer expects. This is required because:
-	// - openapi-gen generates keys using Go module paths (e.g., "go.miloapis.com/...")
-	// - DefinitionNamer uses scheme.ToOpenAPIDefinitionName() which returns REST-friendly names (e.g., "com.miloapis.go...")
-	// - Without matching keys, GVK extensions aren't added and SSA fails with "no corresponding type"
+	// Configure OpenAPI for SSA compatibility.
+	//
+	// The DefinitionNamer in k8s.io/apiserver uses scheme.ToOpenAPIDefinitionName() which
+	// returns REST-friendly names (e.g., "com.miloapis.go.activity..."). GVK extensions
+	// are only returned when the name matches what's in DefinitionNamer's internal map.
+	//
+	// The OpenAPI builder uses reflection to get type names (Go module paths like
+	// "go.miloapis.com/activity/...") and looks them up in the definitions map. So
+	// definition keys must remain in Go module path format for lookups to work.
+	//
+	// Our approach:
+	// 1. GetOpenAPIDefinitionsWithUnstructured keeps keys in Go module path format
+	// 2. Custom GetDefinitionName transforms Go module paths to REST-friendly format
+	//    before looking up in DefinitionNamer (to get GVK extensions)
+	// 3. The builder's internal ref callback uses GetDefinitionName, so $refs in the
+	//    final spec use REST-friendly names matching the definition names
 	namer := apiopenapi.NewDefinitionNamer(activityapiserver.Scheme)
-	genericConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(openapi.GetOpenAPIDefinitionsWithRESTFriendlyKeys, namer)
+
+	// Custom GetDefinitionName that transforms Go module paths to REST-friendly format
+	// before looking up in DefinitionNamer. This ensures GVK extensions are returned.
+	getDefinitionName := func(name string) (string, spec.Extensions) {
+		if strings.Contains(name, "/") {
+			// Go module path - transform to REST-friendly format to match
+			// what DefinitionNamer expects (from scheme.ToOpenAPIDefinitionName)
+			name = openapiutil.ToRESTFriendlyName(name)
+		}
+		return namer.GetDefinitionName(name)
+	}
+
+	// OpenAPI v3 config
+	genericConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(openapi.GetOpenAPIDefinitionsWithUnstructured, namer)
 	genericConfig.OpenAPIV3Config.Info.Title = "Activity"
 	genericConfig.OpenAPIV3Config.Info.Version = version.Version
+	genericConfig.OpenAPIV3Config.GetDefinitionName = getDefinitionName
+	// Re-compute Definitions with our custom getDefinitionName so $refs use REST-friendly names.
+	// DefaultOpenAPIV3Config computes Definitions with the original namer, but we need refs
+	// to match our transformed definition names for SSA TypeConverter lookups.
+	genericConfig.OpenAPIV3Config.Definitions = openapi.GetOpenAPIDefinitionsWithUnstructured(func(name string) spec.Ref {
+		defName, _ := getDefinitionName(name)
+		return spec.MustCreateRef("#/components/schemas/" + openapicommon.EscapeJsonPointer(defName))
+	})
 
-	// Configure OpenAPI v2
-	genericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.GetOpenAPIDefinitionsWithRESTFriendlyKeys, namer)
+	// OpenAPI v2 config
+	genericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.GetOpenAPIDefinitionsWithUnstructured, namer)
 	genericConfig.OpenAPIConfig.Info.Title = "Activity"
 	genericConfig.OpenAPIConfig.Info.Version = version.Version
+	genericConfig.OpenAPIConfig.GetDefinitionName = getDefinitionName
+	// Re-compute Definitions for v2 as well
+	genericConfig.OpenAPIConfig.Definitions = openapi.GetOpenAPIDefinitionsWithUnstructured(func(name string) spec.Ref {
+		defName, _ := getDefinitionName(name)
+		return spec.MustCreateRef("#/definitions/" + openapicommon.EscapeJsonPointer(defName))
+	})
 
 	if err := o.RecommendedOptions.ApplyTo(genericConfig); err != nil {
 		return nil, fmt.Errorf("failed to apply recommended options: %w", err)

--- a/cmd/activity/openapi_test.go
+++ b/cmd/activity/openapi_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	apiopenapi "k8s.io/apiserver/pkg/endpoints/openapi"
+	openapiutil "k8s.io/kube-openapi/pkg/util"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	activityapiserver "go.miloapis.com/activity/internal/apiserver"
@@ -16,72 +18,73 @@ import (
 // This is a regression test for the SSA failure:
 // "no corresponding type for activity.miloapis.com/v1alpha1, Kind=ActivityPolicy"
 //
-// Root cause: The openapi-gen tool generates definition keys using Go module paths
-// (e.g., "go.miloapis.com/activity/..."), but the DefinitionNamer in k8s.io/apiserver v0.35+
-// uses scheme.ToOpenAPIDefinitionName() which returns REST-friendly names
-// (e.g., "com.miloapis.go.activity..."). This mismatch caused GVK extensions to not be added.
-//
-// Fix: GetOpenAPIDefinitionsWithRESTFriendlyKeys transforms keys to match the namer's format.
+// Root cause: The DefinitionNamer only returns GVK extensions when looking up names
+// in REST-friendly format. The OpenAPI builder uses reflection to get Go module paths,
+// so we need GetDefinitionName to transform Go module paths before DefinitionNamer lookup.
 func TestOpenAPIGVKExtensions(t *testing.T) {
-	// Build the DefinitionNamer using the same scheme as the API server
 	namer := apiopenapi.NewDefinitionNamer(activityapiserver.Scheme)
 
-	// Get OpenAPI definitions using the REST-friendly key wrapper (as used in production)
-	defs := openapi.GetOpenAPIDefinitionsWithRESTFriendlyKeys(func(path string) spec.Ref {
+	// Custom GetDefinitionName that transforms Go module paths to REST-friendly format
+	// This mirrors the implementation in main.go
+	getDefinitionName := func(name string) (string, spec.Extensions) {
+		if strings.Contains(name, "/") {
+			name = openapiutil.ToRESTFriendlyName(name)
+		}
+		return namer.GetDefinitionName(name)
+	}
+
+	defs := openapi.GetOpenAPIDefinitionsWithUnstructured(func(path string) spec.Ref {
 		return spec.Ref{}
 	})
 
-	// Test cases for types that need GVK extensions for SSA
-	// Keys are in REST-friendly format (as used by the wrapper and DefinitionNamer)
+	// Activity types should be present with Go module path keys
+	// GetDefinitionName must transform these to REST-friendly format for GVK lookup
 	testCases := []struct {
-		restFriendlyKey string
-		expectedGroup   string
-		expectedKind    string
+		goModulePath  string
+		expectedGroup string
+		expectedKind  string
 	}{
 		{
-			restFriendlyKey: "com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityPolicy",
-			expectedGroup:   "activity.miloapis.com",
-			expectedKind:    "ActivityPolicy",
+			goModulePath:  "go.miloapis.com/activity/pkg/apis/activity/v1alpha1.ActivityPolicy",
+			expectedGroup: "activity.miloapis.com",
+			expectedKind:  "ActivityPolicy",
 		},
 		{
-			restFriendlyKey: "com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityPolicyList",
-			expectedGroup:   "activity.miloapis.com",
-			expectedKind:    "ActivityPolicyList",
+			goModulePath:  "go.miloapis.com/activity/pkg/apis/activity/v1alpha1.ActivityPolicyList",
+			expectedGroup: "activity.miloapis.com",
+			expectedKind:  "ActivityPolicyList",
 		},
 		{
-			restFriendlyKey: "com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ReindexJob",
-			expectedGroup:   "activity.miloapis.com",
-			expectedKind:    "ReindexJob",
+			goModulePath:  "go.miloapis.com/activity/pkg/apis/activity/v1alpha1.ReindexJob",
+			expectedGroup: "activity.miloapis.com",
+			expectedKind:  "ReindexJob",
 		},
 		{
-			restFriendlyKey: "com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ReindexJobList",
-			expectedGroup:   "activity.miloapis.com",
-			expectedKind:    "ReindexJobList",
+			goModulePath:  "go.miloapis.com/activity/pkg/apis/activity/v1alpha1.ReindexJobList",
+			expectedGroup: "activity.miloapis.com",
+			expectedKind:  "ReindexJobList",
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.restFriendlyKey, func(t *testing.T) {
-			// Verify type is in OpenAPI definitions (using REST-friendly key)
-			if _, ok := defs[tc.restFriendlyKey]; !ok {
-				t.Fatalf("Type %q not found in OpenAPI definitions", tc.restFriendlyKey)
+		t.Run(tc.goModulePath, func(t *testing.T) {
+			// Verify the definition exists with Go module path key
+			if _, ok := defs[tc.goModulePath]; !ok {
+				t.Fatalf("Type %q not found in OpenAPI definitions", tc.goModulePath)
 			}
 
-			// Get definition name and extensions from namer (using REST-friendly key)
-			_, extensions := namer.GetDefinitionName(tc.restFriendlyKey)
-
-			// Verify GVK extension is present
+			// Verify GetDefinitionName returns GVK extensions after transformation
+			defName, extensions := getDefinitionName(tc.goModulePath)
 			if extensions == nil {
-				t.Fatalf("No extensions returned for %q - GVK extension missing! "+
-					"This will cause SSA to fail with 'no corresponding type' error", tc.restFriendlyKey)
+				t.Fatalf("No extensions returned for %q (transformed to %q) - GVK extension missing! "+
+					"This will cause SSA to fail with 'no corresponding type' error", tc.goModulePath, defName)
 			}
 
 			gvkExt, ok := extensions["x-kubernetes-group-version-kind"]
 			if !ok {
-				t.Fatalf("x-kubernetes-group-version-kind extension not found for %q", tc.restFriendlyKey)
+				t.Fatalf("x-kubernetes-group-version-kind extension not found for %q", tc.goModulePath)
 			}
 
-			// Verify GVK contains expected values
 			gvks, ok := gvkExt.([]interface{})
 			if !ok {
 				t.Fatalf("GVK extension is not an array: %T", gvkExt)
@@ -109,28 +112,80 @@ func TestOpenAPIGVKExtensions(t *testing.T) {
 	}
 }
 
-// TestDefinitionNamerHasActivityTypes verifies that the DefinitionNamer has entries
-// for all Activity API types. This catches issues where types aren't registered
-// correctly in the scheme.
-func TestDefinitionNamerHasActivityTypes(t *testing.T) {
-	namer := apiopenapi.NewDefinitionNamer(activityapiserver.Scheme)
+// TestCoreV1EventKeysPreserved verifies that standard Kubernetes types using
+// OpenAPIModelName() keys are present and NOT mangled.
+func TestCoreV1EventKeysPreserved(t *testing.T) {
+	defs := openapi.GetOpenAPIDefinitionsWithUnstructured(func(path string) spec.Ref {
+		return spec.Ref{}
+	})
 
-	// Check that the namer returns non-nil extensions for Activity types
-	// Keys must be in REST-friendly format (as returned by scheme.ToOpenAPIDefinitionName)
-	types := []string{
-		"com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityPolicy",
-		"com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityPolicyList",
-		"com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ReindexJob",
-		"com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ReindexJobList",
-		"com.miloapis.go.activity.pkg.apis.activity.v1alpha1.Activity",
-		"com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityList",
+	// These keys come from OpenAPIModelName() and must be preserved exactly
+	coreTypes := []string{
+		"io.k8s.api.core.v1.Event",
+		"io.k8s.api.core.v1.EventList",
+		"io.k8s.api.events.v1.Event",
+		"io.k8s.api.events.v1.EventList",
 	}
 
-	for _, typePath := range types {
-		_, extensions := namer.GetDefinitionName(typePath)
-		if extensions == nil {
-			t.Errorf("DefinitionNamer returned nil extensions for %q - "+
-				"type may not be registered in scheme correctly", typePath)
+	for _, key := range coreTypes {
+		t.Run(key, func(t *testing.T) {
+			if _, ok := defs[key]; !ok {
+				t.Errorf("Core type %q not found in definitions", key)
+			}
+		})
+	}
+}
+
+// TestUnstructuredTypeIncluded verifies that the Unstructured type is included
+// in the definitions (required for some SSA operations).
+func TestUnstructuredTypeIncluded(t *testing.T) {
+	defs := openapi.GetOpenAPIDefinitionsWithUnstructured(func(path string) spec.Ref {
+		return spec.Ref{}
+	})
+
+	unstructuredKey := "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"
+	if _, ok := defs[unstructuredKey]; !ok {
+		t.Errorf("Unstructured type %q not found in definitions", unstructuredKey)
+	}
+}
+
+// TestOpenAPIV3Builder verifies that the OpenAPI v3 builder can successfully
+// build definitions for our types using the same configuration as the actual server.
+func TestOpenAPIV3Builder(t *testing.T) {
+	namer := apiopenapi.NewDefinitionNamer(activityapiserver.Scheme)
+
+	// Custom GetDefinitionName that transforms Go module paths
+	getDefinitionName := func(name string) (string, spec.Extensions) {
+		if strings.Contains(name, "/") {
+			name = openapiutil.ToRESTFriendlyName(name)
+		}
+		return namer.GetDefinitionName(name)
+	}
+
+	// Build definitions the same way DefaultOpenAPIV3Config does
+	defs := openapi.GetOpenAPIDefinitionsWithUnstructured(func(name string) spec.Ref {
+		defName, _ := getDefinitionName(name)
+		return spec.MustCreateRef("#/components/schemas/" + defName)
+	})
+
+	// Check that all Activity types are present with Go module path keys
+	activityTypes := []string{
+		"go.miloapis.com/activity/pkg/apis/activity/v1alpha1.ActivityPolicy",
+		"go.miloapis.com/activity/pkg/apis/activity/v1alpha1.ReindexJob",
+		"go.miloapis.com/activity/pkg/apis/activity/v1alpha1.AuditLogQuery",
+		"go.miloapis.com/activity/pkg/apis/activity/v1alpha1.Activity",
+	}
+
+	for _, typeName := range activityTypes {
+		if _, ok := defs[typeName]; !ok {
+			// List all keys to help debug
+			keys := make([]string, 0, len(defs))
+			for k := range defs {
+				if strings.Contains(k, "activity") {
+					keys = append(keys, k)
+				}
+			}
+			t.Errorf("Type %q not found in definitions. Activity-related keys: %v", typeName, keys)
 		}
 	}
 }

--- a/pkg/generated/openapi/definitions.go
+++ b/pkg/generated/openapi/definitions.go
@@ -2,38 +2,25 @@ package openapi
 
 import (
 	common "k8s.io/kube-openapi/pkg/common"
-	"k8s.io/kube-openapi/pkg/util"
 	spec "k8s.io/kube-openapi/pkg/validation/spec"
 )
 
-// GetOpenAPIDefinitionsWithRESTFriendlyKeys wraps the generated GetOpenAPIDefinitions
-// and transforms all definition keys to REST-friendly format.
+// GetOpenAPIDefinitionsWithUnstructured wraps the generated GetOpenAPIDefinitions
+// and adds the Unstructured type definition which doesn't carry +k8s:openapi-gen markers.
 //
-// This is required because:
-// 1. The openapi-gen tool generates definition keys using Go module paths (e.g., "go.miloapis.com/activity/...")
-// 2. The DefinitionNamer in k8s.io/apiserver v0.35+ uses scheme.ToOpenAPIDefinitionName() which returns REST-friendly names (e.g., "com.miloapis.go.activity...")
-// 3. When GetDefinitionName is called during OpenAPI schema building, the keys don't match
-// 4. This causes GVK extensions (x-kubernetes-group-version-kind) to not be added
-// 5. Without GVK extensions, Server-Side Apply (SSA) fails with "no corresponding type" errors
+// IMPORTANT: This function does NOT transform keys. Keys remain in their original format
+// (Go module paths like "go.miloapis.com/activity/...") because the OpenAPI builder uses
+// reflection to get type names and looks them up in the definitions map.
 //
-// By transforming keys to REST-friendly format, we ensure the keys match what the DefinitionNamer expects.
-func GetOpenAPIDefinitionsWithRESTFriendlyKeys(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
+// For GVK extensions (required for SSA), the GetDefinitionName function must transform
+// Go module paths to REST-friendly format before looking up in DefinitionNamer. This
+// transformation is done in main.go's getDefinitionName wrapper.
+func GetOpenAPIDefinitionsWithUnstructured(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	originalDefs := GetOpenAPIDefinitions(ref)
-	transformedDefs := make(map[string]common.OpenAPIDefinition, len(originalDefs))
 
-	for key, def := range originalDefs {
-		// Transform the key to REST-friendly format
-		// e.g., "go.miloapis.com/activity/pkg/apis/activity/v1alpha1.ActivityPolicy"
-		// becomes "com.miloapis.go.activity.pkg.apis.activity.v1alpha1.ActivityPolicy"
-		restFriendlyKey := util.ToRESTFriendlyName(key)
-		transformedDefs[restFriendlyKey] = def
-	}
-
-	// Also add the missing definition for unstructured.Unstructured which is a
-	// special Kubernetes type that does not carry +k8s:openapi-gen markers.
-	// This is needed when types reference unstructured objects.
-	unstructuredKey := util.ToRESTFriendlyName("k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured")
-	transformedDefs[unstructuredKey] = common.OpenAPIDefinition{
+	// Add the Unstructured type which doesn't carry +k8s:openapi-gen markers
+	// Use the Go module path format to match how other definitions are keyed
+	originalDefs["k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"] = common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Unstructured represents a Kubernetes resource as an arbitrary JSON object.",
@@ -47,5 +34,5 @@ func GetOpenAPIDefinitionsWithRESTFriendlyKeys(ref common.ReferenceCallback) map
 		},
 	}
 
-	return transformedDefs
+	return originalDefs
 }


### PR DESCRIPTION
## Summary

Fixes Server-Side Apply (SSA) failures for ActivityPolicy and ReindexJob resources when applied via FluxCD/kustomize or `kubectl apply --server-side`.

**Error before fix:**
```
Error from server: failed to create manager for existing fields: failed to convert new object 
to smd typed: errors:
  .spec: schema error: no type found matching: go.miloapis.com~1activity~1...ActivityPolicySpec
```

**Root cause:** The OpenAPI builder creates `$refs` using the reference callback provided during `DefaultOpenAPIV3Config`. This callback was using the original `DefinitionNamer` which doesn't transform Go module paths, resulting in refs like `#/components/schemas/go.miloapis.com~1...` that don't match the actual REST-friendly definition names.

**Fix:**
1. Keep definition keys in Go module path format (required for builder lookups via reflection)
2. Use custom `GetDefinitionName` that transforms Go module paths to REST-friendly format before DefinitionNamer lookup (returns GVK extensions)
3. Re-compute `Definitions` after setting `GetDefinitionName` so `$refs` use REST-friendly names matching definition names

## Test plan

- [x] Unit tests pass (`go test ./cmd/activity/...`)
- [x] `kubectl apply --server-side` creates ActivityPolicy successfully
- [x] `kubectl apply --server-side` updates ActivityPolicy successfully  
- [x] OpenAPI schema shows correct definition names and `$refs`
- [x] GVK extensions present (`x-kubernetes-group-version-kind`)
- [x] Verified in KIND test cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)