### PR TITLE
fix: correct events publisher metrics and dashboard queries

### DIFF
--- a/config/components/observability/dashboards/generated/activity-processor.json
+++ b/config/components/observability/dashboards/generated/activity-processor.json
@@ -38,7 +38,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum(rate(activity_processor_audit_events_received_total[5m]))",
+               "expr": "sum(rate(activity_processor_events_received_total[5m]))",
                "legendFormat": "Events/s"
             }
          ],
@@ -138,7 +138,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "(sum(rate(activity_processor_audit_events_errored_total[5m])) or vector(0)) / (sum(rate(activity_processor_audit_events_received_total[5m])) or vector(1)) * 100",
+               "expr": "(sum(rate(activity_processor_events_errored_total[5m])) or vector(0)) / (sum(rate(activity_processor_events_received_total[5m])) or vector(1)) * 100",
                "legendFormat": "Error %"
             }
          ],
@@ -244,7 +244,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum(rate(activity_processor_audit_events_received_total[5m])) by (api_group)",
+               "expr": "sum(rate(activity_processor_events_received_total[5m])) by (api_group)",
                "legendFormat": "{{api_group}}"
             }
          ],
@@ -292,7 +292,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum(rate(activity_processor_audit_events_evaluated_total[5m]))",
+               "expr": "sum(rate(activity_processor_events_evaluated_total[5m]))",
                "legendFormat": "Evaluated"
             },
             {
@@ -350,7 +350,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum(rate(activity_processor_audit_events_skipped_total[5m])) by (reason)",
+               "expr": "sum(rate(activity_processor_events_skipped_total[5m])) by (reason)",
                "legendFormat": "{{reason}}"
             }
          ],
@@ -861,7 +861,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum(rate(activity_processor_audit_events_errored_total[5m])) by (error_type) or vector(0)",
+               "expr": "sum(rate(activity_processor_events_errored_total[5m])) by (error_type) or vector(0)",
                "legendFormat": "{{error_type}}"
             }
          ],

--- a/config/components/observability/dashboards/generated/activity-system-overview.json
+++ b/config/components/observability/dashboards/generated/activity-system-overview.json
@@ -652,7 +652,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "(sum(rate(activity_processor_nats_errors_total[5m])) or vector(0)) + (sum(rate(activity_processor_audit_events_skipped_total[5m])) or vector(0))",
+               "expr": "(sum(rate(activity_processor_nats_errors_total[5m])) or vector(0)) + (sum(rate(activity_processor_events_skipped_total[5m])) or vector(0))",
                "legendFormat": "Processor"
             },
             {

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -157,13 +157,12 @@ Exposed on port 8081 at `/metrics` endpoint.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `activity_processor_audit_events_received_total` | counter | `api_group`, `resource` | Audit events received from NATS |
-| `activity_processor_k8s_events_received_total` | counter | `namespace`, `reason` | Cluster events received from NATS |
-| `activity_processor_audit_events_evaluated_total` | counter | `policy_name`, `api_group`, `kind`, `matched` | Events evaluated against policies |
-| `activity_processor_audit_events_skipped_total` | counter | `reason` | Events skipped during processing |
-| `activity_processor_audit_events_errored_total` | counter | `error_type` | Events that failed processing |
+| `activity_processor_events_received_total` | counter | `source`, `api_group`, `resource` | Events received from NATS (`source` is `audit_log` or `control_plane_event`) |
+| `activity_processor_events_evaluated_total` | counter | `source`, `policy_name`, `api_group`, `kind`, `matched` | Events evaluated against policies |
+| `activity_processor_events_skipped_total` | counter | `source`, `reason` | Events skipped during processing |
+| `activity_processor_events_errored_total` | counter | `source`, `error_type` | Events that failed processing |
 | `activity_processor_activities_generated_total` | counter | `policy_name`, `api_group`, `kind` | Activities successfully generated |
-| `activity_processor_audit_event_processing_duration_seconds` | histogram | `policy_name` | Time to process an event |
+| `activity_processor_event_processing_duration_seconds` | histogram | `source`, `policy_name` | Time to process an event |
 
 **Skip reasons:**
 - `no_matching_policy` - No policy matched the event
@@ -255,21 +254,24 @@ kubectl exec -n activity-system <pod-name> -- wget -qO- http://localhost:8081/me
 Example queries:
 
 ```promql
-# Event processing rate
-rate(activity_processor_audit_events_received_total[5m])
+# Event processing rate (all sources)
+rate(activity_processor_events_received_total[5m])
+
+# Audit log event processing rate only
+rate(activity_processor_events_received_total{source="audit_log"}[5m])
 
 # Activity generation rate
 rate(activity_processor_activities_generated_total[5m])
 
-# Error rate percentage
-sum(rate(activity_processor_audit_events_errored_total[5m]))
+# Error rate percentage (all sources)
+sum(rate(activity_processor_events_errored_total[5m]))
 /
-sum(rate(activity_processor_audit_events_received_total[5m]))
+sum(rate(activity_processor_events_received_total[5m]))
 * 100
 
 # Processing latency p99
 histogram_quantile(0.99,
-  sum(rate(activity_processor_audit_event_processing_duration_seconds_bucket[5m])) by (le)
+  sum(rate(activity_processor_event_processing_duration_seconds_bucket[5m])) by (le)
 )
 
 # Active policies
@@ -851,22 +853,21 @@ Complete list of panels and queries:
 
 | Panel | Query | Purpose |
 |-------|-------|---------|
-| Event Processing Rate | `sum(rate(activity_processor_audit_events_received_total[5m]))` | Incoming event volume |
+| Event Processing Rate | `sum(rate(activity_processor_events_received_total[5m]))` | Incoming event volume (all sources) |
 | Activity Generation Rate | `sum(rate(activity_processor_activities_generated_total[5m]))` | Output activity volume |
-| Error Rate | `sum(rate(..._errored_total[5m])) / sum(rate(..._received_total[5m])) * 100` | Processing health |
+| Error Rate | `sum(rate(activity_processor_events_errored_total[5m])) / sum(rate(activity_processor_events_received_total[5m])) * 100` | Processing health |
 | Active Policies | `activity_processor_active_policies` | Policy cache state |
-| Events by Type | `sum(rate(..._audit_events_received_total[5m]))` | Event type breakdown |
-|  | `sum(rate(..._k8s_events_received_total[5m]))` |  |
-| Events Evaluated vs Generated | `sum(rate(..._evaluated_total[5m]))` | Conversion efficiency |
-|  | `sum(rate(..._generated_total[5m]))` |  |
-| Skipped Events by Reason | `sum(rate(..._skipped_total[5m])) by (reason)` | Skip reason breakdown |
-| Processing Duration p99 by Policy | `histogram_quantile(0.99, sum(rate(..._duration_seconds_bucket[5m])) by (policy_name, le))` | Policy performance |
+| Events by API Group | `sum(rate(activity_processor_events_received_total[5m])) by (api_group)` | Event breakdown by API group |
+| Events Evaluated vs Generated | `sum(rate(activity_processor_events_evaluated_total[5m]))` | Conversion efficiency |
+|  | `sum(rate(activity_processor_activities_generated_total[5m]))` |  |
+| Skipped Events by Reason | `sum(rate(activity_processor_events_skipped_total[5m])) by (reason)` | Skip reason breakdown |
+| Processing Duration p99 by Policy | `histogram_quantile(0.99, sum(rate(activity_processor_event_processing_duration_seconds_bucket[5m])) by (policy, le))` | Policy performance |
 | NATS Connection Status | `min(activity_processor_nats_connection_status)` | Connection health |
 | NATS Disconnects | `sum(activity_processor_nats_disconnects_total)` | Disconnect count |
-| NATS Publish Latency p99 | `histogram_quantile(0.99, sum(rate(..._publish_latency_seconds_bucket[5m])) by (le))` | Publish performance |
-| Messages Published Rate | `sum(rate(..._messages_published_total[5m]))` | NATS throughput |
+| NATS Publish Latency p99 | `histogram_quantile(0.99, sum(rate(activity_processor_nats_publish_latency_seconds_bucket[5m])) by (le))` | Publish performance |
+| Messages Published Rate | `sum(rate(activity_processor_nats_messages_published_total[5m]))` | NATS throughput |
 | Active Workers | `sum(activity_processor_active_workers)` | Concurrency level |
-| Error Types Breakdown | `sum(rate(..._errored_total[5m])) by (error_type)` | Error classification |
+| Error Types Breakdown | `sum(rate(activity_processor_events_errored_total[5m])) by (error_type)` | Error classification |
 
 ## Deployment Configuration
 
@@ -966,7 +967,7 @@ kubectl port-forward -n monitoring svc/prometheus 9090:9090
 
 # Query specific metric
 # Navigate to http://localhost:9090/graph
-# Enter: activity_processor_audit_events_received_total
+# Enter: activity_processor_events_received_total
 ```
 
 ### Alerts Not Firing

--- a/internal/activityprocessor/processor.go
+++ b/internal/activityprocessor/processor.go
@@ -40,40 +40,40 @@ import (
 )
 
 var (
-	auditEventsReceived = prometheus.NewCounterVec(
+	eventsReceived = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "activity_processor",
-			Name:      "audit_events_received_total",
-			Help:      "Total number of audit events received from NATS",
+			Name:      "events_received_total",
+			Help:      "Total number of events received from NATS",
 		},
-		[]string{"api_group", "resource"},
+		[]string{"source", "api_group", "resource"},
 	)
 
-	auditEventsEvaluated = prometheus.NewCounterVec(
+	eventsEvaluated = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "activity_processor",
-			Name:      "audit_events_evaluated_total",
-			Help:      "Total number of audit events evaluated against policies",
+			Name:      "events_evaluated_total",
+			Help:      "Total number of events evaluated against policies",
 		},
-		[]string{"policy", "api_group", "kind", "matched"},
+		[]string{"source", "policy", "api_group", "kind", "matched"},
 	)
 
-	auditEventsSkipped = prometheus.NewCounterVec(
+	eventsSkipped = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "activity_processor",
-			Name:      "audit_events_skipped_total",
-			Help:      "Total number of audit events skipped",
+			Name:      "events_skipped_total",
+			Help:      "Total number of events skipped",
 		},
-		[]string{"reason"}, // "no_object_ref", "no_matching_policy"
+		[]string{"source", "reason"},
 	)
 
-	auditEventsErrored = prometheus.NewCounterVec(
+	eventsErrored = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "activity_processor",
-			Name:      "audit_events_errored_total",
-			Help:      "Total number of audit events that encountered errors",
+			Name:      "events_errored_total",
+			Help:      "Total number of events that encountered errors",
 		},
-		[]string{"error_type"}, // "unmarshal", "publish", "evaluate"
+		[]string{"source", "error_type"},
 	)
 
 	activitiesGenerated = prometheus.NewCounterVec(
@@ -85,14 +85,14 @@ var (
 		[]string{"policy", "api_group", "kind"},
 	)
 
-	auditEventProcessingDuration = prometheus.NewHistogramVec(
+	eventProcessingDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "activity_processor",
-			Name:      "audit_event_processing_duration_seconds",
-			Help:      "Time spent processing audit events per policy",
+			Name:      "event_processing_duration_seconds",
+			Help:      "Time spent processing events per policy",
 			Buckets:   prometheus.DefBuckets,
 		},
-		[]string{"policy"},
+		[]string{"source", "policy"},
 	)
 
 	policyCount = prometheus.NewGauge(
@@ -167,44 +167,17 @@ var (
 		},
 	)
 
-	// Kubernetes event processing metrics
-	k8sEventsReceived = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "activity_processor",
-			Name:      "k8s_events_received_total",
-			Help:      "Total number of Kubernetes events received from NATS",
-		},
-		[]string{"api_group", "kind"},
-	)
-
-	k8sEventsSkipped = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "activity_processor",
-			Name:      "k8s_events_skipped_total",
-			Help:      "Total number of Kubernetes events skipped",
-		},
-		[]string{"reason"}, // "no_involved_object", "no_matching_policy"
-	)
-
-	k8sEventsErrored = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "activity_processor",
-			Name:      "k8s_events_errored_total",
-			Help:      "Total number of Kubernetes events that encountered errors",
-		},
-		[]string{"error_type"}, // "unmarshal", "publish", "evaluate"
-	)
 )
 
 func init() {
 	// Use controller-runtime's registry so metrics are exposed alongside controller metrics.
 	metrics.Registry.MustRegister(
-		auditEventsReceived,
-		auditEventsEvaluated,
-		auditEventsSkipped,
-		auditEventsErrored,
+		eventsReceived,
+		eventsEvaluated,
+		eventsSkipped,
+		eventsErrored,
 		activitiesGenerated,
-		auditEventProcessingDuration,
+		eventProcessingDuration,
 		policyCount,
 		workerCount,
 		// NATS metrics
@@ -214,10 +187,6 @@ func init() {
 		natsErrorsTotal,
 		natsMessagesPublished,
 		natsPublishLatency,
-		// Kubernetes event metrics
-		k8sEventsReceived,
-		k8sEventsSkipped,
-		k8sEventsErrored,
 	)
 }
 
@@ -944,7 +913,7 @@ func (p *Processor) processMessage(msg *nats.Msg) error {
 
 	var audit auditv1.Event
 	if err := json.Unmarshal(msg.Data, &audit); err != nil {
-		auditEventsErrored.WithLabelValues("unmarshal").Inc()
+		eventsErrored.WithLabelValues("audit_log", "unmarshal").Inc()
 		// Publish to DLQ - unmarshal errors are unrecoverable
 		// Tenant is nil since we couldn't unmarshal the event
 		if dlqErr := p.dlqPublisher.PublishAuditFailure(
@@ -962,7 +931,7 @@ func (p *Processor) processMessage(msg *nats.Msg) error {
 	dlqTenant := processor.NewDeadLetterTenantFromActivity(activityTenant.Type, activityTenant.Name)
 
 	if audit.ObjectRef == nil {
-		auditEventsSkipped.WithLabelValues("no_object_ref").Inc()
+		eventsSkipped.WithLabelValues("audit_log", "no_object_ref").Inc()
 		return nil
 	}
 
@@ -970,19 +939,19 @@ func (p *Processor) processMessage(msg *nats.Msg) error {
 	if apiGroup == "" {
 		apiGroup = "core"
 	}
-	auditEventsReceived.WithLabelValues(apiGroup, audit.ObjectRef.Resource).Inc()
+	eventsReceived.WithLabelValues("audit_log", apiGroup, audit.ObjectRef.Resource).Inc()
 
 	// Get compiled policies for this resource
 	policies := p.policyCache.Get(audit.ObjectRef.APIGroup, audit.ObjectRef.Resource)
 	if len(policies) == 0 {
-		auditEventsSkipped.WithLabelValues("no_matching_policy").Inc()
+		eventsSkipped.WithLabelValues("audit_log", "no_matching_policy").Inc()
 		return nil
 	}
 
 	// Convert audit event to map for CEL evaluation
 	auditMap, err := auditToMap(&audit)
 	if err != nil {
-		auditEventsErrored.WithLabelValues("unmarshal").Inc()
+		eventsErrored.WithLabelValues("audit_log", "unmarshal").Inc()
 		// Publish to DLQ - auditToMap errors are unrecoverable
 		dlqResource := &processor.DeadLetterResource{
 			APIGroup:  audit.ObjectRef.APIGroup,
@@ -1059,32 +1028,35 @@ func (p *Processor) processMessage(msg *nats.Msg) error {
 				p.ctx, rawPayload, policy.Name, policyVersion, ruleIndex, errorType, err, dlqResource, dlqTenant,
 			); dlqErr != nil {
 				klog.ErrorS(dlqErr, "Failed to publish to DLQ, NAKing message")
-				auditEventsErrored.WithLabelValues("evaluate").Inc()
-				auditEventsEvaluated.WithLabelValues(
+				eventsErrored.WithLabelValues("audit_log", "evaluate").Inc()
+				eventsEvaluated.WithLabelValues(
+					"audit_log",
 					policy.Name,
 					policy.APIGroup,
 					policy.Kind,
 					"error",
 				).Inc()
-				auditEventProcessingDuration.WithLabelValues(policy.Name).Observe(time.Since(policyStart).Seconds())
+				eventProcessingDuration.WithLabelValues("audit_log", policy.Name).Observe(time.Since(policyStart).Seconds())
 				// Return error to NAK the message so it gets redelivered
 				return fmt.Errorf("failed to evaluate policy and publish to DLQ: %w", dlqErr)
 			}
 
 			// Successfully published to DLQ, continue to next policy (message will be ACKed)
-			auditEventsErrored.WithLabelValues("evaluate").Inc()
-			auditEventsEvaluated.WithLabelValues(
+			eventsErrored.WithLabelValues("audit_log", "evaluate").Inc()
+			eventsEvaluated.WithLabelValues(
+				"audit_log",
 				policy.Name,
 				policy.APIGroup,
 				policy.Kind,
 				"error",
 			).Inc()
-			auditEventProcessingDuration.WithLabelValues(policy.Name).Observe(time.Since(policyStart).Seconds())
+			eventProcessingDuration.WithLabelValues("audit_log", policy.Name).Observe(time.Since(policyStart).Seconds())
 			continue
 		}
 
 		ruleMatched := activity != nil
-		auditEventsEvaluated.WithLabelValues(
+		eventsEvaluated.WithLabelValues(
+			"audit_log",
 			policy.Name,
 			policy.APIGroup,
 			policy.Kind,
@@ -1092,13 +1064,13 @@ func (p *Processor) processMessage(msg *nats.Msg) error {
 		).Inc()
 
 		if !ruleMatched {
-			auditEventProcessingDuration.WithLabelValues(policy.Name).Observe(time.Since(policyStart).Seconds())
+			eventProcessingDuration.WithLabelValues("audit_log", policy.Name).Observe(time.Since(policyStart).Seconds())
 			continue
 		}
 
 		if err := p.publishActivity(activity, policy); err != nil {
-			auditEventsErrored.WithLabelValues("publish").Inc()
-			auditEventProcessingDuration.WithLabelValues(policy.Name).Observe(time.Since(policyStart).Seconds())
+			eventsErrored.WithLabelValues("audit_log", "publish").Inc()
+			eventProcessingDuration.WithLabelValues("audit_log", policy.Name).Observe(time.Since(policyStart).Seconds())
 			return fmt.Errorf("failed to publish activity: %w", err)
 		}
 
@@ -1109,7 +1081,7 @@ func (p *Processor) processMessage(msg *nats.Msg) error {
 			"auditID", audit.AuditID,
 		)
 
-		auditEventProcessingDuration.WithLabelValues(policy.Name).Observe(time.Since(policyStart).Seconds())
+		eventProcessingDuration.WithLabelValues("audit_log", policy.Name).Observe(time.Since(policyStart).Seconds())
 		return nil
 	}
 

--- a/observability/dashboards/activity-processor.jsonnet
+++ b/observability/dashboards/activity-processor.jsonnet
@@ -40,8 +40,7 @@ local allPanels = util.grid.wrapPanels([
   + stat.queryOptions.withTargets([
     prometheus.new(
       datasource,
-      // Note: Using audit_events_received_total (the actual metric name in running code)
-      'sum(rate(activity_processor_audit_events_received_total[5m]))'
+      'sum(rate(activity_processor_events_received_total[5m]))'
     )
     + prometheus.withLegendFormat('Events/s'),
   ])
@@ -79,8 +78,7 @@ local allPanels = util.grid.wrapPanels([
   + stat.queryOptions.withTargets([
     prometheus.new(
       datasource,
-      // Note: Using audit_events_errored_total (actual metric name). Falls back to 0 if no errors occurred.
-      '(sum(rate(activity_processor_audit_events_errored_total[5m])) or vector(0)) / (sum(rate(activity_processor_audit_events_received_total[5m])) or vector(1)) * 100'
+      '(sum(rate(activity_processor_events_errored_total[5m])) or vector(0)) / (sum(rate(activity_processor_events_received_total[5m])) or vector(1)) * 100'
     )
     + prometheus.withLegendFormat('Error %'),
   ])
@@ -133,8 +131,7 @@ local allPanels = util.grid.wrapPanels([
   + timeSeries.queryOptions.withTargets([
     prometheus.new(
       datasource,
-      // Note: Using audit_events_received_total with api_group label (actual metric structure)
-      'sum(rate(activity_processor_audit_events_received_total[5m])) by (api_group)'
+      'sum(rate(activity_processor_events_received_total[5m])) by (api_group)'
     )
     + prometheus.withLegendFormat('{{api_group}}'),
   ])
@@ -156,8 +153,7 @@ local allPanels = util.grid.wrapPanels([
   + timeSeries.queryOptions.withTargets([
     prometheus.new(
       datasource,
-      // Note: Using audit_events_evaluated_total (actual metric name)
-      'sum(rate(activity_processor_audit_events_evaluated_total[5m]))'
+      'sum(rate(activity_processor_events_evaluated_total[5m]))'
     )
     + prometheus.withLegendFormat('Evaluated'),
     prometheus.new(
@@ -184,8 +180,7 @@ local allPanels = util.grid.wrapPanels([
   + timeSeries.queryOptions.withTargets([
     prometheus.new(
       datasource,
-      // Note: Using audit_events_skipped_total (actual metric name)
-      'sum(rate(activity_processor_audit_events_skipped_total[5m])) by (reason)'
+      'sum(rate(activity_processor_events_skipped_total[5m])) by (reason)'
     )
     + prometheus.withLegendFormat('{{reason}}'),
   ])
@@ -421,8 +416,7 @@ local allPanels = util.grid.wrapPanels([
   + timeSeries.queryOptions.withTargets([
     prometheus.new(
       datasource,
-      // Note: Using audit_events_errored_total (actual metric name). May show no data if no errors occurred.
-      'sum(rate(activity_processor_audit_events_errored_total[5m])) by (error_type) or vector(0)'
+      'sum(rate(activity_processor_events_errored_total[5m])) by (error_type) or vector(0)'
     )
     + prometheus.withLegendFormat('{{error_type}}'),
   ])

--- a/observability/dashboards/activity-system-overview.jsonnet
+++ b/observability/dashboards/activity-system-overview.jsonnet
@@ -44,7 +44,7 @@ local queries = {
   auditPipelineErrors: 'sum(rate(vector_component_errors_total{namespace="activity-system"}[5m])) or vector(0)',
   eventsPipelineErrors: '(sum(rate(event_exporter_publish_errors_total[5m])) or vector(0)) + (sum(rate(vector_component_errors_total{component_id="clickhouse_k8s_events"}[5m])) or vector(0))',
   // Using NATS errors + skipped events as proxy for processor errors
-  processorErrors: '(sum(rate(activity_processor_nats_errors_total[5m])) or vector(0)) + (sum(rate(activity_processor_audit_events_skipped_total[5m])) or vector(0))',
+  processorErrors: '(sum(rate(activity_processor_nats_errors_total[5m])) or vector(0)) + (sum(rate(activity_processor_events_skipped_total[5m])) or vector(0))',
   // Using apiserver 5xx errors as proxy for query errors
   queryErrors: 'sum(rate(apiserver_request_total{job="activity-apiserver",code=~"5.."}[5m])) or vector(0)',
 


### PR DESCRIPTION
## Summary

- **Fix metrics registry**: Events publisher metrics (`events_nats_connection_status`, `events_published_total`, etc.) were registered with controller-runtime's Prometheus registry, but the activity-apiserver serves `/metrics` via the component-base `legacyregistry`. Moved metric definitions to `internal/metrics/metrics.go` and registered with `legacyregistry` so they are actually exposed.
- **Fix metric namespace leaking to processor**: The `init()` in `events_publisher.go` ran in every binary importing the `storage` package, causing `activity_apiserver_*` metrics to appear on the processor (always reporting 0). Metrics are now only registered when the apiserver's `internal/metrics` package is imported.
- **Consolidate processor event metrics**: Merged separate `audit_events_*` and `control_plane_events_*` metric families into unified `events_*` metrics with a `source` label (`audit_log`, `control_plane_event`). Reduces 8 metrics to 5 while preserving per-source queryability.
- **Fix stale dashboard queries**: Updated 3 Grafana dashboard jsonnet sources and regenerated JSON. Updated observability docs.

## Test plan

- [ ] Deploy to dev cluster and verify `activity_events_nats_connection_status` appears on apiserver's `/metrics` endpoint
- [ ] Verify processor no longer reports `activity_apiserver_*` metrics
- [ ] Verify processor reports `activity_processor_events_received_total{source="audit_log"}` 
- [ ] Confirm Grafana dashboards load without "No data" on events pipeline and processor panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)