### PR TITLE
feat: enable JSON structured logging across all activity components

### DIFF
--- a/cmd/activity/controller_manager.go
+++ b/cmd/activity/controller_manager.go
@@ -12,12 +12,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"go.miloapis.com/activity/internal/controller"
 )
@@ -49,11 +50,14 @@ type ControllerManagerOptions struct {
 	// JobTemplateConfigMap specifies the ConfigMap containing the Job template.
 	// Format: namespace/name. If not set, a default template is used.
 	JobTemplateConfigMap string
+
+	Logs *logsapi.LoggingConfiguration
 }
 
 // NewControllerManagerOptions creates options with default values.
 func NewControllerManagerOptions() *ControllerManagerOptions {
 	return &ControllerManagerOptions{
+		Logs:                     logsapi.NewLoggingConfiguration(),
 		Workers:                  2,
 		MetricsAddr:              ":8080",
 		HealthProbeAddr:          ":8081",
@@ -110,6 +114,8 @@ func (o *ControllerManagerOptions) AddFlags(fs *pflag.FlagSet) {
 		"ConfigMap containing the Job template for reindex workers (format: namespace/name). "+
 			"The ConfigMap should have a 'template.yaml' key with a PodTemplateSpec. "+
 			"If not set, a default template is used.")
+
+	logsapi.AddFlags(o.Logs, fs)
 }
 
 // NewControllerManagerCommand creates the controller-manager subcommand.
@@ -123,9 +129,10 @@ func NewControllerManagerCommand() *cobra.Command {
 and reconciles the desired state. This includes managing ActivityPolicy resources
 and ensuring consistent state across the cluster.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Set up controller-runtime logging
-			ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
-
+			if err := logsapi.ValidateAndApply(options.Logs, utilfeature.DefaultMutableFeatureGate); err != nil {
+				return fmt.Errorf("failed to apply logging configuration: %w", err)
+			}
+			ctrl.SetLogger(klog.NewKlogr())
 			return RunControllerManager(options)
 		},
 	}

--- a/cmd/activity/event_exporter.go
+++ b/cmd/activity/event_exporter.go
@@ -1,16 +1,35 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	logsapi "k8s.io/component-base/logs/api/v1"
+
 	"go.miloapis.com/activity/internal/eventexporter"
 )
 
-// NewEventExporterCommand creates the event-exporter subcommand.
-func NewEventExporterCommand() *cobra.Command {
-	cfg := eventexporter.Config{
+// EventExporterOptions contains configuration for the event exporter.
+type EventExporterOptions struct {
+	NATSUrl         string
+	SubjectPrefix   string
+	ScopeType       string
+	ScopeName       string
+	Kubeconfig      string
+	ResyncPeriod    time.Duration
+	HealthProbeAddr string
+
+	Logs *logsapi.LoggingConfiguration
+}
+
+// NewEventExporterOptions creates options with default values.
+func NewEventExporterOptions() *EventExporterOptions {
+	return &EventExporterOptions{
+		Logs:            logsapi.NewLoggingConfiguration(),
 		NATSUrl:         getEnvOrDefault("NATS_URL", "nats://nats.nats-system.svc.cluster.local:4222"),
 		SubjectPrefix:   getEnvOrDefault("SUBJECT_PREFIX", "events.k8s"),
 		ScopeType:       getEnvOrDefault("SCOPE_TYPE", "organization"),
@@ -19,6 +38,23 @@ func NewEventExporterCommand() *cobra.Command {
 		ResyncPeriod:    30 * time.Minute,
 		HealthProbeAddr: getEnvOrDefault("HEALTH_PROBE_ADDR", ":8081"),
 	}
+}
+
+// AddFlags adds event exporter flags to the flag set.
+func (o *EventExporterOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.NATSUrl, "nats-url", o.NATSUrl, "NATS server URL")
+	fs.StringVar(&o.SubjectPrefix, "subject-prefix", o.SubjectPrefix, "NATS subject prefix")
+	fs.StringVar(&o.ScopeType, "scope-type", o.ScopeType, "Scope type annotation value")
+	fs.StringVar(&o.ScopeName, "scope-name", o.ScopeName, "Scope name annotation value")
+	fs.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "Path to kubeconfig (empty for in-cluster)")
+	fs.DurationVar(&o.ResyncPeriod, "resync-period", o.ResyncPeriod, "Informer resync period")
+	fs.StringVar(&o.HealthProbeAddr, "health-probe-addr", o.HealthProbeAddr, "Health probe server bind address")
+	logsapi.AddFlags(o.Logs, fs)
+}
+
+// NewEventExporterCommand creates the event-exporter subcommand.
+func NewEventExporterCommand() *cobra.Command {
+	options := NewEventExporterOptions()
 
 	cmd := &cobra.Command{
 		Use:   "event-exporter",
@@ -29,18 +65,23 @@ consistency with the EventRecord API and ClickHouse schema.
 
 Events are published with scope annotations for multi-tenant isolation.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := logsapi.ValidateAndApply(options.Logs, utilfeature.DefaultMutableFeatureGate); err != nil {
+				return fmt.Errorf("failed to apply logging configuration: %w", err)
+			}
+			cfg := eventexporter.Config{
+				NATSUrl:         options.NATSUrl,
+				SubjectPrefix:   options.SubjectPrefix,
+				ScopeType:       options.ScopeType,
+				ScopeName:       options.ScopeName,
+				Kubeconfig:      options.Kubeconfig,
+				ResyncPeriod:    options.ResyncPeriod,
+				HealthProbeAddr: options.HealthProbeAddr,
+			}
 			return eventexporter.Run(cmd.Context(), cfg)
 		},
 	}
 
-	flags := cmd.Flags()
-	flags.StringVar(&cfg.NATSUrl, "nats-url", cfg.NATSUrl, "NATS server URL")
-	flags.StringVar(&cfg.SubjectPrefix, "subject-prefix", cfg.SubjectPrefix, "NATS subject prefix")
-	flags.StringVar(&cfg.ScopeType, "scope-type", cfg.ScopeType, "Scope type annotation value")
-	flags.StringVar(&cfg.ScopeName, "scope-name", cfg.ScopeName, "Scope name annotation value")
-	flags.StringVar(&cfg.Kubeconfig, "kubeconfig", cfg.Kubeconfig, "Path to kubeconfig (empty for in-cluster)")
-	flags.DurationVar(&cfg.ResyncPeriod, "resync-period", cfg.ResyncPeriod, "Informer resync period")
-	flags.StringVar(&cfg.HealthProbeAddr, "health-probe-addr", cfg.HealthProbeAddr, "Health probe server bind address")
+	options.AddFlags(cmd.Flags())
 
 	return cmd
 }

--- a/cmd/activity/processor.go
+++ b/cmd/activity/processor.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"go.miloapis.com/activity/internal/activityprocessor"
 )
@@ -63,11 +64,14 @@ type ProcessorOptions struct {
 
 	// Health probe configuration
 	HealthProbeAddr string
+
+	Logs *logsapi.LoggingConfiguration
 }
 
 // NewProcessorOptions creates options with default values.
 func NewProcessorOptions() *ProcessorOptions {
 	return &ProcessorOptions{
+		Logs:                 logsapi.NewLoggingConfiguration(),
 		NATSURL:              "nats://localhost:4222",
 		NATSStreamName:       "AUDIT_EVENTS",
 		ConsumerName:         "activity-processor@activity.miloapis.com",
@@ -167,6 +171,8 @@ func (o *ProcessorOptions) AddFlags(fs *pflag.FlagSet) {
 	// Health probe flags
 	fs.StringVar(&o.HealthProbeAddr, "health-probe-addr", o.HealthProbeAddr,
 		"Address for health probe server (e.g., :8081). Set to empty to disable.")
+
+	logsapi.AddFlags(o.Logs, fs)
 }
 
 // NewProcessorCommand creates the processor subcommand.
@@ -186,9 +192,10 @@ The processor:
 - Evaluates CEL expressions to match and transform events
 - Publishes activities to NATS for downstream consumption (Vector writes to ClickHouse)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Set up controller-runtime logging
-			ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
-
+			if err := logsapi.ValidateAndApply(options.Logs, utilfeature.DefaultMutableFeatureGate); err != nil {
+				return fmt.Errorf("failed to apply logging configuration: %w", err)
+			}
+			ctrl.SetLogger(klog.NewKlogr())
 			return RunProcessor(options)
 		},
 	}

--- a/cmd/activity/reindex_worker.go
+++ b/cmd/activity/reindex_worker.go
@@ -14,8 +14,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -44,11 +46,15 @@ type ReindexWorkerOptions struct {
 	NATSTLSCertFile string
 	NATSTLSKeyFile  string
 	NATSTLSCAFile   string
+
+	Logs *logsapi.LoggingConfiguration
 }
 
 // NewReindexWorkerOptions creates options with default values.
 func NewReindexWorkerOptions() *ReindexWorkerOptions {
-	return &ReindexWorkerOptions{}
+	return &ReindexWorkerOptions{
+		Logs: logsapi.NewLoggingConfiguration(),
+	}
 }
 
 // AddFlags adds reindex worker flags to the command.
@@ -68,6 +74,8 @@ func (o *ReindexWorkerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Path to client private key file for NATS TLS.")
 	fs.StringVar(&o.NATSTLSCAFile, "nats-tls-ca-file", o.NATSTLSCAFile,
 		"Path to CA certificate file for NATS TLS.")
+
+	logsapi.AddFlags(o.Logs, fs)
 }
 
 // NewReindexWorkerCommand creates the reindex-worker subcommand.
@@ -94,6 +102,10 @@ It should not be run manually.`,
 
 // RunReindexWorker executes the reindex job worker.
 func RunReindexWorker(ctx context.Context, options *ReindexWorkerOptions) error {
+	if err := logsapi.ValidateAndApply(options.Logs, utilfeature.DefaultMutableFeatureGate); err != nil {
+		return fmt.Errorf("failed to apply logging configuration: %w", err)
+	}
+
 	// Validate required flags
 	if options.NATSURL == "" {
 		return fmt.Errorf("--nats-url is required")

--- a/config/base/controller-manager.yaml
+++ b/config/base/controller-manager.yaml
@@ -83,6 +83,7 @@ spec:
         - --activity-image=$(ACTIVITY_IMAGE)
         - --reindex-job-template-configmap=$(REINDEX_JOB_TEMPLATE_CONFIGMAP)
         - -v=$(LOG_LEVEL)
+        - --logging-format=$(LOGGING_FORMAT)
         env:
         - name: KUBECONFIG
           value: ""
@@ -104,6 +105,8 @@ spec:
           value: ""
         - name: LOG_LEVEL
           value: "2"
+        - name: LOGGING_FORMAT
+          value: "json"
         - name: ACTIVITY_IMAGE
           value: "PLACEHOLDER"  # Replaced by kustomize to match deployed image
         - name: REINDEX_JOB_NAMESPACE

--- a/config/base/processor.yaml
+++ b/config/base/processor.yaml
@@ -89,6 +89,7 @@ spec:
         - --batch-size=$(BATCH_SIZE)
         - --health-probe-addr=$(HEALTH_PROBE_ADDR)
         - -v=$(LOG_LEVEL)
+        - --logging-format=$(LOGGING_FORMAT)
         env:
         - name: ACTIVITY_KUBECONFIG
           value: ""
@@ -118,6 +119,8 @@ spec:
           value: ":8081"
         - name: LOG_LEVEL
           value: "2"
+        - name: LOGGING_FORMAT
+          value: "json"
         resources:
           requests:
             cpu: 100m

--- a/config/components/clickhouse-database/clickhouse-installation.yaml
+++ b/config/components/clickhouse-database/clickhouse-installation.yaml
@@ -66,6 +66,9 @@ spec:
                 <size>1000M</size>
                 <count>5</count>
                 <console>1</console>
+                <formatting>
+                    <type>json</type>
+                </formatting>
             </logger>
         </clickhouse>
       # Enable full-text index feature for ngrams tokenizer in activities table

--- a/config/components/clickhouse-standalone/clickhouse-installation.yaml
+++ b/config/components/clickhouse-standalone/clickhouse-installation.yaml
@@ -38,6 +38,9 @@ spec:
                 <size>100M</size>
                 <count>3</count>
                 <console>1</console>
+                <formatting>
+                    <type>json</type>
+                </formatting>
             </logger>
         </clickhouse>
       # Enable full-text index feature for ngrams tokenizer in activities table

--- a/config/components/k8s-event-exporter/deployment.yaml
+++ b/config/components/k8s-event-exporter/deployment.yaml
@@ -31,12 +31,15 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - event-exporter
+            - --logging-format=$(LOGGING_FORMAT)
             - -v=2
           ports:
             - containerPort: 8081
               name: health
               protocol: TCP
           env:
+            - name: LOGGING_FORMAT
+              value: "json"
             - name: NATS_URL
               value: "nats://nats.nats-system.svc.cluster.local:4222"
             - name: SUBJECT_PREFIX

--- a/internal/controller/reindexjob_controller.go
+++ b/internal/controller/reindexjob_controller.go
@@ -325,6 +325,7 @@ func (r *ReindexJobReconciler) buildJobForReindexJob(reindexJob *v1alpha1.Reinde
 		"reindex-worker",
 		reindexJob.Name,
 		"--nats-url=" + r.NATSURL,
+		"--logging-format=json",
 	}
 
 	if r.NATSTLSEnabled {

--- a/internal/controller/reindexjob_controller_test.go
+++ b/internal/controller/reindexjob_controller_test.go
@@ -73,6 +73,7 @@ func TestBuildJobForReindexJob(t *testing.T) {
 		"reindex-worker",
 		"test-reindex",
 		"--nats-url=nats://nats.activity-system.svc:4222",
+		"--logging-format=json",
 	}
 	assert.Equal(t, expectedArgs, container.Args)
 
@@ -143,6 +144,7 @@ func TestBuildJobForReindexJob_WithTLS(t *testing.T) {
 		"reindex-worker",
 		"test-reindex-tls",
 		"--nats-url=nats://nats.activity-system.svc:4222",
+		"--logging-format=json",
 		"--nats-tls-enabled=true",
 		"--nats-tls-cert-file=/certs/tls.crt",
 		"--nats-tls-key-file=/certs/tls.key",


### PR DESCRIPTION
## Summary

- Wire up Kubernetes `logsapi` in the processor, controller-manager, event-exporter, and reindex-worker so all components support `--logging-format=json`
- Previously only the apiserver used JSON logs; other components used `zap.UseDevMode(true)` (console format) or raw klog text output
- Add JSON formatting to both ClickHouse installation configs (HA and standalone)

## Changes

**Go code (4 files):**
- Replace `zap.UseDevMode(true)` with `logsapi.ValidateAndApply()` + `ctrl.SetLogger(klog.NewKlogr())` in processor and controller-manager
- Add `logsapi` wiring to event-exporter (new `EventExporterOptions` struct for consistency) and reindex-worker
- Inject `--logging-format=json` in reindex-worker Job args built by the controller-manager

**Deployment manifests (3 files):**
- Add `--logging-format=$(LOGGING_FORMAT)` arg and `LOGGING_FORMAT=json` env var to processor, controller-manager, and event-exporter (matches apiserver pattern for Kustomize overridability)

**ClickHouse config (2 files):**
- Add `<formatting><type>json</type></formatting>` to logger config in both HA and standalone installations

## Test plan

- [x] `go build ./cmd/activity/` compiles successfully
- [x] `go test ./cmd/activity/...` passes
- [x] `go test ./internal/controller/...` passes (reindex Job args updated in tests)
- [ ] Deploy to dev cluster and verify JSON log output from all components
- [ ] Verify `--logging-format=text` still produces human-readable output for local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)