### PR TITLE
fix: use PascalCase for tenant/scope types to match Milo input

### DIFF
--- a/internal/processor/activity.go
+++ b/internal/processor/activity.go
@@ -169,7 +169,7 @@ func (b *ActivityBuilder) BuildFromEvent(
 
 	// Extract tenant info (may not be present in events)
 	tenant := v1alpha1.ActivityTenant{
-		Type: "platform",
+		Type: TenantTypePlatform,
 		Name: "",
 	}
 

--- a/internal/processor/dlq_test.go
+++ b/internal/processor/dlq_test.go
@@ -166,7 +166,7 @@ func TestDeadLetterEventSerialization(t *testing.T) {
 			Namespace: "default",
 		},
 		Tenant: &DeadLetterTenant{
-			Type: "project",
+			Type: "Project",
 			Name: "my-project",
 		},
 	}
@@ -199,8 +199,8 @@ func TestDeadLetterEventSerialization(t *testing.T) {
 	if unmarshaled.Tenant == nil {
 		t.Fatal("Tenant should not be nil")
 	}
-	if unmarshaled.Tenant.Type != "project" {
-		t.Errorf("Tenant.Type = %q, want %q", unmarshaled.Tenant.Type, "project")
+	if unmarshaled.Tenant.Type != "Project" {
+		t.Errorf("Tenant.Type = %q, want %q", unmarshaled.Tenant.Type, "Project")
 	}
 	if unmarshaled.Tenant.Name != "my-project" {
 		t.Errorf("Tenant.Name = %q, want %q", unmarshaled.Tenant.Name, "my-project")

--- a/internal/processor/event.go
+++ b/internal/processor/event.go
@@ -379,7 +379,7 @@ func (p *EventProcessor) buildActivity(
 			},
 			Links: activityLinks,
 			Tenant: v1alpha1.ActivityTenant{
-				Type: "platform",
+				Type: TenantTypePlatform,
 				Name: "",
 			},
 			Origin: v1alpha1.ActivityOrigin{

--- a/internal/processor/utils.go
+++ b/internal/processor/utils.go
@@ -6,7 +6,16 @@ import (
 	authnv1 "k8s.io/api/authentication/v1"
 
 	"go.miloapis.com/activity/internal/cel"
+	"go.miloapis.com/activity/internal/types"
 	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
+)
+
+// Re-export tenant type constants for use within the processor package.
+const (
+	TenantTypePlatform     = types.TenantTypePlatform
+	TenantTypeOrganization = types.TenantTypeOrganization
+	TenantTypeProject      = types.TenantTypeProject
+	TenantTypeUser         = types.TenantTypeUser
 )
 
 // KindResolver resolves a plural resource name to its Kind using API discovery.
@@ -39,7 +48,7 @@ func GetNestedString(m map[string]any, keys ...string) string {
 // ExtractTenant extracts tenant information from user extra fields.
 func ExtractTenant(user authnv1.UserInfo) v1alpha1.ActivityTenant {
 	tenant := v1alpha1.ActivityTenant{
-		Type: "platform",
+		Type: TenantTypePlatform,
 		Name: "",
 	}
 
@@ -52,17 +61,17 @@ func ExtractTenant(user authnv1.UserInfo) v1alpha1.ActivityTenant {
 		tenant.Name = parentName
 	}
 
-	// Check for organization (alternative field)
-	if tenant.Type == "platform" {
+	// Check for organization (alternative/legacy field)
+	if tenant.Type == TenantTypePlatform {
 		if org := getExtraValue(user.Extra, "organization"); org != "" {
-			tenant.Type = "organization"
+			tenant.Type = TenantTypeOrganization
 			tenant.Name = org
 		}
 	}
 
-	// Check for project (more specific than organization)
+	// Check for project (more specific than organization, legacy field)
 	if project := getExtraValue(user.Extra, "project"); project != "" {
-		tenant.Type = "project"
+		tenant.Type = TenantTypeProject
 		tenant.Name = project
 	}
 

--- a/internal/processor/utils_test.go
+++ b/internal/processor/utils_test.go
@@ -258,29 +258,29 @@ func TestExtractTenant(t *testing.T) {
 		{
 			name:     "platform (no extra fields)",
 			user:     authnv1.UserInfo{},
-			wantType: "platform",
+			wantType: TenantTypePlatform,
 			wantName: "",
 		},
 		{
 			name: "organization from parent fields",
 			user: authnv1.UserInfo{
 				Extra: map[string]authnv1.ExtraValue{
-					"iam.miloapis.com/parent-type": {"organization"},
+					"iam.miloapis.com/parent-type": {"Organization"},
 					"iam.miloapis.com/parent-name": {"acme-corp"},
 				},
 			},
-			wantType: "organization",
+			wantType: TenantTypeOrganization,
 			wantName: "acme-corp",
 		},
 		{
 			name: "project from parent fields",
 			user: authnv1.UserInfo{
 				Extra: map[string]authnv1.ExtraValue{
-					"iam.miloapis.com/parent-type": {"project"},
+					"iam.miloapis.com/parent-type": {"Project"},
 					"iam.miloapis.com/parent-name": {"my-project"},
 				},
 			},
-			wantType: "project",
+			wantType: TenantTypeProject,
 			wantName: "my-project",
 		},
 		{
@@ -290,7 +290,7 @@ func TestExtractTenant(t *testing.T) {
 					"organization": {"legacy-org"},
 				},
 			},
-			wantType: "organization",
+			wantType: TenantTypeOrganization,
 			wantName: "legacy-org",
 		},
 		{
@@ -301,7 +301,7 @@ func TestExtractTenant(t *testing.T) {
 					"project":      {"my-project"},
 				},
 			},
-			wantType: "project",
+			wantType: TenantTypeProject,
 			wantName: "my-project",
 		},
 	}

--- a/internal/registry/activity/auditlog/storage_test.go
+++ b/internal/registry/activity/auditlog/storage_test.go
@@ -203,7 +203,7 @@ func TestQueryStorage_Create_ScopeExtraction(t *testing.T) {
 					scope.ParentNameExtraKey: {"acme-corp"},
 				},
 			},
-			wantType: "organization",
+			wantType: "Organization",
 			wantName: "acme-corp",
 		},
 		{
@@ -215,7 +215,7 @@ func TestQueryStorage_Create_ScopeExtraction(t *testing.T) {
 					scope.ParentNameExtraKey: {"backend-api"},
 				},
 			},
-			wantType: "project",
+			wantType: "Project",
 			wantName: "backend-api",
 		},
 		{
@@ -227,7 +227,7 @@ func TestQueryStorage_Create_ScopeExtraction(t *testing.T) {
 					scope.ParentNameExtraKey: {"550e8400-e29b-41d4-a716-446655440000"},
 				},
 			},
-			wantType: "user",
+			wantType: "User",
 			wantName: "550e8400-e29b-41d4-a716-446655440000",
 		},
 		{

--- a/internal/registry/activity/events/scope.go
+++ b/internal/registry/activity/events/scope.go
@@ -2,6 +2,8 @@ package events
 
 import (
 	"k8s.io/apiserver/pkg/authentication/user"
+
+	"go.miloapis.com/activity/internal/types"
 )
 
 const (
@@ -14,35 +16,38 @@ const (
 // ScopeInfo represents the hierarchical scope for events queries.
 // Used to restrict query results to the appropriate organizational boundary.
 type ScopeInfo struct {
-	Type string // "platform", "organization", "project", "user"
+	Type string // "platform", "Organization", "Project", "User" (PascalCase for K8s Kind convention)
 	Name string // scope identifier (org name, project name, user UID, etc.)
 }
 
 // ExtractScopeFromUser determines the events query scope from user authentication metadata.
 // Defaults to platform-wide scope when no parent resource is specified.
 //
+// The returned Type uses Kubernetes Kind naming convention (PascalCase) to match
+// how scope types are stored in ClickHouse.
+//
 // For user scope, the Name field contains the user's UID (not username), which enables
 // querying all events within that user's context across all organizations and projects.
 func ExtractScopeFromUser(u user.Info) ScopeInfo {
 	if u.GetExtra() == nil {
-		return ScopeInfo{Type: "platform", Name: ""}
+		return ScopeInfo{Type: types.TenantTypePlatform, Name: ""}
 	}
 
 	parentKind := u.GetExtra()[ParentKindExtraKey]
 	parentName := u.GetExtra()[ParentNameExtraKey]
 
 	if len(parentKind) == 0 || len(parentName) == 0 {
-		return ScopeInfo{Type: "platform", Name: ""}
+		return ScopeInfo{Type: types.TenantTypePlatform, Name: ""}
 	}
 
 	switch parentKind[0] {
 	case "Organization":
-		return ScopeInfo{Type: "organization", Name: parentName[0]}
+		return ScopeInfo{Type: types.TenantTypeOrganization, Name: parentName[0]}
 	case "Project":
-		return ScopeInfo{Type: "project", Name: parentName[0]}
+		return ScopeInfo{Type: types.TenantTypeProject, Name: parentName[0]}
 	case "User":
-		return ScopeInfo{Type: "user", Name: parentName[0]}
+		return ScopeInfo{Type: types.TenantTypeUser, Name: parentName[0]}
 	default:
-		return ScopeInfo{Type: "platform", Name: ""}
+		return ScopeInfo{Type: types.TenantTypePlatform, Name: ""}
 	}
 }

--- a/internal/registry/activity/facet/storage_test.go
+++ b/internal/registry/activity/facet/storage_test.go
@@ -174,7 +174,7 @@ func TestFacetQueryStorage_Create_ScopeExtraction(t *testing.T) {
 					scope.ParentNameExtraKey: {"acme-corp"},
 				},
 			},
-			wantType: "organization",
+			wantType: "Organization",
 			wantName: "acme-corp",
 		},
 		{
@@ -186,7 +186,7 @@ func TestFacetQueryStorage_Create_ScopeExtraction(t *testing.T) {
 					scope.ParentNameExtraKey: {"backend-api"},
 				},
 			},
-			wantType: "project",
+			wantType: "Project",
 			wantName: "backend-api",
 		},
 		{
@@ -198,7 +198,7 @@ func TestFacetQueryStorage_Create_ScopeExtraction(t *testing.T) {
 					scope.ParentNameExtraKey: {"550e8400-e29b-41d4-a716-446655440000"},
 				},
 			},
-			wantType: "user",
+			wantType: "User",
 			wantName: "550e8400-e29b-41d4-a716-446655440000",
 		},
 		{

--- a/internal/registry/scope/scope.go
+++ b/internal/registry/scope/scope.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 
 	"go.miloapis.com/activity/internal/storage"
+	"go.miloapis.com/activity/internal/types"
 )
 
 const (
@@ -16,28 +17,31 @@ const (
 // ExtractScopeFromUser determines the query scope from user authentication metadata.
 // Defaults to platform-wide scope when no parent resource is specified.
 //
+// The returned Type uses Kubernetes Kind naming convention (PascalCase) to match
+// how tenant types are stored by the activity processor.
+//
 // For user scope, the Name field contains the user's UID (not username), which enables
 // querying all activity performed by that user across all organizations and projects.
 func ExtractScopeFromUser(u user.Info) storage.ScopeContext {
 	if u.GetExtra() == nil {
-		return storage.ScopeContext{Type: "platform", Name: ""}
+		return storage.ScopeContext{Type: types.TenantTypePlatform, Name: ""}
 	}
 
 	parentKind := u.GetExtra()[ParentKindExtraKey]
 	parentName := u.GetExtra()[ParentNameExtraKey]
 
 	if len(parentKind) == 0 || len(parentName) == 0 {
-		return storage.ScopeContext{Type: "platform", Name: ""}
+		return storage.ScopeContext{Type: types.TenantTypePlatform, Name: ""}
 	}
 
 	switch parentKind[0] {
 	case "Organization":
-		return storage.ScopeContext{Type: "organization", Name: parentName[0]}
+		return storage.ScopeContext{Type: types.TenantTypeOrganization, Name: parentName[0]}
 	case "Project":
-		return storage.ScopeContext{Type: "project", Name: parentName[0]}
+		return storage.ScopeContext{Type: types.TenantTypeProject, Name: parentName[0]}
 	case "User":
-		return storage.ScopeContext{Type: "user", Name: parentName[0]}
+		return storage.ScopeContext{Type: types.TenantTypeUser, Name: parentName[0]}
 	default:
-		return storage.ScopeContext{Type: "platform", Name: ""}
+		return storage.ScopeContext{Type: types.TenantTypePlatform, Name: ""}
 	}
 }

--- a/internal/registry/scope/scope_test.go
+++ b/internal/registry/scope/scope_test.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 
 	"go.miloapis.com/activity/internal/storage"
+	"go.miloapis.com/activity/internal/types"
 )
 
 func TestExtractScopeFromUser(t *testing.T) {
@@ -22,7 +23,7 @@ func TestExtractScopeFromUser(t *testing.T) {
 					ParentNameExtraKey: {"acme-corp"},
 				},
 			},
-			expected: storage.ScopeContext{Type: "organization", Name: "acme-corp"},
+			expected: storage.ScopeContext{Type: types.TenantTypeOrganization, Name: "acme-corp"},
 		},
 		{
 			name: "project scope",
@@ -32,7 +33,7 @@ func TestExtractScopeFromUser(t *testing.T) {
 					ParentNameExtraKey: {"backend-api"},
 				},
 			},
-			expected: storage.ScopeContext{Type: "project", Name: "backend-api"},
+			expected: storage.ScopeContext{Type: types.TenantTypeProject, Name: "backend-api"},
 		},
 		{
 			name: "user scope",
@@ -42,12 +43,12 @@ func TestExtractScopeFromUser(t *testing.T) {
 					ParentNameExtraKey: {"550e8400-e29b-41d4-a716-446655440000"},
 				},
 			},
-			expected: storage.ScopeContext{Type: "user", Name: "550e8400-e29b-41d4-a716-446655440000"},
+			expected: storage.ScopeContext{Type: types.TenantTypeUser, Name: "550e8400-e29b-41d4-a716-446655440000"},
 		},
 		{
 			name:     "no scope (platform)",
 			user:     &user.DefaultInfo{},
-			expected: storage.ScopeContext{Type: "platform", Name: ""},
+			expected: storage.ScopeContext{Type: types.TenantTypePlatform, Name: ""},
 		},
 		{
 			name: "missing parent name",
@@ -56,7 +57,7 @@ func TestExtractScopeFromUser(t *testing.T) {
 					ParentKindExtraKey: {"Organization"},
 				},
 			},
-			expected: storage.ScopeContext{Type: "platform", Name: ""},
+			expected: storage.ScopeContext{Type: types.TenantTypePlatform, Name: ""},
 		},
 		{
 			name: "missing parent kind",
@@ -65,7 +66,7 @@ func TestExtractScopeFromUser(t *testing.T) {
 					ParentNameExtraKey: {"acme-corp"},
 				},
 			},
-			expected: storage.ScopeContext{Type: "platform", Name: ""},
+			expected: storage.ScopeContext{Type: types.TenantTypePlatform, Name: ""},
 		},
 		{
 			name: "unknown parent kind",
@@ -75,7 +76,7 @@ func TestExtractScopeFromUser(t *testing.T) {
 					ParentNameExtraKey: {"some-name"},
 				},
 			},
-			expected: storage.ScopeContext{Type: "platform", Name: ""},
+			expected: storage.ScopeContext{Type: types.TenantTypePlatform, Name: ""},
 		},
 		{
 			name: "empty extra fields",
@@ -85,14 +86,14 @@ func TestExtractScopeFromUser(t *testing.T) {
 					ParentNameExtraKey: {},
 				},
 			},
-			expected: storage.ScopeContext{Type: "platform", Name: ""},
+			expected: storage.ScopeContext{Type: types.TenantTypePlatform, Name: ""},
 		},
 		{
 			name: "nil extra map",
 			user: &user.DefaultInfo{
 				Name: "test-user",
 			},
-			expected: storage.ScopeContext{Type: "platform", Name: ""},
+			expected: storage.ScopeContext{Type: types.TenantTypePlatform, Name: ""},
 		},
 	}
 

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -24,6 +24,7 @@ import (
 	"go.miloapis.com/activity/internal/cel"
 	"go.miloapis.com/activity/internal/metrics"
 	"go.miloapis.com/activity/internal/timeutil"
+	"go.miloapis.com/activity/internal/types"
 	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
 )
 
@@ -242,7 +243,7 @@ type QueryResult struct {
 
 // ScopeContext defines the hierarchical scope boundary for audit log queries.
 type ScopeContext struct {
-	Type string // "platform", "organization", "project", "user"
+	Type string // "platform", "Organization", "Project", "User" (PascalCase for K8s Kind convention)
 	Name string // scope identifier (org name, project name, etc.)
 }
 
@@ -510,8 +511,8 @@ func (s *ClickHouseStorage) buildQuery(ctx context.Context, spec v1alpha1.AuditL
 	var conditions []string
 
 	// Only add scope filters if not platform-wide query
-	if scope.Type != "platform" {
-		if scope.Type == "user" {
+	if scope.Type != types.TenantTypePlatform {
+		if scope.Type == types.TenantTypeUser {
 			// For user scope, filter by user.uid instead of scope annotations.
 			// This allows querying all activity performed BY a specific user
 			// across all organizations and projects on the platform.
@@ -598,7 +599,7 @@ func (s *ClickHouseStorage) buildQuery(ctx context.Context, spec v1alpha1.AuditL
 			// No user filter: use platform_query_projection
 			query += " ORDER BY toStartOfHour(timestamp) DESC, timestamp DESC, api_group DESC, resource DESC, audit_id DESC"
 		}
-	} else if scope.Type == "user" {
+	} else if scope.Type == types.TenantTypeUser {
 		// User-scoped: use user_uid_query_projection to filter by UID
 		query += " ORDER BY toStartOfHour(timestamp) DESC, timestamp DESC, user_uid DESC, api_group DESC, resource DESC, audit_id DESC"
 	} else {
@@ -745,8 +746,8 @@ func (s *ClickHouseStorage) buildActivityQuery(ctx context.Context, spec Activit
 	var conditions []string
 
 	// Scope filtering
-	if scope.Type != "platform" {
-		if scope.Type == "user" {
+	if scope.Type != types.TenantTypePlatform {
+		if scope.Type == types.TenantTypeUser {
 			// For user scope, filter by actor_uid to show activities performed by this user
 			// across all organizations and projects
 			conditions = append(conditions, "actor_uid = ?")
@@ -842,7 +843,7 @@ func (s *ClickHouseStorage) buildActivityQuery(ctx context.Context, spec Activit
 			// No actor filter: use platform_query_projection
 			query += " ORDER BY toStartOfHour(timestamp) DESC, timestamp DESC, api_group DESC, resource_kind DESC, resource_uid DESC"
 		}
-	} else if scope.Type == "user" {
+	} else if scope.Type == types.TenantTypeUser {
 		// User-scoped: use actor_uid_query_projection to filter by UID
 		query += " ORDER BY toStartOfHour(timestamp) DESC, timestamp DESC, actor_uid DESC, api_group DESC, resource_kind DESC, resource_uid DESC"
 	} else {
@@ -1033,8 +1034,8 @@ func (s *ClickHouseStorage) queryAuditLogFacet(ctx context.Context, facet FacetF
 	var conditions []string
 
 	// Scope filtering - same pattern as audit log queries
-	if scope.Type != "platform" {
-		if scope.Type == "user" {
+	if scope.Type != types.TenantTypePlatform {
+		if scope.Type == types.TenantTypeUser {
 			// For user scope, filter by user_uid
 			conditions = append(conditions, "user_uid = ?")
 			args = append(args, scope.Name)
@@ -1197,8 +1198,8 @@ func (s *ClickHouseStorage) queryFacet(ctx context.Context, facet FacetFieldSpec
 	var conditions []string
 
 	// Scope filtering
-	if scope.Type != "platform" {
-		if scope.Type == "user" {
+	if scope.Type != types.TenantTypePlatform {
+		if scope.Type == types.TenantTypeUser {
 			// For user scope, filter by actor_uid to show activities performed by this user
 			// across all organizations and projects
 			conditions = append(conditions, "actor_uid = ?")

--- a/internal/storage/event_query_clickhouse.go
+++ b/internal/storage/event_query_clickhouse.go
@@ -17,6 +17,7 @@ import (
 
 	"go.miloapis.com/activity/internal/metrics"
 	"go.miloapis.com/activity/internal/timeutil"
+	"go.miloapis.com/activity/internal/types"
 	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
 )
 
@@ -242,16 +243,16 @@ func (b *ClickHouseEventQueryBackend) buildScopeConditions(scope ScopeContext) (
 	var conditions []string
 	var args []interface{}
 
-	if scope.Type == "" || scope.Type == "platform" {
+	if scope.Type == "" || scope.Type == types.TenantTypePlatform {
 		// Platform scope sees all events across all tenants
 		return conditions, args
 	}
 
 	switch scope.Type {
-	case "organization", "project":
+	case types.TenantTypeOrganization, types.TenantTypeProject:
 		conditions = append(conditions, "scope_type = ?", "scope_name = ?")
 		args = append(args, scope.Type, scope.Name)
-	case "user":
+	case types.TenantTypeUser:
 		// User scope falls back to organization/project filtering for events
 		// since events don't carry user-level attribution the same way audit logs do.
 		conditions = append(conditions, "scope_type = ?", "scope_name = ?")

--- a/internal/storage/events_clickhouse.go
+++ b/internal/storage/events_clickhouse.go
@@ -16,11 +16,12 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
 
 	"go.miloapis.com/activity/internal/metrics"
+	"go.miloapis.com/activity/internal/types"
 )
 
 // ClickHouseEventsBackend implements the EventsBackend interface using ClickHouse.
@@ -85,7 +86,7 @@ func (b *ClickHouseEventsBackend) Create(ctx context.Context, event *eventsv1.Ev
 
 	// Generate UID if not set
 	if event.UID == "" {
-		event.UID = types.UID(uuid.New().String())
+		event.UID = k8stypes.UID(uuid.New().String())
 	}
 
 	// Set timestamps if not set
@@ -109,7 +110,7 @@ func (b *ClickHouseEventsBackend) Create(ctx context.Context, event *eventsv1.Ev
 	if event.Annotations == nil {
 		event.Annotations = make(map[string]string)
 	}
-	if scope.Type != "" && scope.Type != "platform" {
+	if scope.Type != "" && scope.Type != types.TenantTypePlatform {
 		event.Annotations["platform.miloapis.com/scope.type"] = scope.Type
 		event.Annotations["platform.miloapis.com/scope.name"] = scope.Name
 	}
@@ -428,7 +429,7 @@ func (b *ClickHouseEventsBackend) Update(ctx context.Context, event *eventsv1.Ev
 	if event.Annotations == nil {
 		event.Annotations = make(map[string]string)
 	}
-	if scope.Type != "" && scope.Type != "platform" {
+	if scope.Type != "" && scope.Type != types.TenantTypePlatform {
 		event.Annotations["platform.miloapis.com/scope.type"] = scope.Type
 		event.Annotations["platform.miloapis.com/scope.name"] = scope.Name
 	}
@@ -571,18 +572,18 @@ func (b *ClickHouseEventsBackend) buildScopeConditions(scope ScopeContext) ([]st
 	var conditions []string
 	var args []interface{}
 
-	if scope.Type == "" || scope.Type == "platform" {
+	if scope.Type == "" || scope.Type == types.TenantTypePlatform {
 		// Platform scope sees all events
 		return conditions, args
 	}
 
 	switch scope.Type {
-	case "user":
+	case types.TenantTypeUser:
 		// User scope: filter by user UID (not implemented for events)
 		// Events don't have a user field in the same way as audit logs
 		// For now, fall through to organization/project filtering
 		fallthrough
-	case "organization", "project":
+	case types.TenantTypeOrganization, types.TenantTypeProject:
 		conditions = append(conditions, "scope_type = ?", "scope_name = ?")
 		args = append(args, scope.Type, scope.Name)
 	}

--- a/internal/types/tenant.go
+++ b/internal/types/tenant.go
@@ -1,0 +1,29 @@
+// Package types provides shared type definitions and constants used across
+// the activity service.
+package types
+
+// TenantType constants define the valid values for tenant/scope type fields.
+// These use Kubernetes Kind naming convention (PascalCase) to match how Milo
+// sets the parent type in authentication extra fields.
+//
+// These values are used in:
+// - Activity processing (spec.tenant.type)
+// - Audit log scoping (scope annotations)
+// - ClickHouse storage queries
+// - API request scoping
+const (
+	// TenantTypePlatform represents platform-wide scope with no tenant restriction.
+	// This is the only lowercase value as it's a default/fallback that doesn't
+	// come from Milo's parent kind field.
+	TenantTypePlatform = "platform"
+
+	// TenantTypeOrganization represents organization-level scope.
+	TenantTypeOrganization = "Organization"
+
+	// TenantTypeProject represents project-level scope.
+	TenantTypeProject = "Project"
+
+	// TenantTypeUser represents user-level scope for querying activities
+	// performed by a specific user across all organizations and projects.
+	TenantTypeUser = "User"
+)


### PR DESCRIPTION
## Summary

Activity queries for organization and project scopes were returning empty results even when data existed in ClickHouse. The root cause was a case mismatch between how we store tenant types vs how we query them.

## What was happening

Milo sends tenant types using Kubernetes naming conventions — `"Organization"`, `"Project"`, `"User"` (PascalCase). We were storing these values as-is in ClickHouse, but then lowercasing them when building queries:

```
Stored:  tenant_type = "Project"
Query:   WHERE scope_type = "project"
Result:  Nothing matches 🙃
```

## The fix

Instead of normalizing to lowercase (which would require a data migration), we now preserve PascalCase throughout the pipeline. This matches what Milo sends and what's already in the database.

Key changes:
- Added `internal/types/tenant.go` with shared constants so we're not scattering magic strings everywhere
- Updated scope extraction to return PascalCase values
- Fixed all the query builders to use the constants
- Updated tests to expect the correct casing

## Testing

All unit tests pass. Next step is deploying to staging to verify org/project activity views work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)