### PR TITLE
chore(migrations): add scope_type PascalCase migration

### DIFF
--- a/config/components/clickhouse-migrations/configmap.yaml
+++ b/config/components/clickhouse-migrations/configmap.yaml
@@ -1715,3 +1715,53 @@ data:
         ttl_only_drop_parts = 1,
         deduplicate_merge_projection_mode = 'rebuild';
 
+  008_scope_type_pascalcase.sql: |
+    -- Migration: 008_scope_type_pascalcase
+    -- Description: Update scope_type and tenant_type columns from lowercase to PascalCase
+    -- Author: Claude Code
+    -- Date: 2026-03-10
+    --
+    -- Background: Milo authentication sends tenant types using Kubernetes Kind naming
+    -- conventions (PascalCase: "Organization", "Project", "User"). The activity service
+    -- was incorrectly lowercasing these values during scope extraction, causing a mismatch
+    -- between stored data and query filters.
+    --
+    -- This migration updates existing data to use PascalCase, aligning with the code fix
+    -- in the activity service. New data will be written with PascalCase automatically.
+    --
+    -- Note: These UPDATE statements modify the materialized columns only, not the source
+    -- JSON. This is intentional — all queries use the materialized columns for performance.
+
+    -- ============================================================================
+    -- Step 1: Update audit_logs table
+    -- ============================================================================
+    ALTER TABLE audit.audit_logs UPDATE scope_type = 'Organization' WHERE scope_type = 'organization';
+    ALTER TABLE audit.audit_logs UPDATE scope_type = 'Project' WHERE scope_type = 'project';
+    ALTER TABLE audit.audit_logs UPDATE scope_type = 'User' WHERE scope_type = 'user';
+
+    -- ============================================================================
+    -- Step 2: Update k8s_events table
+    -- ============================================================================
+    ALTER TABLE audit.k8s_events UPDATE scope_type = 'Organization' WHERE scope_type = 'organization';
+    ALTER TABLE audit.k8s_events UPDATE scope_type = 'Project' WHERE scope_type = 'project';
+    ALTER TABLE audit.k8s_events UPDATE scope_type = 'User' WHERE scope_type = 'user';
+
+    -- ============================================================================
+    -- Step 3: Update activities table
+    -- ============================================================================
+    -- Activities use tenant_type instead of scope_type
+    ALTER TABLE audit.activities UPDATE tenant_type = 'Organization' WHERE tenant_type = 'organization';
+    ALTER TABLE audit.activities UPDATE tenant_type = 'Project' WHERE tenant_type = 'project';
+    ALTER TABLE audit.activities UPDATE tenant_type = 'User' WHERE tenant_type = 'user';
+
+    -- ============================================================================
+    -- Verification (run manually after mutations complete)
+    -- ============================================================================
+    -- Check mutation progress:
+    --   SELECT * FROM system.mutations WHERE is_done = 0;
+    --
+    -- Verify no lowercase values remain:
+    --   SELECT scope_type, count() FROM audit.audit_logs GROUP BY scope_type;
+    --   SELECT scope_type, count() FROM audit.k8s_events GROUP BY scope_type;
+    --   SELECT tenant_type, count() FROM audit.activities GROUP BY tenant_type;
+

--- a/migrations/008_scope_type_pascalcase.sql
+++ b/migrations/008_scope_type_pascalcase.sql
@@ -1,0 +1,48 @@
+-- Migration: 008_scope_type_pascalcase
+-- Description: Update scope_type and tenant_type columns from lowercase to PascalCase
+-- Author: Claude Code
+-- Date: 2026-03-10
+--
+-- Background: Milo authentication sends tenant types using Kubernetes Kind naming
+-- conventions (PascalCase: "Organization", "Project", "User"). The activity service
+-- was incorrectly lowercasing these values during scope extraction, causing a mismatch
+-- between stored data and query filters.
+--
+-- This migration updates existing data to use PascalCase, aligning with the code fix
+-- in the activity service. New data will be written with PascalCase automatically.
+--
+-- Note: These UPDATE statements modify the materialized columns only, not the source
+-- JSON. This is intentional — all queries use the materialized columns for performance.
+
+-- ============================================================================
+-- Step 1: Update audit_logs table
+-- ============================================================================
+ALTER TABLE audit.audit_logs UPDATE scope_type = 'Organization' WHERE scope_type = 'organization';
+ALTER TABLE audit.audit_logs UPDATE scope_type = 'Project' WHERE scope_type = 'project';
+ALTER TABLE audit.audit_logs UPDATE scope_type = 'User' WHERE scope_type = 'user';
+
+-- ============================================================================
+-- Step 2: Update k8s_events table
+-- ============================================================================
+ALTER TABLE audit.k8s_events UPDATE scope_type = 'Organization' WHERE scope_type = 'organization';
+ALTER TABLE audit.k8s_events UPDATE scope_type = 'Project' WHERE scope_type = 'project';
+ALTER TABLE audit.k8s_events UPDATE scope_type = 'User' WHERE scope_type = 'user';
+
+-- ============================================================================
+-- Step 3: Update activities table
+-- ============================================================================
+-- Activities use tenant_type instead of scope_type
+ALTER TABLE audit.activities UPDATE tenant_type = 'Organization' WHERE tenant_type = 'organization';
+ALTER TABLE audit.activities UPDATE tenant_type = 'Project' WHERE tenant_type = 'project';
+ALTER TABLE audit.activities UPDATE tenant_type = 'User' WHERE tenant_type = 'user';
+
+-- ============================================================================
+-- Verification (run manually after mutations complete)
+-- ============================================================================
+-- Check mutation progress:
+--   SELECT * FROM system.mutations WHERE is_done = 0;
+--
+-- Verify no lowercase values remain:
+--   SELECT scope_type, count() FROM audit.audit_logs GROUP BY scope_type;
+--   SELECT scope_type, count() FROM audit.k8s_events GROUP BY scope_type;
+--   SELECT tenant_type, count() FROM audit.activities GROUP BY tenant_type;


### PR DESCRIPTION
## Summary

Follow-up to #98. The code now writes tenant types as PascalCase, but existing data in ClickHouse still has lowercase values. This migration fixes that.

## What's changing

We're updating three tables to convert lowercase scope/tenant types to PascalCase:

- `organization` → `Organization`
- `project` → `Project`
- `user` → `User`

The `platform` value stays as-is since it's not derived from Milo.

## After deploying

The mutations run in the background. You can check progress with:

```sql
SELECT * FROM system.mutations WHERE is_done = 0;
```

And verify the fix worked:

```sql
SELECT scope_type, count() FROM audit.audit_logs GROUP BY scope_type;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)