### PR TITLE
Fix event-sourced activities ignoring scope annotations

### DIFF
--- a/internal/processor/activity.go
+++ b/internal/processor/activity.go
@@ -167,11 +167,8 @@ func (b *ActivityBuilder) BuildFromEvent(
 		actor.Name = "unknown"
 	}
 
-	// Extract tenant info (may not be present in events)
-	tenant := v1alpha1.ActivityTenant{
-		Type: TenantTypePlatform,
-		Name: "",
-	}
+	// Extract tenant from scope annotations; fall back to platform scope when absent.
+	tenant := ExtractTenantFromAnnotations(eventMap)
 
 	// Generate activity name
 	activityName := fmt.Sprintf("act-%s", uuid.New().String()[:8])

--- a/internal/processor/event.go
+++ b/internal/processor/event.go
@@ -378,10 +378,8 @@ func (p *EventProcessor) buildActivity(
 				UID:        resourceUID,
 			},
 			Links: activityLinks,
-			Tenant: v1alpha1.ActivityTenant{
-				Type: TenantTypePlatform,
-				Name: "",
-			},
+			// Extract tenant from scope annotations; fall back to platform scope when absent.
+			Tenant: ExtractTenantFromAnnotations(event),
 			Origin: v1alpha1.ActivityOrigin{
 				Type: "event",
 				ID:   eventUID,

--- a/internal/processor/event_test.go
+++ b/internal/processor/event_test.go
@@ -244,6 +244,110 @@ func TestNormalizeEvent(t *testing.T) {
 	}
 }
 
+func TestBuildActivityTenantFromScopeAnnotations(t *testing.T) {
+	p := &EventProcessor{}
+
+	involvedObject := map[string]any{
+		"kind":       "DNSRecord",
+		"name":       "my-record",
+		"namespace":  "project-ns",
+		"uid":        "dns-789",
+		"apiVersion": "dns.miloapis.com/v1alpha1",
+	}
+
+	matched := &MatchedPolicy{
+		PolicyName: "dns-records",
+		Generation: 1,
+		APIGroup:   "dns.miloapis.com",
+		Kind:       "DNSRecord",
+		Summary:    "DNS record created",
+	}
+
+	tests := []struct {
+		name           string
+		event          map[string]any
+		involvedObject map[string]any
+		wantTenant     string
+		wantName       string
+	}{
+		{
+			name: "project scope annotation is used",
+			event: map[string]any{
+				"metadata": map[string]any{
+					"uid": "event-001",
+					"annotations": map[string]any{
+						"platform.miloapis.com/scope.type": TenantTypeProject,
+						"platform.miloapis.com/scope.name": "my-project",
+					},
+				},
+				"reportingController": "dns-operator",
+				"regarding":           involvedObject,
+			},
+			involvedObject: involvedObject,
+			wantTenant:     TenantTypeProject,
+			wantName:       "my-project",
+		},
+		{
+			name: "organization scope annotation is used",
+			event: map[string]any{
+				"metadata": map[string]any{
+					"uid": "event-002",
+					"annotations": map[string]any{
+						"platform.miloapis.com/scope.type": TenantTypeOrganization,
+						"platform.miloapis.com/scope.name": "acme-corp",
+					},
+				},
+				"reportingController": "dns-operator",
+				"regarding":           involvedObject,
+			},
+			involvedObject: involvedObject,
+			wantTenant:     TenantTypeOrganization,
+			wantName:       "acme-corp",
+		},
+		{
+			name: "missing annotations fall back to platform scope",
+			event: map[string]any{
+				"metadata": map[string]any{
+					"uid": "event-003",
+				},
+				"reportingController": "dns-operator",
+				"regarding":           involvedObject,
+			},
+			involvedObject: involvedObject,
+			wantTenant:     TenantTypePlatform,
+			wantName:       "",
+		},
+		{
+			name: "scope annotations with nil regarding does not panic",
+			event: map[string]any{
+				"metadata": map[string]any{
+					"uid": "event-004",
+					"annotations": map[string]any{
+						"platform.miloapis.com/scope.type": TenantTypeProject,
+						"platform.miloapis.com/scope.name": "my-project",
+					},
+				},
+				"reportingController": "dns-operator",
+			},
+			involvedObject: nil,
+			wantTenant:     TenantTypeProject,
+			wantName:       "my-project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			activity := p.buildActivity(tt.event, matched, tt.involvedObject, matched.Summary, nil)
+			if activity.Spec.Tenant.Type != tt.wantTenant {
+				t.Errorf("Tenant.Type = %q, want %q", activity.Spec.Tenant.Type, tt.wantTenant)
+			}
+			if activity.Spec.Tenant.Name != tt.wantName {
+				t.Errorf("Tenant.Name = %q, want %q", activity.Spec.Tenant.Name, tt.wantName)
+			}
+		})
+	}
+}
+
 func TestBuildActivityFromEvent(t *testing.T) {
 	p := &EventProcessor{}
 

--- a/internal/processor/utils.go
+++ b/internal/processor/utils.go
@@ -140,3 +140,44 @@ func getStringFromMap(m map[string]any, key string) string {
 	}
 	return ""
 }
+
+const (
+	// scopeTypeAnnotation is the annotation key carrying the tenant scope type.
+	scopeTypeAnnotation = "platform.miloapis.com/scope.type"
+	// scopeNameAnnotation is the annotation key carrying the tenant scope name.
+	scopeNameAnnotation = "platform.miloapis.com/scope.name"
+)
+
+// ExtractTenantFromAnnotations reads scope annotations from event metadata and
+// returns the corresponding ActivityTenant. Falls back to platform scope when
+// the type annotation is absent or empty.
+func ExtractTenantFromAnnotations(eventMap map[string]any) v1alpha1.ActivityTenant {
+	tenant := v1alpha1.ActivityTenant{
+		Type: TenantTypePlatform,
+		Name: "",
+	}
+
+	if eventMap == nil {
+		return tenant
+	}
+
+	metadata, ok := eventMap["metadata"].(map[string]any)
+	if !ok {
+		return tenant
+	}
+
+	annotations, ok := metadata["annotations"].(map[string]any)
+	if !ok {
+		return tenant
+	}
+
+	scopeType := getStringFromMap(annotations, scopeTypeAnnotation)
+	scopeName := getStringFromMap(annotations, scopeNameAnnotation)
+
+	if scopeType != "" {
+		tenant.Type = scopeType
+		tenant.Name = scopeName
+	}
+
+	return tenant
+}

--- a/internal/processor/utils_test.go
+++ b/internal/processor/utils_test.go
@@ -319,6 +319,113 @@ func TestExtractTenant(t *testing.T) {
 	}
 }
 
+func TestExtractTenantFromAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		eventMap map[string]any
+		wantType string
+		wantName string
+	}{
+		{
+			name:     "nil event map falls back to platform",
+			eventMap: nil,
+			wantType: TenantTypePlatform,
+			wantName: "",
+		},
+		{
+			name:     "no metadata falls back to platform",
+			eventMap: map[string]any{},
+			wantType: TenantTypePlatform,
+			wantName: "",
+		},
+		{
+			name: "metadata without annotations falls back to platform",
+			eventMap: map[string]any{
+				"metadata": map[string]any{
+					"uid": "event-123",
+				},
+			},
+			wantType: TenantTypePlatform,
+			wantName: "",
+		},
+		{
+			name: "annotations without scope keys fall back to platform",
+			eventMap: map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"some-other-annotation": "value",
+					},
+				},
+			},
+			wantType: TenantTypePlatform,
+			wantName: "",
+		},
+		{
+			name: "project scope from annotations",
+			eventMap: map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"platform.miloapis.com/scope.type": TenantTypeProject,
+						"platform.miloapis.com/scope.name": "my-project",
+					},
+				},
+			},
+			wantType: TenantTypeProject,
+			wantName: "my-project",
+		},
+		{
+			name: "organization scope from annotations",
+			eventMap: map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"platform.miloapis.com/scope.type": TenantTypeOrganization,
+						"platform.miloapis.com/scope.name": "acme-corp",
+					},
+				},
+			},
+			wantType: TenantTypeOrganization,
+			wantName: "acme-corp",
+		},
+		{
+			name: "scope.type present but empty falls back to platform",
+			eventMap: map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"platform.miloapis.com/scope.type": "",
+						"platform.miloapis.com/scope.name": "my-project",
+					},
+				},
+			},
+			wantType: TenantTypePlatform,
+			wantName: "",
+		},
+		{
+			name: "scope.type present but scope.name absent uses empty name",
+			eventMap: map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"platform.miloapis.com/scope.type": TenantTypeProject,
+					},
+				},
+			},
+			wantType: TenantTypeProject,
+			wantName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractTenantFromAnnotations(tt.eventMap)
+			if got.Type != tt.wantType {
+				t.Errorf("ExtractTenantFromAnnotations() Type = %q, want %q", got.Type, tt.wantType)
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("ExtractTenantFromAnnotations() Name = %q, want %q", got.Name, tt.wantName)
+			}
+		})
+	}
+}
+
 func TestGetNestedString(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Problem

When Kubernetes events flow through Milo's events proxy, Milo injects scope annotations (`platform.miloapis.com/scope.type` and `scope.name`) based on the authenticated user's project or organization context. However, the activity processor was completely ignoring these annotations — it hardcoded every event-sourced activity to `platform` scope.

This meant that activities created from project-level events (e.g., DNS record changes from dns-operator) were invisible to project-scoped activity queries, even though the underlying events had the correct scope annotations.

## Fix

Replaced the hardcoded `{Type: "platform", Name: ""}` tenant with a call to `ExtractTenantFromAnnotations()`, which reads the scope annotations from the event's metadata. When annotations are missing or the type is empty, it falls back to platform scope — preserving backward compatibility.

The fix applies to both event processing paths:
- `ActivityBuilder.BuildFromEvent()` — used by the audit log processor
- `EventProcessor.buildActivity()` — used by the Kubernetes event processor

## Changes

- **`utils.go`**: Added `ExtractTenantFromAnnotations()` that safely navigates `metadata.annotations` to extract scope type and name, with nil guards at every level
- **`activity.go`**: `BuildFromEvent()` calls `ExtractTenantFromAnnotations(eventMap)` instead of hardcoding platform tenant
- **`event.go`**: `buildActivity()` calls `ExtractTenantFromAnnotations(event)` instead of hardcoding platform tenant
- **`utils_test.go`**: 8 test cases covering nil map, missing metadata, missing annotations, project/org scopes, empty type fallback, and missing name
- **`event_test.go`**: 4 test cases for `buildActivity` including nil regarding object safety

## Test plan

- [x] All processor unit tests pass (`go test ./internal/processor/`)
- [ ] Deploy to staging and verify DNS record events appear with correct project scope in activity timeline
- [ ] Verify platform-scoped events (no annotations) continue to work


🤖 Generated with [Claude Code](https://claude.com/claude-code)