### PR TITLE
feat(iam): add Milo IAM resources for ReindexJob

### DIFF
--- a/config/milo/iam/resources/kustomization.yaml
+++ b/config/milo/iam/resources/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - auditlogqueries.yaml
   - auditlogfacetsqueries.yaml
   - policypreviews.yaml
+  - reindexjobs.yaml
   - events.yaml
   - eventqueries.yaml
   - eventfacetqueries.yaml

--- a/config/milo/iam/resources/reindexjobs.yaml
+++ b/config/milo/iam/resources/reindexjobs.yaml
@@ -1,0 +1,15 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: ProtectedResource
+metadata:
+  name: activity.miloapis.com-reindexjobs
+spec:
+  serviceRef:
+    name: "activity.miloapis.com"
+  kind: ReindexJob
+  plural: reindexjobs
+  singular: reindexjob
+  permissions:
+    - create
+    - list
+    - get
+    - delete

--- a/config/milo/iam/roles/policy-manager.yaml
+++ b/config/milo/iam/roles/policy-manager.yaml
@@ -19,3 +19,8 @@ spec:
     - activity.miloapis.com/activitypolicies.watch
     # PolicyPreview - for testing policies before applying
     - activity.miloapis.com/policypreviews.create
+    # ReindexJob - for re-indexing activities after policy changes
+    - activity.miloapis.com/reindexjobs.create
+    - activity.miloapis.com/reindexjobs.list
+    - activity.miloapis.com/reindexjobs.get
+    - activity.miloapis.com/reindexjobs.delete


### PR DESCRIPTION
## Summary
- Adds a `ProtectedResource` for `ReindexJob` with `create`, `list`, `get`, and `delete` permissions (no update/patch since jobs are immutable once created)
- Grants ReindexJob permissions to the existing `policy-manager` role, since reindexing is typically triggered after policy changes
- Adds `reindexjobs.yaml` to the IAM resources kustomization

## Test plan
- [ ] Verify kustomize build succeeds with the new resource included
- [ ] Confirm a user with the `policy-manager` role can create and manage ReindexJob resources
- [ ] Confirm users without the role are denied access to ReindexJob resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)