### PR TITLE
fix(config): resolve ACTIVITY_IMAGE placeholder in OCI bundle

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -32,6 +32,22 @@ images:
   - name: ghcr.io/datum-cloud/activity
     newTag: latest
 
+# Sync ACTIVITY_IMAGE env var with the container image after image transformation.
+# Kustomize processes images: before replacements:, so this correctly picks up the
+# transformed image tag and injects it into the controller-manager env var used for
+# spawning ReindexJob worker pods.
+replacements:
+  - source:
+      kind: Deployment
+      name: activity-controller-manager
+      fieldPath: spec.template.spec.containers.[name=manager].image
+    targets:
+      - select:
+          kind: Deployment
+          name: activity-controller-manager
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=ACTIVITY_IMAGE].value
+
 # JSON patches to ensure rbac-auth-reader stays in kube-system
 # These are applied AFTER all other transformations
 patches:

--- a/config/overlays/dev/kustomization.yaml
+++ b/config/overlays/dev/kustomization.yaml
@@ -39,9 +39,9 @@ images:
     newName: ghcr.io/datum-cloud/activity-ui
     newTag: dev
 
-# Replacements to sync ACTIVITY_IMAGE env var with the actual deployed image
-# This ensures the controller-manager uses the same image for ReindexJobs
-# NOTE: This must be in the overlay (not base) so it runs AFTER image transformation
+# Sync ACTIVITY_IMAGE env var with the overlay's image tag.
+# Required here because the overlay's images: transformer runs after the base's
+# replacements: have already executed, so it must re-sync the env var.
 replacements:
   - source:
       kind: Deployment

--- a/config/overlays/test-infra/kustomization.yaml
+++ b/config/overlays/test-infra/kustomization.yaml
@@ -30,9 +30,9 @@ images:
     newName: ghcr.io/datum-cloud/activity
     newTag: dev
 
-# Replacements to sync ACTIVITY_IMAGE env var with the actual deployed image
-# This ensures the controller-manager uses the same image for ReindexJobs
-# NOTE: This must be in the overlay (not base) so it runs AFTER image transformation
+# Sync ACTIVITY_IMAGE env var with the overlay's image tag.
+# Required here because the overlay's images: transformer runs after the base's
+# replacements: have already executed, so it must re-sync the env var.
 replacements:
   - source:
       kind: Deployment


### PR DESCRIPTION
## Summary
- Adds kustomize `replacements:` to the base kustomization so the `ACTIVITY_IMAGE` env var is automatically synced from the container image tag when the OCI bundle is built by CI
- Previously the replacement only existed in dev/test-infra overlays, so the published OCI bundle retained the `PLACEHOLDER` value, causing ReindexJob worker pods to fail with `InvalidImageName`
- Updates overlay comments to explain why they also need the replacement (overlay `images:` transformer runs after the base's replacement)

## Verification
Confirmed with `kustomize build`:
- **Base** (`config/base`): `ACTIVITY_IMAGE` = `ghcr.io/datum-cloud/activity:latest` (was `PLACEHOLDER`)
- **Base with CI tag**: `ACTIVITY_IMAGE` = `ghcr.io/datum-cloud/activity:v0.0.0-main-20260311-011054`
- **Dev overlay**: `ACTIVITY_IMAGE` = `ghcr.io/datum-cloud/activity:dev`
- **Test-infra overlay**: `ACTIVITY_IMAGE` = `ghcr.io/datum-cloud/activity:dev`

## Test plan
- [ ] Verify CI build passes and kustomize validation succeeds
- [ ] After merge, confirm the new OCI bundle contains the correct `ACTIVITY_IMAGE` value (not `PLACEHOLDER`)
- [ ] Create a ReindexJob in staging and verify the worker pod starts with the correct image

🤖 Generated with [Claude Code](https://claude.com/claude-code)