### PR TITLE
Fix ActivityLink resource fields not being populated

### DIFF
--- a/internal/processor/utils.go
+++ b/internal/processor/utils.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"fmt"
+	"strings"
 
 	authnv1 "k8s.io/api/authentication/v1"
 
@@ -119,14 +120,43 @@ func ConvertLinks(celLinks []cel.Link, resolveKind KindResolver) ([]v1alpha1.Act
 			kind = getStringFromMap(l.Resource, "type")
 		}
 
+		// Extract name/namespace/uid: top-level first, then nested metadata
+		// for full Kubernetes resource objects (e.g. responseObject).
+		name := getStringFromMap(l.Resource, "name")
+		if name == "" {
+			name = GetNestedString(l.Resource, "metadata", "name")
+		}
+
+		namespace := getStringFromMap(l.Resource, "namespace")
+		if namespace == "" {
+			namespace = GetNestedString(l.Resource, "metadata", "namespace")
+		}
+
+		uid := getStringFromMap(l.Resource, "uid")
+		if uid == "" {
+			uid = GetNestedString(l.Resource, "metadata", "uid")
+		}
+
+		// Parse combined apiVersion (e.g. "dns.networking.miloapis.com/v1alpha1")
+		// to extract apiGroup and version separately when apiGroup is absent.
+		rawAPIVersion := getStringFromMap(l.Resource, "apiVersion")
+		apiVersion := rawAPIVersion
+		if apiGroup == "" && rawAPIVersion != "" {
+			if idx := strings.Index(rawAPIVersion, "/"); idx != -1 {
+				apiGroup = rawAPIVersion[:idx]
+				apiVersion = rawAPIVersion[idx+1:]
+			}
+		}
+
 		links[i] = v1alpha1.ActivityLink{
 			Marker: l.Marker,
 			Resource: v1alpha1.ActivityResource{
-				APIGroup:  apiGroup,
-				Kind:      kind,
-				Name:      getStringFromMap(l.Resource, "name"),
-				Namespace: getStringFromMap(l.Resource, "namespace"),
-				UID:       getStringFromMap(l.Resource, "uid"),
+				APIGroup:   apiGroup,
+				APIVersion: apiVersion,
+				Kind:       kind,
+				Name:       name,
+				Namespace:  namespace,
+				UID:        uid,
 			},
 		}
 	}

--- a/internal/processor/utils_test.go
+++ b/internal/processor/utils_test.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.miloapis.com/activity/internal/cel"
+	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
 	authnv1 "k8s.io/api/authentication/v1"
 )
 
@@ -493,6 +496,114 @@ func TestGetNestedString(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("GetNestedString() = %q, want %q", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestConvertLinksMetadataFallback(t *testing.T) {
+	tests := []struct {
+		name         string
+		link         cel.Link
+		wantResource v1alpha1.ActivityResource
+	}{
+		{
+			name: "kubernetes resource object with nested metadata",
+			link: cel.Link{
+				Marker: "javalords.shop",
+				Resource: map[string]any{
+					"apiVersion": "dns.networking.miloapis.com/v1alpha1",
+					"kind":       "DNSZone",
+					"metadata": map[string]any{
+						"name":      "javalords-shop-06vr2d",
+						"namespace": "default",
+						"uid":       "0d3b8c4e-7609-4635-8457-a59309eb390f",
+					},
+				},
+			},
+			wantResource: v1alpha1.ActivityResource{
+				APIGroup:   "dns.networking.miloapis.com",
+				APIVersion: "v1alpha1",
+				Kind:       "DNSZone",
+				Name:       "javalords-shop-06vr2d",
+				Namespace:  "default",
+				UID:        "0d3b8c4e-7609-4635-8457-a59309eb390f",
+			},
+		},
+		{
+			name: "core group resource with apiVersion v1",
+			link: cel.Link{
+				Marker: "my-config",
+				Resource: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      "my-config",
+						"namespace": "kube-system",
+					},
+				},
+			},
+			wantResource: v1alpha1.ActivityResource{
+				APIGroup:   "",
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Name:       "my-config",
+				Namespace:  "kube-system",
+			},
+		},
+		{
+			name: "top-level fields take precedence over metadata",
+			link: cel.Link{
+				Marker: "top-level-resource",
+				Resource: map[string]any{
+					"kind":      "Deployment",
+					"name":      "top-level-name",
+					"namespace": "production",
+					"uid":       "flat-uid",
+					"apiGroup":  "apps",
+					"metadata": map[string]any{
+						"name":      "metadata-name",
+						"namespace": "metadata-ns",
+						"uid":       "metadata-uid",
+					},
+				},
+			},
+			wantResource: v1alpha1.ActivityResource{
+				APIGroup:  "apps",
+				Kind:      "Deployment",
+				Name:      "top-level-name",
+				Namespace: "production",
+				UID:       "flat-uid",
+			},
+		},
+		{
+			name: "actorRef format unchanged",
+			link: cel.Link{
+				Marker: "alice",
+				Resource: map[string]any{
+					"type": "user",
+					"name": "alice",
+				},
+			},
+			wantResource: v1alpha1.ActivityResource{
+				Kind: "user",
+				Name: "alice",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertLinks([]cel.Link{tt.link}, nil)
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+
+			assert.Equal(t, tt.link.Marker, got[0].Marker, "Marker")
+			assert.Equal(t, tt.wantResource.APIGroup, got[0].Resource.APIGroup, "APIGroup")
+			assert.Equal(t, tt.wantResource.APIVersion, got[0].Resource.APIVersion, "APIVersion")
+			assert.Equal(t, tt.wantResource.Kind, got[0].Resource.Kind, "Kind")
+			assert.Equal(t, tt.wantResource.Name, got[0].Resource.Name, "Name")
+			assert.Equal(t, tt.wantResource.Namespace, got[0].Resource.Namespace, "Namespace")
+			assert.Equal(t, tt.wantResource.UID, got[0].Resource.UID, "UID")
 		})
 	}
 }

--- a/pkg/apis/activity/v1alpha1/types_activitypolicy.go
+++ b/pkg/apis/activity/v1alpha1/types_activitypolicy.go
@@ -25,7 +25,7 @@ import (
 //	    kind: HTTPProxy
 //	  auditRules:
 //	    - match: "audit.verb == 'create'"
-//	      summary: "{{ actor }} created {{ link(kind + ' ' + audit.objectRef.name, audit.responseObject) }}"
+//	      summary: "{{ actor }} created {{ link(kind + ' ' + audit.objectRef.name, audit.objectRef) }}"
 //	  eventRules:
 //	    - match: "event.reason == 'Programmed'"
 //	      summary: "{{ link(kind + ' ' + event.regarding.name, event.regarding) }} is now programmed"
@@ -133,7 +133,7 @@ type ActivityPolicyRule struct {
 	//   - link(displayText, resourceRef): Creates a clickable reference
 	//
 	// Examples:
-	//   "{{ actor }} created {{ link(kind + ' ' + audit.objectRef.name, audit.responseObject) }}"
+	//   "{{ actor }} created {{ link(kind + ' ' + audit.objectRef.name, audit.objectRef) }}"
 	//   "{{ link(kind + ' ' + event.regarding.name, event.regarding) }} is now programmed"
 	//
 	// +required


### PR DESCRIPTION
## Summary

Activity links in API responses were showing sparse resource references — only `kind` was populated while `name`, `namespace`, `uid`, `apiGroup`, and `apiVersion` were all empty. This made it impossible for consumers to resolve links into navigation URLs.

**Before:**
```json
"links": [{
  "marker": "javalords.shop",
  "resource": { "apiVersion": "", "kind": "DNSZone", "name": "" }
}]
```

**After:**
```json
"links": [{
  "marker": "javalords.shop",
  "resource": {
    "apiGroup": "dns.networking.miloapis.com",
    "apiVersion": "v1alpha1",
    "kind": "DNSZone",
    "name": "javalords-shop-06vr2d",
    "namespace": "default",
    "uid": "0d3b8c4e-7609-4635-8457-a59309eb390f"
  }
}]
```

## Root cause

The `link()` function in ActivityPolicy CEL templates accepts a resource reference map. When policies passed `audit.responseObject` (a full Kubernetes resource), the fields were nested differently than expected:

- `name`, `namespace`, `uid` live under `metadata`, not at the top level
- `apiGroup` is embedded in the `apiVersion` string (e.g., `"dns.networking.miloapis.com/v1alpha1"`)
- `apiVersion` was never written to the output at all

`ConvertLinks` only checked top-level keys, so everything except `kind` came back empty.

## What changed

- **`ConvertLinks`** now falls back to `metadata.*` for name/namespace/uid, splits combined `apiVersion` values to extract `apiGroup`, and populates `APIVersion` on the result
- **Doc examples** on `ActivityPolicy` corrected to recommend `audit.objectRef` (which has a flat structure) instead of `audit.responseObject` as the link resource ref

## Test plan

- [x] New `TestConvertLinksMetadataFallback` covers nested metadata, core-group `v1` resources, top-level precedence, and actorRef format
- [x] All existing `ConvertLinks` tests continue to pass
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)