### PR TITLE
refactor: use pre-compiled CEL and real KindResolver in reindexer

### DIFF
--- a/cmd/activity/reindex_worker.go
+++ b/cmd/activity/reindex_worker.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"go.miloapis.com/activity/internal/controller"
+	"go.miloapis.com/activity/internal/processor"
 	"go.miloapis.com/activity/internal/reindex"
 	"go.miloapis.com/activity/internal/timeutil"
 	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
@@ -172,8 +173,17 @@ func RunReindexWorker(ctx context.Context, options *ReindexWorkerOptions) error 
 		return fmt.Errorf("failed to update status to Running: %w", err)
 	}
 
+	// Build REST mapper for kind/resource resolution
+	mapper, err := processor.NewRESTMapperFromConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create REST mapper: %w", err)
+	}
+
+	kindResolver := processor.NewKindResolver(mapper)
+	resourceResolver := processor.NewResourceResolver(mapper)
+
 	// Create reindexer
-	reindexer := reindex.NewReindexer(cl, js)
+	reindexer := reindex.NewReindexer(cl, js, kindResolver, resourceResolver)
 
 	// Set up progress callback to update ReindexJob status
 	reindexer.OnProgress = func(progress reindex.Progress) {

--- a/internal/activityprocessor/policycache.go
+++ b/internal/activityprocessor/policycache.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/google/cel-go/cel"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 	"k8s.io/klog/v2"
 
 	internalcel "go.miloapis.com/activity/internal/cel"
@@ -458,6 +459,51 @@ func (r *CompiledRule) EvaluateEventMatch(eventMap map[string]any) (bool, error)
 	}
 
 	return result, nil
+}
+
+// EvaluateCompiledAuditRules evaluates pre-compiled audit rules against an audit event.
+// Returns the generated Activity, the matching rule index, and any error.
+// Returns (nil, -1, nil) if no rule matched.
+func EvaluateCompiledAuditRules(
+	policy *CompiledPolicy,
+	auditMap map[string]any,
+	audit *auditv1.Event,
+	resolveKind processor.KindResolver,
+) (*v1alpha1.Activity, int, error) {
+	for i := range policy.AuditRules {
+		rule := &policy.AuditRules[i]
+		if !rule.Valid {
+			continue
+		}
+
+		matched, err := rule.EvaluateAuditMatch(auditMap)
+		if err != nil {
+			return nil, i, fmt.Errorf("rule %d match: %w", i, err)
+		}
+
+		if matched {
+			// Use the interpreted summary evaluation (not pre-compiled EvaluateSummary) because
+			// link() calls capture links via a side-channel collector that must be freshly
+			// created per evaluation. The pre-compiled programs don't support link collection.
+			summary, links, err := internalcel.EvaluateAuditSummaryMap(rule.Summary, auditMap)
+			if err != nil {
+				return nil, i, fmt.Errorf("rule %d summary: %w", i, err)
+			}
+
+			builder := &processor.ActivityBuilder{
+				APIGroup: policy.APIGroup,
+				Kind:     policy.Kind,
+			}
+			activity, err := builder.BuildFromAudit(audit, summary, links, resolveKind)
+			if err != nil {
+				return nil, i, fmt.Errorf("rule %d build: %w", i, err)
+			}
+
+			return activity, i, nil
+		}
+	}
+
+	return nil, -1, nil
 }
 
 // MatchEvent implements processor.EventPolicyLookup.

--- a/internal/activityprocessor/processor.go
+++ b/internal/activityprocessor/processor.go
@@ -18,7 +18,6 @@ import (
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
@@ -33,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	"go.miloapis.com/activity/internal/cel"
 	"go.miloapis.com/activity/internal/controller"
 	"go.miloapis.com/activity/internal/processor"
 	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
@@ -647,67 +645,13 @@ func (p *Processor) monitorWorkers(ctx context.Context, workerErrors <-chan erro
 }
 
 // kindToResource converts a Kind to its plural resource name using API discovery.
-// On cache miss, it resets the discovery cache and retries to handle newly registered CRDs.
 func (p *Processor) kindToResource(apiGroup, kind string) (string, error) {
-	gk := schema.GroupKind{
-		Group: apiGroup,
-		Kind:  kind,
-	}
-
-	mapping, err := p.mapper.RESTMapping(gk)
-	if err != nil {
-		if meta.IsNoMatchError(err) {
-			// Cache miss - reset and retry to discover newly registered CRDs.
-			klog.V(2).InfoS("REST mapping not found, resetting discovery cache",
-				"apiGroup", apiGroup,
-				"kind", kind,
-			)
-			p.mapper.Reset()
-
-			mapping, err = p.mapper.RESTMapping(gk)
-			if err != nil {
-				return "", fmt.Errorf("failed to find resource mapping for %s/%s: %w", apiGroup, kind, err)
-			}
-		} else {
-			return "", fmt.Errorf("failed to find resource mapping for %s/%s: %w", apiGroup, kind, err)
-		}
-	}
-
-	return mapping.Resource.Resource, nil
+	return processor.NewResourceResolver(p.mapper)(apiGroup, kind)
 }
 
 // resourceToKind converts a plural resource name to its Kind using API discovery.
-// On cache miss, it resets the discovery cache and retries to handle newly registered CRDs.
 func (p *Processor) resourceToKind(apiGroup, resource string) (string, error) {
-	gvr := schema.GroupVersionResource{
-		Group:    apiGroup,
-		Resource: resource,
-	}
-
-	kinds, err := p.mapper.KindsFor(gvr)
-	if err != nil {
-		if meta.IsNoMatchError(err) {
-			// Cache miss - reset and retry to discover newly registered CRDs.
-			klog.V(2).InfoS("Kind mapping not found, resetting discovery cache",
-				"apiGroup", apiGroup,
-				"resource", resource,
-			)
-			p.mapper.Reset()
-
-			kinds, err = p.mapper.KindsFor(gvr)
-			if err != nil {
-				return "", fmt.Errorf("failed to find kind for %s/%s: %w", apiGroup, resource, err)
-			}
-		} else {
-			return "", fmt.Errorf("failed to find kind for %s/%s: %w", apiGroup, resource, err)
-		}
-	}
-
-	if len(kinds) == 0 {
-		return "", fmt.Errorf("no kind found for %s/%s", apiGroup, resource)
-	}
-
-	return kinds[0].Kind, nil
+	return processor.NewKindResolver(p.mapper)(apiGroup, resource)
 }
 
 func (p *Processor) onPolicyAdd(obj any) {
@@ -1090,40 +1034,7 @@ func (p *Processor) processMessage(msg *nats.Msg) error {
 
 // evaluateCompiledAuditRules evaluates audit rules using pre-compiled CEL programs.
 func (p *Processor) evaluateCompiledAuditRules(policy *CompiledPolicy, auditMap map[string]any, audit *auditv1.Event) (*v1alpha1.Activity, int, error) {
-	for i := range policy.AuditRules {
-		rule := &policy.AuditRules[i]
-		if !rule.Valid {
-			continue
-		}
-
-		matched, err := rule.EvaluateAuditMatch(auditMap)
-		if err != nil {
-			return nil, i, fmt.Errorf("rule %d match: %w", i, err)
-		}
-
-		if matched {
-			// Use the cel package's EvaluateAuditSummaryMap which properly collects links
-			// from link() function calls in the summary template.
-			summary, links, err := cel.EvaluateAuditSummaryMap(rule.Summary, auditMap)
-			if err != nil {
-				return nil, i, fmt.Errorf("rule %d summary: %w", i, err)
-			}
-
-			// Build activity using the processor package
-			builder := &processor.ActivityBuilder{
-				APIGroup: policy.APIGroup,
-				Kind:     policy.Kind,
-			}
-			activity, err := builder.BuildFromAudit(audit, summary, links, p.resourceToKind)
-			if err != nil {
-				return nil, i, fmt.Errorf("rule %d build: %w", i, err)
-			}
-
-			return activity, i, nil
-		}
-	}
-
-	return nil, -1, nil
+	return EvaluateCompiledAuditRules(policy, auditMap, audit, p.resourceToKind)
 }
 
 // auditToMap converts an audit event to a map for CEL evaluation.

--- a/internal/processor/kind_resolver.go
+++ b/internal/processor/kind_resolver.go
@@ -1,0 +1,96 @@
+package processor
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/klog/v2"
+)
+
+// ResourceResolver resolves a Kind to its plural resource name using API discovery.
+type ResourceResolver func(apiGroup, kind string) (string, error)
+
+// NewKindResolver creates a KindResolver that uses a ResettableRESTMapper.
+// On cache miss, it resets the discovery cache and retries to handle newly registered CRDs.
+func NewKindResolver(mapper meta.ResettableRESTMapper) KindResolver {
+	return func(apiGroup, resource string) (string, error) {
+		gvr := schema.GroupVersionResource{
+			Group:    apiGroup,
+			Resource: resource,
+		}
+
+		kinds, err := mapper.KindsFor(gvr)
+		if err != nil {
+			if meta.IsNoMatchError(err) {
+				klog.V(2).InfoS("Kind mapping not found, resetting discovery cache",
+					"apiGroup", apiGroup,
+					"resource", resource,
+				)
+				mapper.Reset()
+
+				kinds, err = mapper.KindsFor(gvr)
+				if err != nil {
+					return "", fmt.Errorf("failed to find kind for %s/%s: %w", apiGroup, resource, err)
+				}
+			} else {
+				return "", fmt.Errorf("failed to find kind for %s/%s: %w", apiGroup, resource, err)
+			}
+		}
+
+		if len(kinds) == 0 {
+			return "", fmt.Errorf("no kind found for %s/%s", apiGroup, resource)
+		}
+
+		return kinds[0].Kind, nil
+	}
+}
+
+// NewResourceResolver creates a ResourceResolver that uses a ResettableRESTMapper.
+// On cache miss, it resets the discovery cache and retries.
+func NewResourceResolver(mapper meta.ResettableRESTMapper) ResourceResolver {
+	return func(apiGroup, kind string) (string, error) {
+		gk := schema.GroupKind{
+			Group: apiGroup,
+			Kind:  kind,
+		}
+
+		mapping, err := mapper.RESTMapping(gk)
+		if err != nil {
+			if meta.IsNoMatchError(err) {
+				klog.V(2).InfoS("Resource mapping not found, resetting discovery cache",
+					"apiGroup", apiGroup,
+					"kind", kind,
+				)
+				mapper.Reset()
+
+				mapping, err = mapper.RESTMapping(gk)
+				if err != nil {
+					return "", fmt.Errorf("failed to find resource mapping for %s/%s: %w", apiGroup, kind, err)
+				}
+			} else {
+				return "", fmt.Errorf("failed to find resource mapping for %s/%s: %w", apiGroup, kind, err)
+			}
+		}
+
+		return mapping.Resource.Resource, nil
+	}
+}
+
+// NewRESTMapperFromConfig creates a ResettableRESTMapper from a Kubernetes rest.Config.
+// Uses a cached discovery client for efficient API group/resource lookups.
+func NewRESTMapperFromConfig(config *rest.Config) (meta.ResettableRESTMapper, error) {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create discovery client: %w", err)
+	}
+
+	cachedClient := memory.NewMemCacheClient(discoveryClient)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedClient)
+
+	return mapper, nil
+}

--- a/internal/reindex/batch.go
+++ b/internal/reindex/batch.go
@@ -2,7 +2,9 @@ package reindex
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
@@ -10,6 +12,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"go.miloapis.com/activity/internal/activityprocessor"
 	"go.miloapis.com/activity/internal/processor"
 	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
 )
@@ -116,86 +119,127 @@ func fetchEventBatch(
 	return batch, query.Status.Continue, nil
 }
 
-// evaluateBatch applies ActivityPolicy rules to a batch of events.
-// The originType should be "audit" or "event" to indicate the source.
-func evaluateBatch(
-	ctx context.Context,
-	batch interface{},
-	policies []*v1alpha1.ActivityPolicy,
-	originType string,
-) ([]*v1alpha1.Activity, error) {
+// evaluateAuditBatch evaluates a batch of audit events using pre-compiled policies.
+func (r *Reindexer) evaluateAuditBatch(ctx context.Context, batch []*auditv1.Event) ([]*v1alpha1.Activity, error) {
 	var activities []*v1alpha1.Activity
 
-	switch originType {
-	case "audit":
-		// Process audit logs
-		auditBatch, ok := batch.([]*auditv1.Event)
-		if !ok {
-			return nil, fmt.Errorf("invalid batch type for audit logs")
+	for _, audit := range batch {
+		// Extract apiGroup and resource from the audit event's ObjectRef
+		if audit.ObjectRef == nil {
+			continue
+		}
+		apiGroup := audit.ObjectRef.APIGroup
+		resource := audit.ObjectRef.Resource
+
+		// Look up compiled policies for this resource
+		compiledPolicies := r.policyCache.Get(apiGroup, resource)
+		if len(compiledPolicies) == 0 {
+			continue
 		}
 
-		for _, audit := range auditBatch {
-			for _, policy := range policies {
-				result, err := processor.EvaluateAuditRules(&policy.Spec, audit, nil)
-				if err != nil {
-					klog.ErrorS(err, "Failed to evaluate audit rules",
-						"policy", policy.Name,
-						"auditID", audit.AuditID,
-					)
-					continue
-				}
+		// Convert audit event to map for CEL evaluation
+		auditMap, err := auditToMap(audit)
+		if err != nil {
+			klog.V(2).InfoS("Failed to convert audit event to map",
+				"auditID", audit.AuditID,
+				"error", err,
+			)
+			continue
+		}
 
-				if result.Activity != nil {
-					// Add policy label for tracking
-					if result.Activity.Labels == nil {
-						result.Activity.Labels = make(map[string]string)
-					}
-					result.Activity.Labels["activity.miloapis.com/policy-name"] = policy.Name
+		// Try each policy (first match wins)
+		for _, policy := range compiledPolicies {
+			activity, _, err := activityprocessor.EvaluateCompiledAuditRules(policy, auditMap, audit, r.kindResolver)
+			if err != nil {
+				klog.ErrorS(err, "Failed to evaluate compiled audit rules",
+					"policy", policy.Name,
+					"auditID", audit.AuditID,
+				)
+				continue
+			}
 
-					activities = append(activities, result.Activity)
-					break // Only first matching policy generates an activity
+			if activity != nil {
+				if activity.Labels == nil {
+					activity.Labels = make(map[string]string)
 				}
+				activity.Labels["activity.miloapis.com/policy-name"] = policy.Name
+				activities = append(activities, activity)
+				break // First matching policy wins
 			}
 		}
-
-	case "event":
-		// Process Kubernetes events
-		eventBatch, ok := batch.([]map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("invalid batch type for events")
-		}
-
-		for _, eventMap := range eventBatch {
-			for _, policy := range policies {
-				result, err := processor.EvaluateEventRules(&policy.Spec, eventMap, nil)
-				if err != nil {
-					klog.ErrorS(err, "Failed to evaluate event rules",
-						"policy", policy.Name,
-						"eventUID", processor.GetNestedString(eventMap, "metadata", "uid"),
-					)
-					continue
-				}
-
-				if result.Activity != nil {
-					// Add policy label for tracking
-					if result.Activity.Labels == nil {
-						result.Activity.Labels = make(map[string]string)
-					}
-					result.Activity.Labels["activity.miloapis.com/policy-name"] = policy.Name
-
-					activities = append(activities, result.Activity)
-					break // Only first matching policy generates an activity
-				}
-			}
-		}
-
-	default:
-		return nil, fmt.Errorf("invalid origin type: %s", originType)
 	}
 
-	klog.V(3).InfoS("Evaluated batch",
-		"originType", originType,
-		"inputEvents", batchSize(batch),
+	klog.V(3).InfoS("Evaluated audit batch",
+		"inputEvents", len(batch),
+		"activitiesGenerated", len(activities),
+	)
+
+	return activities, nil
+}
+
+// evaluateEventBatch evaluates a batch of Kubernetes events using pre-compiled policies.
+func (r *Reindexer) evaluateEventBatch(ctx context.Context, batch []map[string]interface{}) ([]*v1alpha1.Activity, error) {
+	var activities []*v1alpha1.Activity
+
+	for _, eventMap := range batch {
+		// Extract apiGroup and kind from the event's regarding field
+		regarding, _ := eventMap["regarding"].(map[string]interface{})
+		if regarding == nil {
+			continue
+		}
+
+		apiVersion, _ := regarding["apiVersion"].(string)
+		kind, _ := regarding["kind"].(string)
+
+		// Parse apiGroup from apiVersion (e.g., "networking.datumapis.com/v1alpha1" -> "networking.datumapis.com")
+		// Core-group resources have apiVersion "v1" with no slash, so apiGroup is "".
+		apiGroup := ""
+		if idx := strings.Index(apiVersion, "/"); idx != -1 {
+			apiGroup = apiVersion[:idx]
+		}
+
+		if kind == "" {
+			continue
+		}
+
+		// Use PolicyCache.MatchEvent which handles lookup + evaluation
+		matched, err := r.policyCache.MatchEvent(apiGroup, kind, eventMap)
+		if err != nil {
+			klog.ErrorS(err, "Failed to evaluate event rules",
+				"eventUID", processor.GetNestedString(eventMap, "metadata", "uid"),
+			)
+			continue
+		}
+
+		if matched == nil {
+			continue
+		}
+
+		// Build the Activity from the matched result
+		builder := &processor.ActivityBuilder{
+			APIGroup: matched.APIGroup,
+			Kind:     matched.Kind,
+		}
+		activity, err := builder.BuildFromEvent(eventMap, matched.Summary, matched.Links, r.kindResolver)
+		if err != nil {
+			klog.ErrorS(err, "Failed to build activity from event match",
+				"policy", matched.PolicyName,
+				"eventUID", processor.GetNestedString(eventMap, "metadata", "uid"),
+			)
+			continue
+		}
+
+		if activity != nil {
+			if activity.Labels == nil {
+				activity.Labels = make(map[string]string)
+			}
+			activity.Labels["activity.miloapis.com/policy-name"] = matched.PolicyName
+			activities = append(activities, activity)
+		}
+	}
+
+	klog.V(3).InfoS("Evaluated event batch",
+		"inputEvents", len(batch),
 		"activitiesGenerated", len(activities),
 	)
 
@@ -221,13 +265,13 @@ func eventRecordToMap(record *v1alpha1.EventRecord) (map[string]interface{}, err
 			"namespace":  record.Event.Regarding.Namespace,
 			"uid":        string(record.Event.Regarding.UID),
 		},
-		"reason":             record.Event.Reason,
-		"note":               record.Event.Note,
-		"type":               record.Event.Type,
-		"eventTime":          record.Event.EventTime.Time,
+		"reason":              record.Event.Reason,
+		"note":                record.Event.Note,
+		"type":                record.Event.Type,
+		"eventTime":           record.Event.EventTime.Time,
 		"reportingController": record.Event.ReportingController,
-		"reportingInstance":  record.Event.ReportingInstance,
-		"action":             record.Event.Action,
+		"reportingInstance":   record.Event.ReportingInstance,
+		"action":              record.Event.Action,
 	}
 
 	// Add series if present
@@ -252,14 +296,15 @@ func eventRecordToMap(record *v1alpha1.EventRecord) (map[string]interface{}, err
 	return eventMap, nil
 }
 
-// batchSize returns the size of a batch regardless of type.
-func batchSize(batch interface{}) int {
-	switch v := batch.(type) {
-	case []*auditv1.Event:
-		return len(v)
-	case []map[string]interface{}:
-		return len(v)
-	default:
-		return 0
+// auditToMap converts an audit event to a map for CEL evaluation.
+func auditToMap(audit *auditv1.Event) (map[string]any, error) {
+	data, err := json.Marshal(audit)
+	if err != nil {
+		return nil, err
 	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }

--- a/internal/reindex/reindexer.go
+++ b/internal/reindex/reindexer.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"go.miloapis.com/activity/internal/activityprocessor"
+	"go.miloapis.com/activity/internal/processor"
 	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
 )
 
@@ -19,6 +21,13 @@ type Reindexer struct {
 	js          nats.JetStreamContext
 	rateLimiter *RateLimiter
 	publisher   *Publisher
+
+	// policyCache holds pre-compiled policies for efficient evaluation.
+	policyCache *activityprocessor.PolicyCache
+	// kindResolver resolves plural resource names to Kind.
+	kindResolver processor.KindResolver
+	// resourceResolver resolves Kind to plural resource name.
+	resourceResolver processor.ResourceResolver
 
 	// OnProgress is called after each batch with updated progress information
 	OnProgress func(Progress)
@@ -75,11 +84,16 @@ type Progress struct {
 func NewReindexer(
 	client client.Client,
 	js nats.JetStreamContext,
+	kindResolver processor.KindResolver,
+	resourceResolver processor.ResourceResolver,
 ) *Reindexer {
 	return &Reindexer{
-		client:    client,
-		js:        js,
-		publisher: NewPublisher(js),
+		client:           client,
+		js:               js,
+		publisher:        NewPublisher(js),
+		policyCache:      activityprocessor.NewPolicyCache(),
+		kindResolver:     kindResolver,
+		resourceResolver: resourceResolver,
 	}
 }
 
@@ -109,10 +123,25 @@ func (r *Reindexer) Run(ctx context.Context, opts Options) error {
 		return nil
 	}
 
+	// Compile policies into the cache for efficient evaluation
+	for _, policy := range policies {
+		resource, err := r.resourceResolver(policy.Spec.Resource.APIGroup, policy.Spec.Resource.Kind)
+		if err != nil {
+			klog.Warningf("Failed to resolve resource for policy %s (apiGroup=%s, kind=%s): %v",
+				policy.Name, policy.Spec.Resource.APIGroup, policy.Spec.Resource.Kind, err)
+			continue
+		}
+		if err := r.policyCache.Add(policy, resource); err != nil {
+			klog.Warningf("Failed to compile policy %s: %v", policy.Name, err)
+			continue
+		}
+	}
+
 	klog.InfoS("Starting reindex job",
 		"startTime", opts.StartTime,
 		"endTime", opts.EndTime,
 		"policies", len(policies),
+		"compiledPolicies", r.policyCache.Len(),
 		"batchSize", opts.BatchSize,
 		"rateLimit", opts.RateLimit,
 		"dryRun", opts.DryRun,
@@ -132,12 +161,12 @@ func (r *Reindexer) Run(ctx context.Context, opts Options) error {
 	}
 
 	// Process audit logs first
-	if err := r.processAuditLogs(ctx, opts, policies, &progress); err != nil {
+	if err := r.processAuditLogs(ctx, opts, &progress); err != nil {
 		return fmt.Errorf("failed to process audit logs: %w", err)
 	}
 
 	// Process Kubernetes events second
-	if err := r.processEvents(ctx, opts, policies, &progress); err != nil {
+	if err := r.processEvents(ctx, opts, &progress); err != nil {
 		return fmt.Errorf("failed to process events: %w", err)
 	}
 
@@ -231,7 +260,7 @@ func matchesLabels(resourceLabels, selectorLabels map[string]string) bool {
 
 
 // processAuditLogs processes all audit logs in the time range.
-func (r *Reindexer) processAuditLogs(ctx context.Context, opts Options, policies []*v1alpha1.ActivityPolicy, progress *Progress) error {
+func (r *Reindexer) processAuditLogs(ctx context.Context, opts Options, progress *Progress) error {
 	klog.InfoS("Processing audit logs", "startTime", opts.StartTime, "endTime", opts.EndTime)
 
 	cursor := ""
@@ -260,8 +289,8 @@ func (r *Reindexer) processAuditLogs(ctx context.Context, opts Options, policies
 			break
 		}
 
-		// Evaluate batch against policies
-		activities, err := evaluateBatch(ctx, batch, policies, "audit")
+		// Evaluate batch against policies using pre-compiled CEL programs
+		activities, err := r.evaluateAuditBatch(ctx, batch)
 		if err != nil {
 			reindexErrors.WithLabelValues("evaluate").Inc()
 			return fmt.Errorf("failed to evaluate audit batch %d: %w", batchNum, err)
@@ -335,7 +364,7 @@ func (r *Reindexer) processAuditLogs(ctx context.Context, opts Options, policies
 }
 
 // processEvents processes all Kubernetes events in the time range.
-func (r *Reindexer) processEvents(ctx context.Context, opts Options, policies []*v1alpha1.ActivityPolicy, progress *Progress) error {
+func (r *Reindexer) processEvents(ctx context.Context, opts Options, progress *Progress) error {
 	klog.InfoS("Processing Kubernetes events", "startTime", opts.StartTime, "endTime", opts.EndTime)
 
 	cursor := ""
@@ -364,8 +393,8 @@ func (r *Reindexer) processEvents(ctx context.Context, opts Options, policies []
 			break
 		}
 
-		// Evaluate batch against policies
-		activities, err := evaluateBatch(ctx, batch, policies, "event")
+		// Evaluate batch against policies using pre-compiled CEL programs
+		activities, err := r.evaluateEventBatch(ctx, batch)
 		if err != nil {
 			reindexErrors.WithLabelValues("evaluate").Inc()
 			return fmt.Errorf("failed to evaluate event batch %d: %w", batchNum, err)


### PR DESCRIPTION
## Summary

- Consolidate the reindexer to use pre-compiled CEL evaluation via `PolicyCache` instead of re-interpreting CEL expressions per event, matching the live activity processor's performance characteristics
- Implement a real `KindResolver` backed by Kubernetes API discovery so activity links with plural resource names (from audit `ObjectRef.resource`) get their Kind resolved correctly
- Extract shared `KindResolver`, `ResourceResolver`, and `NewRESTMapperFromConfig` factories into `internal/processor/kind_resolver.go` for reuse across processor, reindexer, and future consumers
- Fix a bug where core-group Kubernetes events (`apiVersion: "v1"`) would never match policies because `apiGroup` was set to `"v1"` instead of `""`

## Details

**Pre-compiled CEL**: The reindexer previously used `processor.EvaluateAuditRules`/`processor.EvaluateEventRules` which re-compiled CEL programs from scratch for every event. Now it populates a `PolicyCache` once at startup and uses compiled match programs with O(1) policy lookups by `apiGroup/resource` instead of iterating all policies per event.

**KindResolver**: Previously all reindexer callers passed `nil` for `KindResolver`, meaning links referencing plural resource names couldn't resolve their Kind. The reindex worker now builds a discovery-backed REST mapper from its existing `rest.Config` and passes it through.

**Shared helpers**: `Processor.resourceToKind()`/`kindToResource()` in `activityprocessor` now delegate to the shared factories, eliminating ~60 lines of duplicated discovery-with-cache-reset logic.

**Note**: Summary evaluation still uses the interpreted path (`EvaluateAuditSummaryMap`) because `link()` function calls capture links via a side-channel collector that must be freshly created per evaluation — the pre-compiled programs don't support link collection. This is a pre-existing pattern, now documented with a comment.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests)
- [ ] Deploy to staging and run a ReindexJob to verify activities are generated correctly
- [ ] Verify core-group events (if any policies target them) produce activities