### PR TITLE
fix(reindex): rate limiter burst and pre-compiled CEL

### DIFF
--- a/internal/reindex/ratelimiter.go
+++ b/internal/reindex/ratelimiter.go
@@ -13,11 +13,14 @@ type RateLimiter struct {
 	limiter *rate.Limiter
 }
 
-// NewRateLimiter creates a new rate limiter that allows up to eventsPerSecond events
-// with bursts up to 2x the rate.
-func NewRateLimiter(eventsPerSecond int) *RateLimiter {
-	// Allow bursts up to 2x the rate
+// NewRateLimiter creates a new rate limiter that allows up to eventsPerSecond events.
+// The burst size is set to max(eventsPerSecond*2, batchSize) so that a single batch
+// reservation never exceeds the burst capacity and causes ReserveN to fail.
+func NewRateLimiter(eventsPerSecond, batchSize int) *RateLimiter {
 	burst := eventsPerSecond * 2
+	if batchSize > burst {
+		burst = batchSize
+	}
 	if burst < 1 {
 		burst = 1
 	}

--- a/internal/reindex/reindexer.go
+++ b/internal/reindex/reindexer.go
@@ -109,7 +109,7 @@ func (r *Reindexer) Run(ctx context.Context, opts Options) error {
 
 	// Initialize rate limiter if configured
 	if opts.RateLimit > 0 {
-		r.rateLimiter = NewRateLimiter(int(opts.RateLimit))
+		r.rateLimiter = NewRateLimiter(int(opts.RateLimit), int(opts.BatchSize))
 	}
 
 	// Fetch active policies to apply


### PR DESCRIPTION
## Summary

- Refactors reindexer to use pre-compiled CEL expressions and real KindResolver for efficient policy evaluation
- Fixes rate limiter burst size to be at least as large as the batch size, preventing "cannot reserve N tokens" errors when batchSize > eventsPerSecond * 2

## Test plan

- [x] Merge and deploy to staging
- [x] Create a ReindexJob via `datumctl --platform-wide` and verify it processes batches without rate limiter errors
- [x] Confirm activities are generated for the reindexed time range

🤖 Generated with [Claude Code](https://claude.com/claude-code)