### PR TITLE
fix: deterministic activity names to prevent duplicates from DLQ retries

### DIFF
--- a/internal/activityprocessor/dlq_retry.go
+++ b/internal/activityprocessor/dlq_retry.go
@@ -428,15 +428,15 @@ func (c *DLQRetryController) republishEvent(ctx context.Context, event *processo
 		return fmt.Errorf("unknown event type: %s", event.Type)
 	}
 
-	// Use message ID for deduplication - include policy name and payload hash
-	// to ensure uniqueness across different policies and payloads
+	// Use a stable message ID for deduplication - excludes retry count so that
+	// repeated retries of the same event are deduplicated on the source stream.
+	// This prevents duplicates if the DLQ ACK fails after a successful republish.
 	payloadHash := computePayloadHash(event.OriginalPayload)
-	msgID := fmt.Sprintf("dlq-retry-%s-%s-%s-%s-%d",
+	msgID := fmt.Sprintf("dlq-retry-%s-%s-%s-%s",
 		event.Type,
 		event.PolicyName,
 		payloadHash,
 		event.Timestamp.Format(time.RFC3339Nano),
-		event.RetryCount+1,
 	)
 
 	_, err := c.js.Publish(

--- a/internal/processor/activity.go
+++ b/internal/processor/activity.go
@@ -1,11 +1,12 @@
 package processor
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
@@ -13,6 +14,21 @@ import (
 	"go.miloapis.com/activity/internal/cel"
 	"go.miloapis.com/activity/pkg/apis/activity/v1alpha1"
 )
+
+// activityName generates a deterministic activity name from the origin event
+// identifier and the policy's resource target. The same input always produces
+// the same name, enabling NATS message deduplication on retries.
+func activityName(originType, originID, apiGroup, kind string) string {
+	h := sha256.New()
+	h.Write([]byte(originType))
+	h.Write([]byte{0}) // separator
+	h.Write([]byte(originID))
+	h.Write([]byte{0})
+	h.Write([]byte(apiGroup))
+	h.Write([]byte{0})
+	h.Write([]byte(kind))
+	return "act-" + hex.EncodeToString(h.Sum(nil))[:12]
+}
 
 // ActivityBuilder contains the common fields needed to build an Activity.
 type ActivityBuilder struct {
@@ -53,7 +69,7 @@ func (b *ActivityBuilder) BuildFromAudit(
 	tenant := ExtractTenant(audit.User)
 
 	// Generate activity name
-	activityName := fmt.Sprintf("act-%s", uuid.New().String()[:8])
+	name := activityName("audit", string(audit.AuditID), b.APIGroup, b.Kind)
 
 	// Convert links
 	activityLinks, err := ConvertLinks(links, resolveKind)
@@ -67,7 +83,7 @@ func (b *ActivityBuilder) BuildFromAudit(
 			Kind:       "Activity",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              activityName,
+			Name:              name,
 			Namespace:         namespace,
 			CreationTimestamp: metav1.NewTime(timestamp),
 			Labels: map[string]string{
@@ -170,19 +186,20 @@ func (b *ActivityBuilder) BuildFromEvent(
 	// Extract tenant from scope annotations; fall back to platform scope when absent.
 	tenant := ExtractTenantFromAnnotations(eventMap)
 
+	// Get event UID for origin (extracted before name generation so it can be
+	// used as input to the deterministic name hash).
+	eventUID := ""
+	if metadata, ok := eventMap["metadata"].(map[string]interface{}); ok {
+		eventUID = GetNestedString(metadata, "uid")
+	}
+
 	// Generate activity name
-	activityName := fmt.Sprintf("act-%s", uuid.New().String()[:8])
+	name := activityName("event", eventUID, b.APIGroup, b.Kind)
 
 	// Convert links
 	activityLinks, err := ConvertLinks(links, resolveKind)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrActivityBuild, err)
-	}
-
-	// Get event UID for origin
-	eventUID := ""
-	if metadata, ok := eventMap["metadata"].(map[string]interface{}); ok {
-		eventUID = GetNestedString(metadata, "uid")
 	}
 
 	return &v1alpha1.Activity{
@@ -191,7 +208,7 @@ func (b *ActivityBuilder) BuildFromEvent(
 			Kind:       "Activity",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              activityName,
+			Name:              name,
 			Namespace:         namespace,
 			CreationTimestamp: metav1.NewTime(timestamp),
 			Labels: map[string]string{

--- a/internal/processor/event.go
+++ b/internal/processor/event.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
@@ -331,7 +330,7 @@ func (p *EventProcessor) buildActivity(
 	}
 
 	// Generate activity name.
-	activityName := fmt.Sprintf("act-%s", uuid.New().String()[:8])
+	name := activityName("event", eventUID, matched.APIGroup, matched.Kind)
 
 	// Convert links.
 	var activityLinks []v1alpha1.ActivityLink
@@ -354,7 +353,7 @@ func (p *EventProcessor) buildActivity(
 			Kind:       "Activity",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              activityName,
+			Name:              name,
 			Namespace:         namespace,
 			CreationTimestamp: metav1.NewTime(timestamp),
 			Labels: map[string]string{


### PR DESCRIPTION
## Summary

- Replace random UUID-based activity names with deterministic SHA-256 hashes of `(originType, originID, apiGroup, kind)`, enabling NATS JetStream message deduplication across retries
- Remove `RetryCount` from DLQ republish `MsgId` so repeated retries of the same event are deduplicated on the source stream
- Fixes duplicate activities accumulating in staging when the DLQ reprocessor retries failed events

## Context

Two compounding bugs caused old activities to keep "popping up" in staging:

1. **Non-deterministic activity names**: Each processing attempt generated a new UUID-based name, so NATS dedup couldn't detect that the same logical activity was being republished.
2. **Retry-count-dependent MsgIds**: The DLQ republish included `RetryCount+1` in the MsgId, producing a unique ID per retry that bypassed NATS dedup on the source stream.

Together, these created an endless cycle: failed events were retried, produced new duplicate activities (with new names), and if those failed again, went back to the DLQ.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/processor/... ./internal/activityprocessor/...` passes
- [ ] Deploy to staging and verify duplicate activities stop accumulating
- [ ] Verify DLQ retry metrics stabilize (no more steady-state ~0.5-0.667 ops/s periodic-succeeded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)