### PR TITLE
feat(ui): add shared deep-linking utilities and ActivityLayout

### DIFF
--- a/ui/src/components/ActivityLayout.tsx
+++ b/ui/src/components/ActivityLayout.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Tabs, TabsList, TabsTrigger } from './ui/tabs';
+import { cn } from '../lib/utils';
+
+export interface ActivityTab {
+  label: string;
+  value: string;
+  href: string;
+}
+
+export interface ActivityLayoutProps {
+  /** Base path for constructing tab routes */
+  basePath: string;
+  /** Currently active tab value. Derive from the current URL in your app. */
+  activeTab: string;
+  /** Optional custom tabs. Defaults to Activity Feed, Events, and Audit Logs. */
+  tabs?: ActivityTab[];
+  /** Link component to render tab triggers as navigable links (e.g., react-router's Link) */
+  linkComponent?: React.ElementType;
+  /** Content to render below the tabs */
+  children: React.ReactNode;
+  /** Optional className for the outer container */
+  className?: string;
+}
+
+const defaultTabs = (basePath: string): ActivityTab[] => [
+  { label: 'Activity Feed', value: 'feed', href: basePath },
+  { label: 'Events', value: 'events', href: `${basePath}/events` },
+  { label: 'Audit Logs', value: 'audit-logs', href: `${basePath}/audit-logs` },
+];
+
+/**
+ * Shared activity layout with tab navigation for Activity Feed, Events, and Audit Logs.
+ * Framework-agnostic — pass a linkComponent (e.g., react-router's Link) for navigation.
+ */
+export function ActivityLayout({
+  basePath,
+  activeTab,
+  tabs,
+  linkComponent: LinkComp,
+  children,
+  className,
+}: ActivityLayoutProps) {
+  const resolvedTabs = tabs ?? defaultTabs(basePath);
+
+  return (
+    <div className={cn('flex h-full flex-col overflow-hidden', className)}>
+      <div className="shrink-0 border-b px-4 pt-3">
+        <Tabs value={activeTab}>
+          <TabsList>
+            {resolvedTabs.map((tab) => (
+              <TabsTrigger key={tab.value} value={tab.value} asChild={!!LinkComp}>
+                {LinkComp ? (
+                  <LinkComp to={tab.href}>{tab.label}</LinkComp>
+                ) : (
+                  <span>{tab.label}</span>
+                )}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden p-4">
+        <div className="flex h-full flex-col">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -85,6 +85,10 @@ export type { RulePreviewPanelProps } from './components/RulePreviewPanel';
 export { CelEditor } from './components/CelEditor';
 export type { CelEditorProps } from './components/CelEditor';
 
+// Components - Activity Layout
+export { ActivityLayout } from './components/ActivityLayout';
+export type { ActivityLayoutProps, ActivityTab } from './components/ActivityLayout';
+
 // Components - ReindexJob
 export { ReindexJobList } from './components/ReindexJobList';
 export type { ReindexJobListProps } from './components/ReindexJobList';
@@ -178,6 +182,18 @@ export { cn } from './lib/utils';
 export { ApiError, parseApiError, NetworkError, defaultErrorFormatter } from './lib/errors';
 export type { ApiErrorResponse } from './lib/errors';
 export { extractFieldPaths, extractFieldPathsFromMany } from './lib/extractFieldPaths';
+
+// Utilities - Deep Linking & URL Serialization
+export {
+  serializeActivityFilters,
+  parseActivityFilters,
+  serializeEventFilters,
+  parseEventFilters,
+  parseTimeRange,
+} from './lib/activity-filters';
+
+// Utilities - Shareable URLs
+export { generateShareableUrl, copyToClipboard } from './lib/activity-share';
 
 // Hooks - Audit Log Query (existing)
 export { useAuditLogQuery } from './hooks/useAuditLogQuery';

--- a/ui/src/lib/activity-filters.ts
+++ b/ui/src/lib/activity-filters.ts
@@ -1,0 +1,203 @@
+import type { ActivityFeedFilters, TimeRange } from '../hooks/useActivityFeed';
+import type { EventsFeedFilters } from '../hooks/useEventsFeed';
+
+/**
+ * Serialize Activity Feed filters to URL search params.
+ * Used to sync filter changes back to the URL for deep linking.
+ */
+export function serializeActivityFilters(
+  filters: Partial<ActivityFeedFilters>,
+  timeRange: TimeRange,
+  streamingEnabled: boolean = true
+): URLSearchParams {
+  const params = new URLSearchParams();
+
+  if (timeRange.start) {
+    params.set('start', timeRange.start);
+  }
+  if (timeRange.end) {
+    params.set('end', timeRange.end);
+  }
+
+  if (!streamingEnabled) {
+    params.set('streaming', 'false');
+  }
+
+  if (filters.changeSource && filters.changeSource !== 'human') {
+    params.set('changeSource', filters.changeSource);
+  }
+
+  if (filters.actorNames && filters.actorNames.length > 0) {
+    params.set('actorNames', filters.actorNames.join(','));
+  }
+
+  if (filters.resourceKinds && filters.resourceKinds.length > 0) {
+    params.set('resourceKinds', filters.resourceKinds.join(','));
+  }
+
+  if (filters.apiGroups && filters.apiGroups.length > 0) {
+    params.set('apiGroups', filters.apiGroups.join(','));
+  }
+
+  if (filters.resourceNamespaces && filters.resourceNamespaces.length > 0) {
+    params.set('resourceNamespaces', filters.resourceNamespaces.join(','));
+  }
+
+  if (filters.resourceUid) {
+    params.set('resourceUid', filters.resourceUid);
+  }
+
+  if (filters.resourceName) {
+    params.set('resourceName', filters.resourceName);
+  }
+
+  if (filters.search) {
+    params.set('search', filters.search);
+  }
+
+  return params;
+}
+
+/**
+ * Serialize Events Feed filters to URL search params.
+ * Used to sync filter changes back to the URL for deep linking.
+ */
+export function serializeEventFilters(
+  filters: Partial<EventsFeedFilters>,
+  timeRange: TimeRange,
+  streamingEnabled: boolean = true
+): URLSearchParams {
+  const params = new URLSearchParams();
+
+  if (timeRange.start) {
+    params.set('start', timeRange.start);
+  }
+  if (timeRange.end) {
+    params.set('end', timeRange.end);
+  }
+
+  if (!streamingEnabled) {
+    params.set('streaming', 'false');
+  }
+
+  if (filters.eventType && filters.eventType !== 'all') {
+    params.set('eventType', filters.eventType);
+  }
+
+  if (filters.reasons && filters.reasons.length > 0) {
+    params.set('reasons', filters.reasons.join(','));
+  }
+
+  if (filters.namespaces && filters.namespaces.length > 0) {
+    params.set('namespaces', filters.namespaces.join(','));
+  }
+
+  if (filters.involvedKinds && filters.involvedKinds.length > 0) {
+    params.set('involvedKinds', filters.involvedKinds.join(','));
+  }
+
+  if (filters.search) {
+    params.set('search', filters.search);
+  }
+
+  return params;
+}
+
+/**
+ * Parse Activity Feed filters from URL query params
+ */
+export function parseActivityFilters(searchParams: URLSearchParams): Partial<ActivityFeedFilters> {
+  const filters: Partial<ActivityFeedFilters> = {};
+
+  const changeSource = searchParams.get('changeSource');
+  if (changeSource === 'human' || changeSource === 'system' || changeSource === 'all') {
+    filters.changeSource = changeSource;
+  } else {
+    filters.changeSource = 'human';
+  }
+
+  const actorNames = searchParams.get('actorNames');
+  if (actorNames) {
+    filters.actorNames = actorNames.split(',').filter(Boolean);
+  }
+
+  const resourceKinds = searchParams.get('resourceKinds');
+  if (resourceKinds) {
+    filters.resourceKinds = resourceKinds.split(',').filter(Boolean);
+  }
+
+  const apiGroups = searchParams.get('apiGroups');
+  if (apiGroups) {
+    filters.apiGroups = apiGroups.split(',').filter(Boolean);
+  }
+
+  const resourceNamespaces = searchParams.get('resourceNamespaces');
+  if (resourceNamespaces) {
+    filters.resourceNamespaces = resourceNamespaces.split(',').filter(Boolean);
+  }
+
+  const resourceUid = searchParams.get('resourceUid');
+  if (resourceUid) {
+    filters.resourceUid = resourceUid;
+  }
+
+  const resourceName = searchParams.get('resourceName');
+  if (resourceName) {
+    filters.resourceName = resourceName;
+  }
+
+  const search = searchParams.get('search');
+  if (search) {
+    filters.search = search;
+  }
+
+  return filters;
+}
+
+/**
+ * Parse Events Feed filters from URL query params
+ */
+export function parseEventFilters(searchParams: URLSearchParams): Partial<EventsFeedFilters> {
+  const filters: Partial<EventsFeedFilters> = {};
+
+  const eventType = searchParams.get('eventType');
+  if (eventType === 'Normal' || eventType === 'Warning' || eventType === 'all') {
+    filters.eventType = eventType;
+  }
+
+  const reasons = searchParams.get('reasons');
+  if (reasons) {
+    filters.reasons = reasons.split(',').filter(Boolean);
+  }
+
+  const namespaces = searchParams.get('namespaces');
+  if (namespaces) {
+    filters.namespaces = namespaces.split(',').filter(Boolean);
+  }
+
+  const involvedKinds = searchParams.get('involvedKinds');
+  if (involvedKinds) {
+    filters.involvedKinds = involvedKinds.split(',').filter(Boolean);
+  }
+
+  const search = searchParams.get('search');
+  if (search) {
+    filters.search = search;
+  }
+
+  return filters;
+}
+
+/**
+ * Parse time range from URL query params
+ */
+export function parseTimeRange(searchParams: URLSearchParams): TimeRange | undefined {
+  const start = searchParams.get('start');
+  const end = searchParams.get('end');
+
+  if (!start) {
+    return undefined;
+  }
+
+  return { start, end: end || undefined };
+}

--- a/ui/src/lib/activity-share.ts
+++ b/ui/src/lib/activity-share.ts
@@ -1,0 +1,55 @@
+import type { EffectiveTimeRange } from '../types/activity';
+
+/**
+ * Generate a shareable URL for the current activity view.
+ *
+ * The shareable URL:
+ * - Uses absolute timestamps (not relative like "now-1h")
+ * - Disables streaming so the view is static
+ * - Preserves all current filters
+ *
+ * This ensures the shared link shows the exact same data regardless of
+ * when someone opens it.
+ *
+ * @param basePath - Current route path (e.g., "/activity/feed")
+ * @param effectiveTimeRange - Server-calculated effective time range
+ * @param filters - Current filter state
+ * @param origin - Window origin for absolute URL (e.g., "https://staff.datum.cloud")
+ */
+export function generateShareableUrl(
+  basePath: string,
+  effectiveTimeRange: EffectiveTimeRange,
+  filters: Record<string, string>,
+  origin: string = typeof window !== 'undefined' ? window.location.origin : ''
+): string {
+  const params = new URLSearchParams();
+
+  // Use absolute timestamps from server-calculated range
+  params.set('start', effectiveTimeRange.startTime);
+  params.set('end', effectiveTimeRange.endTime);
+
+  // Disable streaming for shared links (static view)
+  params.set('streaming', 'false');
+
+  // Preserve all current filters
+  for (const [key, value] of Object.entries(filters)) {
+    if (value && key !== 'start' && key !== 'end' && key !== 'streaming') {
+      params.set(key, value);
+    }
+  }
+
+  return `${origin}${basePath}?${params.toString()}`;
+}
+
+/**
+ * Copy text to clipboard and return success status
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch (err) {
+    console.error('Failed to copy to clipboard:', err);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Add URL serialization/parsing utilities for activity feed and event feed filters (`activity-filters.ts`)
- Add shareable URL generation and clipboard helper (`activity-share.ts`)
- Add framework-agnostic `ActivityLayout` component with tabbed navigation for Activity Feed, Events, and Audit Logs
- Export all new utilities and components from the package index

These were previously implemented in the staff-portal and are being extracted into the shared library so any consumer app (staff-portal, customer portal, etc.) can use them.

## Test plan
- [x] `npm run build` passes with no errors
- [ ] Verify deep-linking round-trip: serialize filters → URL → parse filters produces identical state
- [ ] Verify ActivityLayout renders tabs correctly with a `linkComponent` prop
- [ ] Verify shareable URL generation produces absolute URLs with static timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)