### PR TITLE
fix: drain DLQ backlog in loop instead of single batch per tick

### DIFF
--- a/internal/activityprocessor/dlq_retry.go
+++ b/internal/activityprocessor/dlq_retry.go
@@ -168,21 +168,59 @@ func (c *DLQRetryController) Start(ctx context.Context) error {
 	}
 }
 
-// periodicRetry processes a batch of retry-eligible DLQ events.
+// maxPeriodicRunDuration caps how long a single periodic drain run may take.
+// This prevents unbounded processing when the DLQ is being filled faster than
+// it can be drained, ensuring the goroutine remains responsive to cancellation.
+const maxPeriodicRunDuration = 2 * time.Minute
+
+// periodicRetry drains the DLQ backlog by repeatedly calling processRetryBatch
+// until the queue is empty, the context is cancelled, or maxPeriodicRunDuration
+// is exceeded. The batch duration metric is recorded per batch; a summary log is
+// emitted once at the end of the full drain run.
 func (c *DLQRetryController) periodicRetry(ctx context.Context) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	start := time.Now()
-	processed, succeeded, failed := c.processRetryBatch(ctx, "periodic", nil)
-	dlqRetryBatchDuration.WithLabelValues("periodic").Observe(time.Since(start).Seconds())
+	runDeadline := time.Now().Add(maxPeriodicRunDuration)
 
-	if processed > 0 {
-		klog.InfoS("Completed periodic DLQ retry batch",
-			"processed", processed,
-			"succeeded", succeeded,
-			"failed", failed,
-			"duration", time.Since(start),
+	var totalProcessed, totalSucceeded, totalFailed int
+	runStart := time.Now()
+
+	for {
+		// Respect context cancellation between batches.
+		if ctx.Err() != nil {
+			break
+		}
+
+		// Enforce the per-run time cap.
+		if time.Now().After(runDeadline) {
+			klog.InfoS("DLQ periodic retry reached max run duration, deferring remainder to next tick",
+				"maxDuration", maxPeriodicRunDuration,
+				"totalProcessed", totalProcessed,
+			)
+			break
+		}
+
+		batchStart := time.Now()
+		processed, succeeded, failed := c.processRetryBatch(ctx, "periodic", nil)
+		dlqRetryBatchDuration.WithLabelValues("periodic").Observe(time.Since(batchStart).Seconds())
+
+		totalProcessed += processed
+		totalSucceeded += succeeded
+		totalFailed += failed
+
+		// An empty batch means the DLQ has been fully drained.
+		if processed == 0 {
+			break
+		}
+	}
+
+	if totalProcessed > 0 {
+		klog.InfoS("Completed periodic DLQ retry run",
+			"totalProcessed", totalProcessed,
+			"totalSucceeded", totalSucceeded,
+			"totalFailed", totalFailed,
+			"duration", time.Since(runStart),
 		)
 	}
 }


### PR DESCRIPTION
## Summary

- Change `periodicRetry()` to loop until the DLQ is empty rather than processing a single 100-message batch per 5-minute tick
- Add a 2-minute max run duration safety cap to prevent unbounded processing
- Follows up on #108 which fixed the root cause of duplicate activities; this drains the ~15K accumulated backlog

## Context

PR #108 fixed deterministic activity names and stable DLQ MsgIds, stopping new events from cycling through the DLQ. However, ~14,719 accumulated DLQ messages remain from before the fix. At the previous rate of 100 messages per 5 minutes, draining would take 12+ hours. This change makes the periodic retry loop through all available messages (up to the 2-minute cap), clearing the backlog in minutes.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/activityprocessor/...` passes
- [ ] Deploy to staging and verify DLQ drains completely
- [ ] Verify `periodic-succeeded` retry rate drops to zero after drain

🤖 Generated with [Claude Code](https://claude.com/claude-code)