### PR TITLE
fix: switch DLQ stream to workqueue retention

### DIFF
--- a/config/components/nats-streams/dlq-stream.yaml
+++ b/config/components/nats-streams/dlq-stream.yaml
@@ -38,8 +38,10 @@ spec:
   subjects:
     - activity.dlq.>
 
-  # Retention policy: limits-based (time + size)
-  retention: limits
+  # Retention policy: workqueue removes messages once acknowledged by a consumer.
+  # This ensures the DLQ drains automatically as the retry controller processes
+  # and re-publishes events. Time and size limits still apply as upper bounds.
+  retention: workqueue
 
   # Storage: file-based for durability
   storage: file


### PR DESCRIPTION
## Summary

- Change DLQ stream retention from `limits` to `workqueue` so ACKs automatically remove messages
- Add explicit `DeleteMsg` calls in the retry controller as a defensive fallback
- Root cause: with `limits` retention, ACKing DLQ messages from ephemeral consumers had no effect, so ~15K messages were reprocessed in an endless loop every 5 minutes

## Migration

**NATS does not allow changing retention policy on an existing stream.** The `ACTIVITY_DEAD_LETTER` stream must be deleted and recreated:

```bash
# In staging (via nats-box or port-forward):
nats stream delete ACTIVITY_DEAD_LETTER --force

# The NATS JetStream operator will recreate it with workqueue retention
# from the updated Stream CRD
```

The existing ~15K DLQ messages are stale duplicates from the bug fixed in #108 and have no value.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/activityprocessor/...` passes
- [ ] Delete and recreate DLQ stream in staging
- [ ] Verify `periodic-succeeded` retry rate drops to zero
- [ ] Verify DLQ backlog stays at zero on the new dashboard panel (#111)

🤖 Generated with [Claude Code](https://claude.com/claude-code)