### PR TITLE
chore(ui): bump version to 0.1.1

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datum-cloud/activity-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "packageManager": "pnpm@10.29.3",
   "description": "React components for Kubernetes Activity",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Manually bump `@datum-cloud/activity-ui` version to 0.1.1

The previous publish workflow ([run](https://github.com/datum-cloud/activity/actions/runs/22958363534)) failed at the npm publish step after the UI changes from #109 were merged. Main has the new code but npm still has 0.1.0. This bump will trigger a fresh publish run (to 0.1.2) once merged.

## Test plan
- [ ] Merge and verify the "Publish UI to NPM" workflow succeeds
- [ ] Confirm `npm view @datum-cloud/activity-ui version` shows the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)