### PR TITLE
fix(ui): add repository URL for npm provenance verification

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -36,6 +36,11 @@
   ],
   "author": "Milo APIs",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/datum-cloud/activity",
+    "directory": "ui"
+  },
   "peerDependencies": {
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-checkbox": "^1.0.0",


### PR DESCRIPTION
## Summary
- Add `repository` field to `ui/package.json` pointing to `https://github.com/datum-cloud/activity`

The npm publish workflow uses `--provenance` (sigstore OIDC), which requires `package.json` to have a `repository.url` matching the publishing GitHub repo. Without it, npm rejects the publish with:

```
E422: Error verifying sigstore provenance bundle: Failed to validate repository 
information: package.json: "repository.url" is "", expected to match 
"https://github.com/datum-cloud/activity" from provenance
```

## Test plan
- [ ] Merge and verify the "Publish UI to NPM" workflow succeeds
- [ ] Confirm `npm view @datum-cloud/activity-ui version` shows the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)