### PR TITLE
feat(ci): adopt dev builds for activity-ui npm publishing

### DIFF
--- a/.github/workflows/publish-ui-npm.yaml
+++ b/.github/workflows/publish-ui-npm.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    uses: datum-cloud/actions/.github/workflows/publish-npm-package.yaml@feat/npm-dev-builds
+    uses: datum-cloud/actions/.github/workflows/publish-npm-package.yaml@v0.12.0
     with:
       package-name: "@datum-cloud/activity-ui"
       package-path: ui


### PR DESCRIPTION
## Summary
- Switch `publish-ui-npm.yaml` to the dual-mode dev/release workflow pattern
- **Push to main** → publishes `x.y.z-dev.{sha}` to the `dev` npm dist-tag
- **GitHub release** → publishes stable version to `latest` npm dist-tag with auto version bump

Currently references `datum-cloud/actions@feat/npm-dev-builds` — update to the tagged release once [datum-cloud/actions#56](https://github.com/datum-cloud/actions/pull/56) is merged and tagged.

## Test plan
- [x] Merge and verify a dev build is published (e.g., `0.1.2-dev.abc1234`)
- [x] Verify `npm install @datum-cloud/activity-ui@dev` resolves the new version
- [ ] Create a GitHub release and verify stable publish works

🤖 Generated with [Claude Code](https://claude.com/claude-code)