### PR TITLE
docs: update README to reflect v0.3.0 capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ Activity consists of several components that work together:
 **Releases**
 - [v0.3.0 Release Notes](docs/releases/v0.3.0.md)
 
+## Claude Code plugin
+
+The `milo-activity` plugin adds guided workflows for incident investigation, user auditing, and ActivityPolicy authoring on top of the [MCP server](docs/guides/mcp-server.md). Install it from the marketplace:
+
+```
+/plugin marketplace add datum-cloud/claude-code-plugins
+/plugin install milo-activity@datum-claude-code-plugins
+```
+
+**Prerequisite:** the `activity` binary must be on your PATH and configured as an MCP server. See the [MCP server guide](docs/guides/mcp-server.md) for setup.
+
 ## Who is this for?
 
 - **Platform teams** who need to understand cluster activity across multiple tenants


### PR DESCRIPTION
## Summary
- Reframed intro and "What is this?" to lead with human-readable activity summaries instead of raw audit log queries
- Added missing components (activity-processor, activity-controller-manager, MCP server)
- Updated capabilities list with v0.3.0 features: activity policies, control plane events, real-time streaming, ReindexJob, AI/MCP integration, embeddable UI
- Removed "What's coming next?" section (those features shipped)
- Reorganized documentation links into Guides / Reference / Releases with links to new v0.3.0 guides
- Updated Go prerequisite to 1.25+

## Test plan
- [ ] Verify all documentation links resolve correctly
- [ ] Review rendered markdown on GitHub for formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)