### PR TITLE
fix(iam): include ActivityPolicy ProtectedResource in kustomization

### DIFF
--- a/config/milo/iam/resources/kustomization.yaml
+++ b/config/milo/iam/resources/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - activities.yaml
   - activityqueries.yaml
   - activityfacetqueries.yaml
+  - activitypolicies.yaml
   - auditlogqueries.yaml
   - auditlogfacetsqueries.yaml
   - policypreviews.yaml


### PR DESCRIPTION
## Summary

The ActivityPolicy resource was defined but accidentally left out of the kustomization file, so it was never deployed. This meant staff users couldn't manage activity policies in production because the IAM system didn't know the resource existed.

## Test plan
- [ ] After deployment, confirm `activity.miloapis.com-activitypolicies` ProtectedResource exists in the milo control plane
- [ ] Confirm staff-activity policy bindings reconcile to Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)