### PR TITLE
feat(ui): timeline variant, debounced search, and UTC timestamp fix

### DIFF
--- a/ui/src/components/ActivityExpandedDetails.tsx
+++ b/ui/src/components/ActivityExpandedDetails.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { format } from 'date-fns';
 import { Copy, Check } from 'lucide-react';
 import type { Activity, TenantLinkResolver } from '../types/activity';
 import { TenantBadge } from './TenantBadge';
@@ -15,15 +14,18 @@ export interface ActivityExpandedDetailsProps {
   activity: Activity;
   /** Optional resolver function to make tenant badges clickable */
   tenantLinkResolver?: TenantLinkResolver;
+  /** When true, removes the top margin/border (caller handles the separator) */
+  compact?: boolean;
 }
 
 /**
- * Format timestamp for display (with timezone)
+ * Format timestamp for display (in UTC)
  */
 function formatTimestampFull(timestamp?: string): string {
   if (!timestamp) return 'Unknown time';
   try {
-    return format(new Date(timestamp), 'yyyy-MM-dd HH:mm:ss \'UTC\'');
+    const date = new Date(timestamp);
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')} ${String(date.getUTCHours()).padStart(2, '0')}:${String(date.getUTCMinutes()).padStart(2, '0')}:${String(date.getUTCSeconds()).padStart(2, '0')} UTC`;
   } catch {
     return timestamp;
   }
@@ -80,14 +82,14 @@ function CopyButton({ value, label }: { value: string; label: string }) {
  * 5. Resource - what resource was affected
  * 6. Origin - correlation to audit logs
  */
-export function ActivityExpandedDetails({ activity, tenantLinkResolver }: ActivityExpandedDetailsProps) {
+export function ActivityExpandedDetails({ activity, tenantLinkResolver, compact = false }: ActivityExpandedDetailsProps) {
   const { spec, metadata } = activity;
   const { actor, resource, origin, changes, tenant } = spec;
   const timestamp = metadata?.creationTimestamp;
 
   return (
     <TooltipProvider>
-      <div className="mt-4 pt-4 border-t border-border">
+      <div className={compact ? 'p-4 bg-muted/30' : 'mt-4 pt-4 border-t border-border'}>
         {/* Field Changes - Most actionable, shown first */}
         {changes && changes.length > 0 && (
           <div className="mb-3">

--- a/ui/src/components/ActivityFeed.tsx
+++ b/ui/src/components/ActivityFeed.tsx
@@ -36,6 +36,8 @@ export interface ActivityFeedProps {
   onActivityClick?: (activity: Activity) => void;
   /** Whether to show in compact mode (for resource detail tabs) */
   compact?: boolean;
+  /** Layout variant for activity items: 'feed' (default) or 'timeline' */
+  variant?: 'feed' | 'timeline';
   /** Filter to a specific resource UID */
   resourceUid?: string;
   /** Whether to show filters */
@@ -82,6 +84,7 @@ export function ActivityFeed({
   tenantRenderer,
   onActivityClick,
   compact = false,
+  variant = 'feed',
   resourceUid,
   showFilters = true,
   hiddenFilters = [],
@@ -231,13 +234,13 @@ export function ActivityFeed({
   // Build container classes - use flex layout to properly fill available space
   // flex-1 min-h-0 allows the Card to fill parent flex container and enable child scrolling
   const containerClasses = compact
-    ? `flex-1 min-h-0 flex flex-col p-1 shadow-none border-border ${className}`
+    ? `flex-1 min-h-0 flex flex-col p-0 shadow-none border-none ${className}`
     : `flex-1 min-h-0 flex flex-col p-3 ${className}`;
 
   // Build list classes - use flex-1 min-h-0 for flex-based scrolling
   // Parent containers must have proper height constraints (h-screen/h-full + overflow-hidden)
   const effectiveMaxHeight = maxHeight === 'none' ? undefined : maxHeight;
-  const listClasses = 'flex-1 min-h-0 overflow-y-auto pr-2 flex flex-col';
+  const listClasses = 'flex-1 min-h-0 overflow-y-auto flex flex-col';
 
   return (
     <Card className={containerClasses}>
@@ -396,6 +399,8 @@ export function ActivityFeed({
             onActivityClick={onActivityClick}
             compact={compact}
             isNew={enableStreaming && index < newActivitiesCount}
+            variant={variant}
+            isLast={index === activities.length - 1}
           />
         ))}
 

--- a/ui/src/components/ActivityFeedFilters.tsx
+++ b/ui/src/components/ActivityFeedFilters.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { formatISO, subDays } from 'date-fns';
-import { Search } from 'lucide-react';
+import { Search, X } from 'lucide-react';
 
 import type { ActivityFeedFilters as FilterState } from '../hooks/useActivityFeed';
 import type { TimeRange } from '../hooks/useActivityFeed';
@@ -200,13 +200,16 @@ export function ActivityFeedFilters({
   };
 
   // Determine which filters are currently active (have values) and not hidden
-  const filtersWithValues: FilterId[] = [];
-  if (filters.resourceKinds && filters.resourceKinds.length > 0 && !hiddenFilters.includes('resourceKinds')) filtersWithValues.push('resourceKinds');
-  if (filters.actorNames && filters.actorNames.length > 0 && !hiddenFilters.includes('actorNames')) filtersWithValues.push('actorNames');
-  if (filters.apiGroups && filters.apiGroups.length > 0 && !hiddenFilters.includes('apiGroups')) filtersWithValues.push('apiGroups');
-  if (filters.resourceNamespaces && filters.resourceNamespaces.length > 0 && !hiddenFilters.includes('resourceNamespaces')) filtersWithValues.push('resourceNamespaces');
-  if (filters.resourceName && !hiddenFilters.includes('resourceName')) filtersWithValues.push('resourceName');
-  if (filters.actions && filters.actions.length > 0) filtersWithValues.push('actions');
+  const filtersWithValues = useMemo<FilterId[]>(() => {
+    const result: FilterId[] = [];
+    if (filters.resourceKinds && filters.resourceKinds.length > 0 && !hiddenFilters.includes('resourceKinds')) result.push('resourceKinds');
+    if (filters.actorNames && filters.actorNames.length > 0 && !hiddenFilters.includes('actorNames')) result.push('actorNames');
+    if (filters.apiGroups && filters.apiGroups.length > 0 && !hiddenFilters.includes('apiGroups')) result.push('apiGroups');
+    if (filters.resourceNamespaces && filters.resourceNamespaces.length > 0 && !hiddenFilters.includes('resourceNamespaces')) result.push('resourceNamespaces');
+    if (filters.resourceName && !hiddenFilters.includes('resourceName')) result.push('resourceName');
+    if (filters.actions && filters.actions.length > 0) result.push('actions');
+    return result;
+  }, [filters, hiddenFilters]);
 
   // Include pendingFilter (newly added filter awaiting value selection) in the displayed filters
   const activeFilterIds: FilterId[] = pendingFilter && !filtersWithValues.includes(pendingFilter)
@@ -228,7 +231,7 @@ export function ActivityFeedFilters({
     { id: 'apiGroups', label: 'API Group' },
     { id: 'resourceNamespaces', label: 'Namespace' },
     { id: 'resourceName', label: 'Resource Name' },
-    { id: 'actions', label: 'Action' },
+    // 'actions' hidden until backend facet support is available
   ].filter((filter) => !hiddenFilters.includes(filter.id as FilterId));
 
   // Handle adding a filter
@@ -330,20 +333,39 @@ export function ActivityFeedFilters({
     return (value as string[] | undefined) || [];
   };
 
-  // Handle search input change with debouncing
-  const handleSearchChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value;
-      onFiltersChange({
-        ...filters,
-        search: value || undefined,
-      });
-    },
-    [filters, onFiltersChange]
-  );
+  // Local search value for debouncing — keeps input responsive while query runs
+  const [searchInputValue, setSearchInputValue] = useState(filters.search || '');
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Use refs so the debounced callback never closes over stale values
+  const filtersRef = useRef(filters);
+  filtersRef.current = filters;
+  const onFiltersChangeRef = useRef(onFiltersChange);
+  onFiltersChangeRef.current = onFiltersChange;
+
+  // Cancel any pending debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    };
+  }, []);
+
+  const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setSearchInputValue(value);
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    searchDebounceRef.current = setTimeout(() => {
+      onFiltersChangeRef.current({ ...filtersRef.current, search: value || undefined });
+    }, 400);
+  }, []);
+
+  const handleSearchClear = useCallback(() => {
+    setSearchInputValue('');
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    onFiltersChangeRef.current({ ...filtersRef.current, search: undefined });
+  }, []);
 
   return (
-    <div className={`mb-3 pb-3 border-b border-border pr-2 ${className}`}>
+    <div className={`mb-3 pb-3 border-b border-border p-4 ${className}`}>
       <div className="flex flex-wrap gap-2 items-center">
         {/* Change Source Toggle */}
         {!hiddenFilters.includes('changeSource') && (
@@ -360,11 +382,19 @@ export function ActivityFeedFilters({
           <Input
             type="text"
             placeholder="Search activities..."
-            value={filters.search || ''}
+            value={searchInputValue}
             onChange={handleSearchChange}
-            disabled={disabled}
-            className="pl-8 h-7 text-xs"
+            className="pl-8 h-7 text-xs pr-6"
           />
+          {searchInputValue && (
+            <button
+              onClick={handleSearchClear}
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="Clear search"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
         </div>
 
         {/* Active Filter Chips */}

--- a/ui/src/components/ActivityFeedItem.tsx
+++ b/ui/src/components/ActivityFeedItem.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { format, formatDistanceToNow } from 'date-fns';
+import { formatDistanceToNow } from 'date-fns';
 import type { Activity, ResourceLinkResolver, TenantLinkResolver, TenantRenderer } from '../types/activity';
 import { ActivityFeedSummary, ResourceLinkClickHandler } from './ActivityFeedSummary';
 import { ActivityExpandedDetails } from './ActivityExpandedDetails';
@@ -7,6 +7,7 @@ import { TenantBadge } from './TenantBadge';
 import { cn } from '../lib/utils';
 import { Button } from './ui/button';
 import { Card } from './ui/card';
+import { Plus, Pencil, Trash2, Activity as ActivityIcon } from 'lucide-react';
 
 export interface ActivityFeedItemProps {
   /** The activity to render */
@@ -33,9 +34,7 @@ export interface ActivityFeedItemProps {
   isNew?: boolean;
   /** Layout variant: 'feed' (default) or 'timeline' */
   variant?: 'feed' | 'timeline';
-  /** Whether this is the first item in the list (hides timeline head, only used in timeline variant) */
-  isFirst?: boolean;
-  /** Whether this is the last item in the list (hides timeline tail, only used in timeline variant) */
+  /** Whether this is the last item in the list (hides bottom border, only used in timeline variant) */
   isLast?: boolean;
   /** Whether the item starts expanded */
   defaultExpanded?: boolean;
@@ -55,12 +54,13 @@ function formatTimestamp(timestamp?: string): string {
 }
 
 /**
- * Format timestamp for tooltip (with timezone)
+ * Format timestamp for tooltip (in UTC)
  */
 function formatTimestampFull(timestamp?: string): string {
   if (!timestamp) return 'Unknown time';
   try {
-    return format(new Date(timestamp), 'yyyy-MM-dd HH:mm:ss \'UTC\'');
+    const date = new Date(timestamp);
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')} ${String(date.getUTCHours()).padStart(2, '0')}:${String(date.getUTCMinutes()).padStart(2, '0')}:${String(date.getUTCSeconds()).padStart(2, '0')} UTC`;
   } catch {
     return timestamp;
   }
@@ -119,19 +119,36 @@ function normalizeVerb(verb: string): 'create' | 'update' | 'delete' | 'other' {
 }
 
 /**
- * Get timeline node classes based on verb
+ * Get icon container + icon color classes based on verb
  */
-function getTimelineNodeClasses(verb: string): string {
+function getActionIconClasses(verb: string): { container: string; icon: string } {
   const normalizedVerb = normalizeVerb(verb);
   switch (normalizedVerb) {
     case 'create':
-      return 'bg-green-500';
+      return { container: 'bg-blue-50 dark:bg-blue-950', icon: 'text-blue-500 dark:text-blue-400' };
     case 'update':
-      return 'bg-amber-500';
+      return { container: 'bg-green-50 dark:bg-green-950', icon: 'text-green-600 dark:text-green-400' };
     case 'delete':
-      return 'bg-red-500';
+      return { container: 'bg-red-50 dark:bg-red-950', icon: 'text-red-500 dark:text-red-400' };
     default:
-      return 'bg-muted-foreground';
+      return { container: 'bg-slate-100 dark:bg-slate-800', icon: 'text-slate-500 dark:text-slate-400' };
+  }
+}
+
+/**
+ * Get the Lucide icon component for the timeline node based on verb
+ */
+function getTimelineIcon(verb: string): React.ElementType {
+  const normalizedVerb = normalizeVerb(verb);
+  switch (normalizedVerb) {
+    case 'create':
+      return Plus;
+    case 'update':
+      return Pencil;
+    case 'delete':
+      return Trash2;
+    default:
+      return ActivityIcon;
   }
 }
 
@@ -151,7 +168,6 @@ export function ActivityFeedItem({
   compact = false,
   isNew = false,
   variant = 'feed',
-  isFirst = false,
   isLast = false,
   defaultExpanded = false,
 }: ActivityFeedItemProps) {
@@ -180,104 +196,71 @@ export function ActivityFeedItem({
   const verb = extractVerb(summary);
   const isTimeline = variant === 'timeline';
 
-  // Timeline variant wrapper
+  // Timeline variant — flat list row with bottom border
   if (isTimeline) {
+    const { container: iconBg, icon: iconColor } = getActionIconClasses(verb);
+    const Icon = getTimelineIcon(verb);
     return (
-      <div
-        className={cn(
-          'relative cursor-pointer group flex',
-          compact ? 'pl-7' : 'pl-9',
-          className
-        )}
-        onClick={handleClick}
-      >
-        {/* Timeline column - contains line and dot */}
+      <div className={cn(!isLast && !isExpanded && 'border-b border-border', className)}>
         <div
           className={cn(
-            'absolute left-0 top-0 bottom-0 flex flex-col items-center',
-            compact ? 'w-7' : 'w-9'
+            'flex items-center gap-3 py-3 pl-4 cursor-pointer group',
+            isSelected && 'bg-muted/40',
           )}
+          onClick={toggleExpand}
         >
-          {/* Top line segment (connects to previous item) */}
+          {/* Action icon square */}
           <div
             className={cn(
-              'w-0.5 flex-1',
-              isFirst ? 'bg-transparent' : 'bg-border'
+              'w-8 h-8 rounded-md shrink-0 flex items-center justify-center',
+              iconBg, iconColor
             )}
-            style={{ minHeight: compact ? 12 : 16 }}
-          />
-
-          {/* Timeline node (dot) - centered */}
-          <div
-            className={cn(
-              'rounded-full shrink-0 z-10',
-              compact ? 'w-2.5 h-2.5' : 'w-3 h-3',
-              getTimelineNodeClasses(verb)
-            )}
-          />
-
-          {/* Bottom line segment (connects to next item) */}
-          <div
-            className={cn(
-              'w-0.5 flex-1',
-              isLast ? 'bg-transparent' : 'bg-border'
-            )}
-          />
-        </div>
-
-        {/* Event content card */}
-        <div
-          className={cn(
-            'flex-1 border border-border rounded-lg transition-all duration-200 bg-card',
-            'shadow-sm hover:shadow-md hover:-translate-y-0.5',
-            'hover:border-primary/30 dark:hover:border-primary/40',
-            compact ? 'p-2 mb-2' : 'p-2.5 mb-2',
-            isSelected && 'border-primary bg-primary/5 ring-1 ring-primary/20 dark:bg-primary/10'
-          )}
-        >
-          {/* Single row layout */}
-          <div className="flex items-center gap-2">
-            {/* Summary - takes remaining space */}
-            <div className="flex-1 min-w-0 text-xs leading-snug">
-              <ActivityFeedSummary
-                summary={summary}
-                links={links}
-                onResourceClick={onResourceClick}
-                resourceLinkResolver={resourceLinkResolver}
-                resourceLinkContext={{ tenant }}
-              />
-            </div>
-
-            {/* Tenant badge */}
-            {tenant && (
-              <div className="shrink-0">
-                {tenantRenderer ? tenantRenderer(tenant) : <TenantBadge tenant={tenant} tenantLinkResolver={tenantLinkResolver} size="compact" />}
-              </div>
-            )}
-
-            {/* Timestamp */}
-            <span
-              className="text-xs text-muted-foreground whitespace-nowrap shrink-0"
-              title={formatTimestampFull(timestamp)}
-            >
-              {formatTimestamp(timestamp)}
-            </span>
-
-            {/* Expand button */}
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-5 py-0 px-1 text-base text-muted-foreground hover:text-foreground shrink-0"
-              onClick={toggleExpand}
-              aria-expanded={isExpanded}
-            >
-              {isExpanded ? '−' : '+'}
-            </Button>
+          >
+            <Icon size={16} strokeWidth={2} />
           </div>
 
-          {/* Expanded Details */}
-          {isExpanded && <ActivityExpandedDetails activity={activity} tenantLinkResolver={tenantLinkResolver} />}
+          {/* Summary */}
+          <div className="flex-1 min-w-0 text-sm text-foreground leading-snug">
+            <ActivityFeedSummary
+              summary={summary}
+              links={links}
+              onResourceClick={onResourceClick}
+              resourceLinkResolver={resourceLinkResolver}
+              resourceLinkContext={{ tenant }}
+            />
+          </div>
+
+          {/* Tenant badge */}
+          {tenant && (
+            <div className="shrink-0">
+              {tenantRenderer ? tenantRenderer(tenant) : <TenantBadge tenant={tenant} tenantLinkResolver={tenantLinkResolver} size="compact" />}
+            </div>
+          )}
+
+          {/* Timestamp */}
+          <span
+            className="text-xs text-muted-foreground whitespace-nowrap shrink-0"
+            title={formatTimestampFull(timestamp)}
+          >
+            {formatTimestamp(timestamp)}
+          </span>
+
+          {/* Expand toggle */}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-5 py-0 px-1 text-base text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+            onClick={toggleExpand}
+            aria-expanded={isExpanded}
+          >
+            {isExpanded ? '−' : '+'}
+          </Button>
         </div>
+
+        {/* Expanded Details */}
+        {isExpanded && (
+          <ActivityExpandedDetails activity={activity} tenantLinkResolver={tenantLinkResolver} compact />
+        )}
       </div>
     );
   }

--- a/ui/src/components/ResourceHistoryView.tsx
+++ b/ui/src/components/ResourceHistoryView.tsx
@@ -259,7 +259,6 @@ export function ResourceHistoryView({
                   activity={activity}
                   variant="timeline"
                   compact={compact}
-                  isFirst={index === 0}
                   isLast={index === activities.length - 1 && !hasMore}
                   onActivityClick={onActivityClick}
                   onResourceClick={onResourceClick}

--- a/ui/src/components/ui/filter-chip.tsx
+++ b/ui/src/components/ui/filter-chip.tsx
@@ -209,9 +209,8 @@ export function FilterChip({
             type="button"
             disabled={disabled}
             className={cn(
-              'flex h-7 items-center gap-2 rounded-l-md border border-r-0 border-border bg-secondary px-2 text-xs',
-              'hover:bg-secondary/80 transition-colors',
-              'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+              'flex h-7 items-center gap-2 rounded-l-md border border-r-0 border-border bg-card px-2 text-xs outline-none',
+              'hover:bg-accent/40 data-[state=open]:bg-accent/40 transition-colors',
               'disabled:cursor-not-allowed disabled:opacity-50'
             )}
           >
@@ -278,12 +277,16 @@ export function FilterChip({
                         'hover:bg-accent hover:text-accent-foreground'
                       )}
                     >
-                      <input
-                        type="checkbox"
-                        checked={values.includes(option.value)}
-                        onChange={() => {}}
-                        className="mr-2 h-4 w-4"
-                      />
+                      <div className={cn(
+                        'mr-2 h-4 w-4 shrink-0 rounded-sm border border-border',
+                        values.includes(option.value) && 'bg-primary border-primary'
+                      )}>
+                        {values.includes(option.value) && (
+                          <svg viewBox="0 0 12 12" fill="none" className="h-full w-full p-0.5 text-primary-foreground">
+                            <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                          </svg>
+                        )}
+                      </div>
                       <span className="flex-1 truncate">{option.label}</span>
                       {option.count !== undefined && (
                         <span className="ml-2 text-xs text-muted-foreground">
@@ -315,9 +318,8 @@ export function FilterChip({
         onClick={handleClearAll}
         disabled={disabled}
         className={cn(
-          'flex h-7 items-center rounded-r-md border border-border bg-secondary px-2',
-          'hover:bg-secondary/80 transition-colors',
-          'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+          'flex h-7 items-center rounded-r-md border border-border bg-card px-2 outline-none',
+          'hover:bg-accent/40 transition-colors',
           'disabled:cursor-not-allowed disabled:opacity-50'
         )}
         aria-label={`Clear ${label} filter`}


### PR DESCRIPTION

<img width="1346" height="700" alt="image" src="https://github.com/user-attachments/assets/c214dd8a-b3a4-4abc-9b87-a9618e238e92" />

<img width="1346" height="700" alt="image" src="https://github.com/user-attachments/assets/6e63116d-aa27-4d4c-a77c-3023f3bc9ea2" />

## Summary

- **New `timeline` variant** for `ActivityFeedItem`: flat bordered rows with colored 32×32 action icon squares (blue=create, green=update, red=delete) with dark mode support. Replaces previous card-on-timeline-track layout.
- **Expanded details in timeline**: clicking a row reveals `ActivityExpandedDetails` inline with a muted background. New `compact` prop on `ActivityExpandedDetails` removes the redundant top border/margin when embedded this way.
- **UTC timestamp fix**: `formatTimestampFull` was formatting in local browser time but labeling it "UTC". Fixed in both `ActivityFeedItem` and `ActivityExpandedDetails` using `getUTC*` methods.
- **Debounced search**: `ActivityFeedFilters` now debounces search input (400ms) with local state + refs to avoid stale closures. Includes a clear (✕) button and proper unmount cleanup.
- **Filter-chip blue tint fix**: `bg-secondary` replaced with `bg-card`/`hover:bg-accent` — the alpha theme's `--secondary` has hue 240 which caused chips to appear blue when active.
- **Removed `actions` filter** from the "Add filter" menu until backend facet support is available.
- **Compact `ActivityFeed`** removes card padding and border for cleaner embedding in detail tabs.

## Test plan

- [ ] Verify `variant="timeline"` renders flat rows with colored icon squares
- [ ] Verify clicking a timeline row expands/collapses details inline
- [ ] Verify icon colors correct in both light and dark mode
- [ ] Verify tooltip timestamps show correct UTC time for non-UTC browser timezone
- [ ] Verify search input debounces (no lockup while typing)
- [ ] Verify search clear button appears when text is present and clears on click
- [ ] Verify filter chips no longer appear blue when added/open
- [ ] Verify `actions` no longer appears in the Add Filter dropdown
- [ ] Verify existing `feed` variant is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)