### PR TITLE
Fix inhibit rule silencing all warning alerts

### DIFF
--- a/config/components/observability/alerts/alertmanager-config.yaml
+++ b/config/components/observability/alerts/alertmanager-config.yaml
@@ -7,13 +7,22 @@ metadata:
     app.kubernetes.io/part-of: activity
 spec:
   inhibitRules:
-    # Severity-based: critical suppresses related warnings for same component
+    # Severity-based: critical suppresses related warnings for same component.
+    # Both source and target must have a component label to match, scoping
+    # this rule to activity alerts and preventing it from suppressing
+    # unrelated warnings across the cluster.
     - sourceMatch:
         - name: severity
           value: critical
+        - name: component
+          matchType: "=~"
+          value: ".+"
       targetMatch:
         - name: severity
           value: warning
+        - name: component
+          matchType: "=~"
+          value: ".+"
       equal:
         - component
 


### PR DESCRIPTION
## Summary

A severity-based inhibit rule intended for activity system alerts was accidentally suppressing all warning alerts across the entire cluster. Any critical alert (like `PolicyBindingsNotReady` or `CertManagerCertNotReady`) was silencing every warning alert — including unrelated ones like `KubePodCrashLooping` and `KubeJobFailed`.

The fix scopes the rule so it only applies to alerts that have a `component` label, which limits it to activity system alerts as originally intended.

## Test plan

- [ ] Verify warning alerts start appearing in Slack again
- [ ] Verify activity-specific severity inhibition still works for alerts with matching `component` labels

Relates to datum-cloud/infra#277