### PR TITLE
chore: sync ui package.json version to latest published tag

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datum-cloud/activity-ui",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "packageManager": "pnpm@10.33.0",
   "description": "React components for Kubernetes Activity",
   "main": "dist/index.js",


### PR DESCRIPTION
`package.json` was at `0.3.0` but the latest published npm release is `v0.3.3`. The old release flow tagged `v0.3.1`–`v0.3.3` without updating `package.json`, leaving it out of sync.

The new `bump-npm-version` workflow derives the next version from `package.json`, so without this fix it would try to bump to `v0.3.1` — a tag that already exists.

This brings `package.json` in line with the latest tag so the next `workflow_dispatch` bump produces a correct new version.