### PR TITLE
chore: bump ui package version to 0.4.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datum-cloud/activity-ui",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "packageManager": "pnpm@10.33.0",
   "description": "React components for Kubernetes Activity",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps `@datum-cloud/activity-ui` version from `0.3.3` to `0.4.0`
- Fixes npm publish failure where the release workflow tried to publish over the already-existing `0.3.3` version

## Test plan

- [ ] Merge and trigger the "Publish UI to NPM" workflow — confirm it publishes `0.4.0` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)