### PR TITLE
feat: add DiscoveryContextPolicy for activity service resources

### DIFF
--- a/config/milo/discovery/discovery-context-policy.yaml
+++ b/config/milo/discovery/discovery-context-policy.yaml
@@ -1,0 +1,30 @@
+apiVersion: discovery.miloapis.com/v1alpha1
+kind: DiscoveryContextPolicy
+metadata:
+  name: activity-service
+spec:
+  rules:
+    # Activity data resources are visible wherever the tenant model supports:
+    # organizations, projects, and individual users.
+    - group: activity.miloapis.com
+      resources:
+        - activities
+        - activityfacetqueries
+        - activityqueries
+        - auditlogfacetsqueries
+        - auditlogqueries
+        - eventfacetqueries
+        - eventqueries
+        - policypreviews
+      contexts:
+        - Organization
+        - Project
+        - User
+    # Administrative resources have no parent resource scoping and are
+    # only relevant to platform operators.
+    - group: activity.miloapis.com
+      resources:
+        - activitypolicies
+        - reindexjobs
+      contexts:
+        - Platform

--- a/config/milo/discovery/kustomization.yaml
+++ b/config/milo/discovery/kustomization.yaml
@@ -1,5 +1,5 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
 
 resources:
   - discovery-context-policy.yaml

--- a/config/milo/discovery/kustomization.yaml
+++ b/config/milo/discovery/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - discovery-context-policy.yaml

--- a/config/milo/kustomization.yaml
+++ b/config/milo/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Component
 
 components:
   - iam/
+  - discovery/


### PR DESCRIPTION
## Summary

- Adds a `DiscoveryContextPolicy` for the `activity.miloapis.com` API group under `config/milo/discovery/`
- Wires the new `discovery/` component into `config/milo/kustomization.yaml`

### Context assignments

| Resources | Contexts |
|---|---|
| `activities`, `activityqueries`, `activityfacetqueries`, `auditlogqueries`, `auditlogfacetsqueries`, `eventqueries`, `eventfacetqueries`, `policypreviews` | `Organization`, `Project`, `User` |
| `activitypolicies`, `reindexjobs` | `Platform` |

Context assignments mirror the `parentResources` defined in the IAM `ProtectedResource` manifests under `config/milo/iam/resources/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)