### PR TITLE
Update references for the move to milo-os

### DIFF
--- a/.github/workflows/build-apiserver.yaml
+++ b/.github/workflows/build-apiserver.yaml
@@ -22,6 +22,7 @@ jobs:
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.12.1
     with:
       image-name: activity
+      registry-organization: milo-os
     secrets: inherit
 
   publish-ui-container-image:
@@ -38,6 +39,7 @@ jobs:
       image-name: activity-ui
       context: ui
       dockerfile-path: ui/Dockerfile
+      registry-organization: milo-os
     secrets: inherit
 
   publish-kustomize-bundles:
@@ -53,10 +55,10 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.12.1
     with:
-      bundle-name: ghcr.io/datum-cloud/activity-kustomize
+      bundle-name: ghcr.io/milo-os/activity-kustomize
       bundle-path: config
       image-overlays: config/base
-      image-name: ghcr.io/datum-cloud/activity
+      image-name: ghcr.io/milo-os/activity
     secrets: inherit
 
   publish-ui-kustomize-bundle:
@@ -70,8 +72,8 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.12.1
     with:
-      bundle-name: ghcr.io/datum-cloud/activity-ui-kustomize
+      bundle-name: ghcr.io/milo-os/activity-ui-kustomize
       bundle-path: config/components/ui
       image-overlays: config/components/ui
-      image-name: ghcr.io/datum-cloud/activity-ui
+      image-name: ghcr.io/milo-os/activity-ui
     secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ All development tasks use [Task](https://taskfile.dev). Run `task --list` to see
 
 ```bash
 task build                    # Build the activity binary to bin/activity
-task dev:build                # Build container image (ghcr.io/datum-cloud/activity:dev)
+task dev:build                # Build container image (ghcr.io/milo-os/activity:dev)
 ```
 
 ### Testing

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -3,8 +3,8 @@ version: '3'
 vars:
   TOOL_DIR: "{{.USER_WORKING_DIR}}/bin"
   # Container image configuration
-  ACTIVITY_IMAGE_NAME: "ghcr.io/datum-cloud/activity"
-  ACTIVITY_UI_IMAGE_NAME: "ghcr.io/datum-cloud/activity-ui"
+  ACTIVITY_IMAGE_NAME: "ghcr.io/milo-os/activity"
+  ACTIVITY_UI_IMAGE_NAME: "ghcr.io/milo-os/activity-ui"
   ACTIVITY_IMAGE_TAG: "dev"
   TEST_INFRA_CLUSTER_NAME: "test-infra"
   # Test infra repository configuration - can be overridden with environment variable

--- a/cmd/activity/controller_manager.go
+++ b/cmd/activity/controller_manager.go
@@ -66,7 +66,7 @@ func NewControllerManagerOptions() *ControllerManagerOptions {
 		ReindexMemoryLimit:       "2Gi",
 		ReindexCPULimit:          "1000m",
 		MaxConcurrentReindexJobs: 1,
-		ActivityImage:            "ghcr.io/datum-cloud/activity:latest",
+		ActivityImage:            "ghcr.io/milo-os/activity:latest",
 	}
 }
 

--- a/config/base/controller-manager.yaml
+++ b/config/base/controller-manager.yaml
@@ -45,7 +45,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: manager
-        image: ghcr.io/datum-cloud/activity:latest
+        image: ghcr.io/milo-os/activity:latest
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: apiserver
-        image: ghcr.io/datum-cloud/activity:latest
+        image: ghcr.io/milo-os/activity:latest
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -29,7 +29,7 @@ labels:
 
 # Images (will be replaced by overlays for different environments)
 images:
-  - name: ghcr.io/datum-cloud/activity
+  - name: ghcr.io/milo-os/activity
     newTag: latest
 
 # Sync ACTIVITY_IMAGE env var with the container image after image transformation.

--- a/config/base/processor.yaml
+++ b/config/base/processor.yaml
@@ -57,7 +57,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: processor
-        image: ghcr.io/datum-cloud/activity:latest
+        image: ghcr.io/milo-os/activity:latest
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/components/k8s-event-exporter/deployment.yaml
+++ b/config/components/k8s-event-exporter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: event-exporter
           # Uses the same activity image with the event-exporter subcommand
-          image: ghcr.io/datum-cloud/activity:dev
+          image: ghcr.io/milo-os/activity:dev
           imagePullPolicy: IfNotPresent
           args:
             - event-exporter

--- a/config/components/observability/alerts/dlq-alerts.yaml
+++ b/config/components/observability/alerts/dlq-alerts.yaml
@@ -30,7 +30,7 @@ spec:
             summary: "DLQ is growing - messages not being processed"
             description: "DLQ is receiving {{ $value }} events/sec for 15+ minutes. Events are failing processing faster than retry can handle."
             impact: "Failed events accumulating - may indicate systematic policy issue or processor problem"
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/dlq/dlq-growth.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/dlq/dlq-growth.md"
 
         # DLQ Publish Errors
         - alert: DLQPublishErrors
@@ -44,7 +44,7 @@ spec:
             summary: "Failed to publish events to DLQ"
             description: "{{ $value }} DLQ publish errors/sec. Events may be lost entirely."
             impact: "Failed events not being captured - complete data loss for affected events"
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/dlq/dlq-publish-errors.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/dlq/dlq-publish-errors.md"
 
         # High Retry Count Events
         - alert: DLQHighRetryCount
@@ -59,7 +59,7 @@ spec:
             summary: "DLQ events with excessive retry attempts"
             description: "{{ $value }} events have exceeded the high retry threshold for {{ $labels.api_group }}/{{ $labels.kind }}."
             impact: "Events failing persistently - policy or cluster issue preventing recovery"
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/dlq/dlq-high-retry-count.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/dlq/dlq-high-retry-count.md"
 
         # DLQ slow-leak - low-rate but persistent failures
         - alert: DLQSlowLeak
@@ -74,7 +74,7 @@ spec:
             summary: "DLQ receiving events at a slow but steady rate"
             description: "{{ $value }} events sent to DLQ in the last 6 hours. A policy may be failing for specific event shapes."
             impact: "Some activities silently not being generated"
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/dlq/dlq-growth.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/dlq/dlq-growth.md"
 
     # =========================================================================
     # DLQ Retry Effectiveness
@@ -99,7 +99,7 @@ spec:
             summary: "DLQ retry success rate is low"
             description: "{{ $value | humanizePercentage }} of retry attempts are failing. Events not recovering after retry."
             impact: "Automatic retry not effective - manual intervention may be required"
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/dlq/dlq-retry-failing.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/dlq/dlq-retry-failing.md"
 
     # =========================================================================
     # Per-Policy DLQ Alerts - Policy Owner Responsibility
@@ -121,4 +121,4 @@ spec:
             summary: "ActivityPolicy {{ $labels.policy_name }} sending events to DLQ"
             description: "Policy {{ $labels.policy_name }} for {{ $labels.api_group }}/{{ $labels.kind }} has {{ $value }} events/sec failing with {{ $labels.error_type }}."
             impact: "Activities not being generated for this resource type - users see incomplete timeline"
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/dlq/policy-dlq-errors.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/dlq/policy-dlq-errors.md"

--- a/config/components/observability/alerts/slo-alerts.yaml
+++ b/config/components/observability/alerts/slo-alerts.yaml
@@ -50,7 +50,7 @@ spec:
               Error ratio is {{ $value | humanizePercentage }} over the last hour
               (threshold: 14.4%). At this rate the 99% latency SLO error budget
               will be exhausted within hours. Investigate activitypolicies GET/LIST/APPLY latency.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         - alert: ActivitySLOMetadataTicketBurn
           expr: |
@@ -69,7 +69,7 @@ spec:
               Error ratio is {{ $value | humanizePercentage }} over the last 6 hours
               (threshold: 6%). The 99% latency SLO error budget is draining at an
               elevated rate. Review activitypolicies request latency trends.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         - alert: ActivitySLOMetadataLowBurn
           expr: |
@@ -88,7 +88,7 @@ spec:
               Error ratio is {{ $value | humanizePercentage }} over the last 3 days
               (threshold: 3%). The SLO error budget is slowly eroding.
               No immediate action required but worth investigating.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         # =====================================================================
         # SLO: Audit Queries (auditlogqueries POST, latency < 3s)
@@ -111,7 +111,7 @@ spec:
               Error ratio is {{ $value | humanizePercentage }} over the last hour
               (threshold: 14.4%). AuditLogQuery POST latency is breaching the 3s
               target at a rate that will exhaust the error budget within hours.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         - alert: ActivitySLOAuditQueryTicketBurn
           expr: |
@@ -130,7 +130,7 @@ spec:
               Error ratio is {{ $value | humanizePercentage }} over the last 6 hours
               (threshold: 6%). AuditLogQuery latency SLO error budget draining at
               elevated rate.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         - alert: ActivitySLOAuditQueryLowBurn
           expr: |
@@ -148,7 +148,7 @@ spec:
             description: >-
               Error ratio is {{ $value | humanizePercentage }} over the last 3 days
               (threshold: 3%). Audit query latency SLO slowly eroding.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         # =====================================================================
         # SLO: Activity Queries (activityqueries + activityfacetqueries POST,
@@ -173,7 +173,7 @@ spec:
               (threshold: 14.4%). ActivityQuery/ActivityFacetQuery POST latency is
               breaching the 3s target at a rate that will exhaust the error budget
               within hours.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         - alert: ActivitySLOActivityQueryTicketBurn
           expr: |
@@ -192,7 +192,7 @@ spec:
               Error ratio is {{ $value | humanizePercentage }} over the last 6 hours
               (threshold: 6%). Activity query latency SLO error budget draining at
               elevated rate.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         - alert: ActivitySLOActivityQueryLowBurn
           expr: |
@@ -210,7 +210,7 @@ spec:
             description: >-
               Error ratio is {{ $value | humanizePercentage }} over the last 3 days
               (threshold: 3%). Activity query latency SLO slowly eroding.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         # =====================================================================
         # SLO: Event Queries (eventqueries + eventfacetqueries POST, latency < 3s)
@@ -234,7 +234,7 @@ spec:
               (threshold: 14.4%). EventQuery/EventFacetQuery POST latency is
               breaching the 3s target at a rate that will exhaust the error budget
               within hours.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         - alert: ActivitySLOEventQueryTicketBurn
           expr: |
@@ -253,7 +253,7 @@ spec:
               Error ratio is {{ $value | humanizePercentage }} over the last 6 hours
               (threshold: 6%). Event query latency SLO error budget draining at
               elevated rate.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         - alert: ActivitySLOEventQueryLowBurn
           expr: |
@@ -271,7 +271,7 @@ spec:
             description: >-
               Error ratio is {{ $value | humanizePercentage }} over the last 3 days
               (threshold: 3%). Event query latency SLO slowly eroding.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         # =====================================================================
         # SLO: Availability (all verb!="WATCH", non-5xx responses)
@@ -294,7 +294,7 @@ spec:
               5xx error ratio is {{ $value | humanizePercentage }} over the last hour
               (threshold: 14.4%). The 99% availability SLO error budget will be
               exhausted within hours. Investigate apiserver error logs immediately.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         - alert: ActivitySLOAvailabilityTicketBurn
           expr: |
@@ -312,7 +312,7 @@ spec:
             description: >-
               5xx error ratio is {{ $value | humanizePercentage }} over the last 6 hours
               (threshold: 6%). Availability SLO error budget draining at elevated rate.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"
 
         - alert: ActivitySLOAvailabilityLowBurn
           expr: |
@@ -330,4 +330,4 @@ spec:
             description: >-
               5xx error ratio is {{ $value | humanizePercentage }} over the last 3 days
               (threshold: 3%). Availability SLO slowly eroding.
-            runbook_url: "https://github.com/datum-cloud/activity/blob/main/docs/runbooks/slo-burn.md"
+            runbook_url: "https://github.com/milo-os/activity/blob/main/docs/runbooks/slo-burn.md"

--- a/config/components/observability/alerts/vector-alerts.yaml
+++ b/config/components/observability/alerts/vector-alerts.yaml
@@ -29,7 +29,7 @@ spec:
             summary: "All Vector NATS sources stopped - likely lame duck reconnection failure"
             description: "No NATS sources are receiving events. This typically indicates Vector's NATS connection did not recover after server entered lame duck mode."
             runbook: "Restart vector-aggregator pods: kubectl rollout restart statefulset/vector-aggregator -n activity-system"
-            issue_link: "https://github.com/datum-cloud/activity/issues/82"
+            issue_link: "https://github.com/milo-os/activity/issues/82"
 
         # NATS Source Stalled with audit event backlog confirmation
         - alert: VectorNATSAuditStalledWithBacklog

--- a/config/components/ui/deployment.yaml
+++ b/config/components/ui/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ui
-          image: ghcr.io/datum-cloud/activity-ui:latest
+          image: ghcr.io/milo-os/activity-ui:latest
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/config/overlays/dev/kustomization.yaml
+++ b/config/overlays/dev/kustomization.yaml
@@ -32,11 +32,11 @@ components:
 
 # Image overrides for dev environment
 images:
-  - name: ghcr.io/datum-cloud/activity
-    newName: ghcr.io/datum-cloud/activity
+  - name: ghcr.io/milo-os/activity
+    newName: ghcr.io/milo-os/activity
     newTag: dev
-  - name: ghcr.io/datum-cloud/activity-ui
-    newName: ghcr.io/datum-cloud/activity-ui
+  - name: ghcr.io/milo-os/activity-ui
+    newName: ghcr.io/milo-os/activity-ui
     newTag: dev
 
 # Sync ACTIVITY_IMAGE env var with the overlay's image tag.

--- a/config/overlays/test-infra/kustomization.yaml
+++ b/config/overlays/test-infra/kustomization.yaml
@@ -26,8 +26,8 @@ components:
 
 # Image overrides for test-infra environment
 images:
-  - name: ghcr.io/datum-cloud/activity
-    newName: ghcr.io/datum-cloud/activity
+  - name: ghcr.io/milo-os/activity
+    newName: ghcr.io/milo-os/activity
     newTag: dev
 
 # Sync ACTIVITY_IMAGE env var with the overlay's image tag.

--- a/internal/controller/jobtemplate_test.go
+++ b/internal/controller/jobtemplate_test.go
@@ -139,7 +139,7 @@ func TestMergeJobTemplate(t *testing.T) {
 		opts := JobBuildOptions{
 			ReindexJobName: "test-reindex",
 			JobNamespace:   "activity-system",
-			ActivityImage:  "ghcr.io/datum-cloud/activity:test",
+			ActivityImage:  "ghcr.io/milo-os/activity:test",
 			ControllerArgs: []string{"reindex-worker", "test-reindex", "--nats-url=nats://localhost:4222"},
 		}
 
@@ -159,7 +159,7 @@ func TestMergeJobTemplate(t *testing.T) {
 		require.Len(t, job.Spec.Template.Spec.Containers, 1)
 		container := job.Spec.Template.Spec.Containers[0]
 		assert.Equal(t, "reindex", container.Name)
-		assert.Equal(t, "ghcr.io/datum-cloud/activity:test", container.Image)
+		assert.Equal(t, "ghcr.io/milo-os/activity:test", container.Image)
 		assert.Equal(t, []string{"reindex-worker", "test-reindex", "--nats-url=nats://localhost:4222"}, container.Args)
 	})
 
@@ -178,7 +178,7 @@ func TestMergeJobTemplate(t *testing.T) {
 		opts := JobBuildOptions{
 			ReindexJobName: "test-reindex",
 			JobNamespace:   "activity-system",
-			ActivityImage:  "ghcr.io/datum-cloud/activity:test",
+			ActivityImage:  "ghcr.io/milo-os/activity:test",
 			ControllerArgs: []string{"reindex-worker", "test-reindex", "--nats-url=nats://localhost:4222"},
 		}
 
@@ -226,7 +226,7 @@ func TestMergeJobTemplate(t *testing.T) {
 		opts := JobBuildOptions{
 			ReindexJobName: "test-reindex",
 			JobNamespace:   "activity-system",
-			ActivityImage:  "ghcr.io/datum-cloud/activity:test",
+			ActivityImage:  "ghcr.io/milo-os/activity:test",
 			ControllerArgs: []string{"reindex-worker", "test-reindex"},
 		}
 
@@ -263,7 +263,7 @@ func TestMergeJobTemplate(t *testing.T) {
 		opts := JobBuildOptions{
 			ReindexJobName: "test-reindex",
 			JobNamespace:   "activity-system",
-			ActivityImage:  "ghcr.io/datum-cloud/activity:test",
+			ActivityImage:  "ghcr.io/milo-os/activity:test",
 			ControllerArgs: []string{"reindex-worker", "test-reindex"},
 			ResourceRequirements: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
@@ -298,7 +298,7 @@ func TestMergeJobTemplate(t *testing.T) {
 		opts := JobBuildOptions{
 			ReindexJobName:     "test-reindex",
 			JobNamespace:       "activity-system",
-			ActivityImage:      "ghcr.io/datum-cloud/activity:test",
+			ActivityImage:      "ghcr.io/milo-os/activity:test",
 			ControllerArgs:     []string{"reindex-worker", "test-reindex"},
 			ServiceAccountName: "controller-sa",
 		}
@@ -322,7 +322,7 @@ func TestMergeJobTemplate(t *testing.T) {
 		opts := JobBuildOptions{
 			ReindexJobName: "test-reindex",
 			JobNamespace:   "activity-system",
-			ActivityImage:  "ghcr.io/datum-cloud/activity:test",
+			ActivityImage:  "ghcr.io/milo-os/activity:test",
 			ControllerArgs: []string{"reindex-worker", "test-reindex"},
 			// No ServiceAccountName set
 		}
@@ -345,7 +345,7 @@ func TestMergeJobTemplate(t *testing.T) {
 		opts := JobBuildOptions{
 			ReindexJobName: "test-reindex",
 			JobNamespace:   "activity-system",
-			ActivityImage:  "ghcr.io/datum-cloud/activity:test",
+			ActivityImage:  "ghcr.io/milo-os/activity:test",
 			ControllerArgs: []string{"reindex-worker", "test-reindex"},
 		}
 
@@ -363,7 +363,7 @@ func TestMergeJobTemplate(t *testing.T) {
 			}
 		}
 		require.NotNil(t, reindexContainer)
-		assert.Equal(t, "ghcr.io/datum-cloud/activity:test", reindexContainer.Image)
+		assert.Equal(t, "ghcr.io/milo-os/activity:test", reindexContainer.Image)
 	})
 
 	t.Run("merges labels from template", func(t *testing.T) {
@@ -384,7 +384,7 @@ func TestMergeJobTemplate(t *testing.T) {
 		opts := JobBuildOptions{
 			ReindexJobName: "test-reindex",
 			JobNamespace:   "activity-system",
-			ActivityImage:  "ghcr.io/datum-cloud/activity:test",
+			ActivityImage:  "ghcr.io/milo-os/activity:test",
 			ControllerArgs: []string{"reindex-worker", "test-reindex"},
 		}
 

--- a/internal/controller/reindexjob_controller_test.go
+++ b/internal/controller/reindexjob_controller_test.go
@@ -27,7 +27,7 @@ func TestBuildJobForReindexJob(t *testing.T) {
 
 	reconciler := &ReindexJobReconciler{
 		JobNamespace:          "activity-system",
-		ActivityImage:         "ghcr.io/datum-cloud/activity:test",
+		ActivityImage:         "ghcr.io/milo-os/activity:test",
 		ReindexServiceAccount: "activity-reindex-worker",
 		ReindexMemoryLimit:    "2Gi",
 		ReindexCPULimit:       "1000m",
@@ -66,7 +66,7 @@ func TestBuildJobForReindexJob(t *testing.T) {
 	require.Len(t, job.Spec.Template.Spec.Containers, 1)
 	container := job.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "reindex", container.Name)
-	assert.Equal(t, "ghcr.io/datum-cloud/activity:test", container.Image)
+	assert.Equal(t, "ghcr.io/milo-os/activity:test", container.Image)
 
 	// Verify args
 	expectedArgs := []string{
@@ -113,7 +113,7 @@ func TestBuildJobForReindexJob_WithTLS(t *testing.T) {
 
 	reconciler := &ReindexJobReconciler{
 		JobNamespace:          "activity-system",
-		ActivityImage:         "ghcr.io/datum-cloud/activity:test",
+		ActivityImage:         "ghcr.io/milo-os/activity:test",
 		ReindexServiceAccount: "activity-reindex-worker",
 		ReindexMemoryLimit:    "2Gi",
 		ReindexCPULimit:       "1000m",

--- a/ui/README.md
+++ b/ui/README.md
@@ -330,5 +330,5 @@ Apache-2.0
 ## Support
 
 For issues and questions:
-- GitHub Issues: https://github.com/datum-cloud/activity/issues
+- GitHub Issues: https://github.com/milo-os/activity/issues
 - Documentation: See the main [Activity README](../README.md)

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,7 +38,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/datum-cloud/activity",
+    "url": "https://github.com/milo-os/activity",
     "directory": "ui"
   },
   "peerDependencies": {


### PR DESCRIPTION
This repo recently moved from [datum-cloud](https://github.com/datum-cloud) to [milo-os](https://github.com/milo-os). Updates internal links and image references to reflect the new home.