### PR TITLE
feat(ui): export ActivityFeedFilters + add extraFilters slot

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datum-cloud/activity-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "packageManager": "pnpm@10.33.0",
   "description": "React components for Kubernetes Activity",
   "main": "dist/index.js",

--- a/ui/src/components/ActivityFeedFilters.tsx
+++ b/ui/src/components/ActivityFeedFilters.tsx
@@ -37,6 +37,14 @@ export interface ActivityFeedFiltersProps {
   >;
   /** Additional CSS class */
   className?: string;
+  /**
+   * Optional node rendered inline in the filter row, immediately after the
+   * built-in filter controls (Search / Change Source / Add Filters) and before
+   * the time range dropdown. Use this to inject consumer-specific filter
+   * affordances (e.g. a multi-source selector) that need to live in the same
+   * row as the library's controls.
+   */
+  extraFilters?: React.ReactNode;
 }
 
 /**
@@ -140,6 +148,7 @@ export function ActivityFeedFilters({
   disabled = false,
   hiddenFilters = [],
   className = "",
+  extraFilters,
 }: ActivityFeedFiltersProps) {
   const {
     resourceKinds,
@@ -480,6 +489,9 @@ export function ActivityFeedFilters({
           hasActiveFilters={activeFilterIds.length > 0}
           disabled={disabled}
         />
+
+        {/* Consumer-injected filter controls, rendered inline before the time range */}
+        {extraFilters}
 
         {/* Spacer */}
         <div className="flex-1 min-w-[20px]" />

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -28,6 +28,7 @@ export { ActivityFeedItemSkeleton } from './components/ActivityFeedItemSkeleton'
 export type { ActivityFeedItemSkeletonProps } from './components/ActivityFeedItemSkeleton';
 export { ActivityFeedSummary } from './components/ActivityFeedSummary';
 export type { ActivityFeedSummaryProps, ResourceLinkClickHandler } from './components/ActivityFeedSummary';
+export { ActivityFeedFilters } from './components/ActivityFeedFilters';
 export type { ActivityFeedFiltersProps } from './components/ActivityFeedFilters';
 export { ChangeSourceToggle } from './components/ChangeSourceToggle';
 export type { ChangeSourceToggleProps, ChangeSourceOption } from './components/ChangeSourceToggle';
@@ -213,7 +214,6 @@ export { useActivityFeed } from './hooks/useActivityFeed';
 export type {
   UseActivityFeedOptions,
   UseActivityFeedResult,
-  ActivityFeedFilters,
   ActivityFeedFilters as ActivityFeedFilterState,
   TimeRange,
 } from './hooks/useActivityFeed';


### PR DESCRIPTION
## Summary

- Promotes `ActivityFeedFilters` from a type-only export to a value export so consumers can render the filter bar themselves when wrapping `ActivityFeed`.
- Adds an `extraFilters?: React.ReactNode` slot to `ActivityFeedFilters` that renders inline after the built-in filter controls (Search / Change Source / Add Filters) and before the time range dropdown, so consumers can inject custom filter affordances in the same row.
- Removes the duplicate `ActivityFeedFilters` type re-export from `useActivityFeed` (which collided with the component identifier). Consumers should use the already-aliased `ActivityFeedFilterState` instead.
- Bumps version to `0.5.1`.

## Motivation

Downstream consumer staff-portal is adding a Projects multi-select filter to the org Activity Feed that needs to live in the same filter row as the library's existing controls, immediately next to "Add Filters". The `extraFilters` slot keeps the library's filter row in charge of layout (spacer, time range alignment) while letting consumers add their own pills inline.

## Test plan

- [ ] CI passes (build, type-check, lint)
- [ ] `dist/index.d.ts` exposes `ActivityFeedFilters` as a function and `ActivityFeedFiltersProps` as a type
- [ ] `ActivityFeedFiltersProps.extraFilters?: React.ReactNode` is present in the generated types
- [ ] No `ActivityFeedFilters` type export remains in `dist/index.d.ts` (was already aliased to `ActivityFeedFilterState`)
- [ ] Consumer staff-portal builds against `0.5.1` once published, with Projects pill rendering inline after Add Filters