### PR TITLE
ci: grant id-token: write to publish-ui-npm caller jobs

### DIFF
--- a/.github/workflows/publish-ui-npm.yaml
+++ b/.github/workflows/publish-ui-npm.yaml
@@ -19,6 +19,9 @@ jobs:
   publish-dev:
     name: Publish dev build
     if: github.event_name == 'push'
+    permissions:
+      contents: read
+      id-token: write
     uses: datum-cloud/actions/.github/workflows/publish-npm-package.yaml@v1.14.0
     with:
       package-name: "@datum-cloud/activity-ui"
@@ -46,6 +49,9 @@ jobs:
   publish-release:
     name: Publish release
     needs: bump-version
+    permissions:
+      contents: read
+      id-token: write
     uses: datum-cloud/actions/.github/workflows/publish-npm-package.yaml@v1.14.0
     with:
       package-name: "@datum-cloud/activity-ui"


### PR DESCRIPTION
## Summary

The **Publish UI to NPM** workflow has been failing with `startup_failure` on every push to `main` (most recently run [26196587341](https://github.com/milo-os/activity/actions/runs/26196587341)). PR #203 bumped the `datum-cloud/actions` refs to `v1.14.0` but didn't address the underlying cause.

GitHub's validation error:

> The nested job `publish-dev` is requesting `id-token: write`, but is only allowed `id-token: none`.
> The nested job `publish-release` is requesting `id-token: write`, but is only allowed `id-token: none`.

The called reusable workflow (`publish-npm-package.yaml`) declares `id-token: write` for npm OIDC provenance. Reusable workflows can only receive permissions the caller already grants, so the caller jobs must declare `id-token: write` explicitly.

## Change

Grant `permissions: { contents: read, id-token: write }` on the two caller jobs that invoke `publish-npm-package.yaml`:
- `publish-dev`
- `publish-release`

`bump-version` and `create-release` are unchanged — they don't call that workflow and don't need the elevated token.

## Test plan

- [ ] On merge, the post-merge run of `Publish UI to NPM` reaches the `publish-dev` job (no longer rejected at startup) and publishes a `0.5.1-dev.*` pre-release to npm.
- [ ] Manual `workflow_dispatch` runs `bump-version` → `publish-release` → `create-release` end-to-end.