### PR TITLE
ci: bump datum-cloud/actions refs in publish-ui-npm to v1.15.0

### DIFF
--- a/.github/workflows/publish-ui-npm.yaml
+++ b/.github/workflows/publish-ui-npm.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: datum-cloud/actions/.github/workflows/publish-npm-package.yaml@v1.14.0
+    uses: datum-cloud/actions/.github/workflows/publish-npm-package.yaml@v1.15.0
     with:
       package-name: "@datum-cloud/activity-ui"
       package-path: ui
@@ -38,7 +38,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
-    uses: datum-cloud/actions/.github/workflows/bump-npm-version.yaml@v1.14.0
+    uses: datum-cloud/actions/.github/workflows/bump-npm-version.yaml@v1.15.0
     with:
       package-path: ui
       package-name: "@datum-cloud/activity-ui"
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: datum-cloud/actions/.github/workflows/publish-npm-package.yaml@v1.14.0
+    uses: datum-cloud/actions/.github/workflows/publish-npm-package.yaml@v1.15.0
     with:
       package-name: "@datum-cloud/activity-ui"
       package-path: ui


### PR DESCRIPTION
## Summary

Picks up [datum-cloud/actions#72](https://github.com/datum-cloud/actions/pull/72) (released as `v1.15.0`), which fixes `bump-npm-version` so the `package.json` bump commit actually lands on `main`.

Previously, `actions/checkout` left `HEAD` detached and `npm version` made the bump commit on the detached HEAD, leaving `main` unchanged. `publish-release` then republished the prior version. The workaround was to manually bump `ui/package.json` in a PR before triggering release.

After this lands, `workflow_dispatch` with `bump-type: patch|minor|major` will correctly:

1. Advance `ui/package.json` on `main` to the new version
2. Push the matching `vX.Y.Z` tag at the bump commit
3. Publish that new version to npm

Manual version bumps in PRs are no longer required.

## Test plan

- [ ] After merge, run `Publish UI to NPM` with `bump-type: patch`. Confirm:
  - `ui/package.json` on `main` advances from `0.5.1` to `0.5.2`
  - Tag `v0.5.2` points at the bump commit (not at the merge commit before it)
  - `@datum-cloud/activity-ui@0.5.2` is published to npm with `latest` dist-tag
  - GitHub Release `v0.5.2` is created