### PR TITLE
fix: correct DLQ runbook CEL null-check guidance

### DIFF
--- a/docs/runbooks/dlq/policy-dlq-errors.md
+++ b/docs/runbooks/dlq/policy-dlq-errors.md
@@ -92,12 +92,15 @@ kubectl edit activitypolicy <policy-name>
 # After:  has(audit.verb) && audit.verb == 'create'
 
 # 2. Add null checks for nested fields
+#    Guard the full leaf path, not just the root object: responseObject can be
+#    present while metadata.name is absent (DELETE, status subresource, error
+#    responses), which still raises "no such key: name".
 # Before: audit.responseObject.metadata.name
-# After:  has(audit.responseObject) ? audit.responseObject.metadata.name : audit.objectRef.name
+# After:  has(audit.responseObject.metadata.name) ? audit.responseObject.metadata.name : audit.objectRef.name
 
 # 3. Handle DELETE operations (no responseObject)
 # Before: {{ audit.responseObject.spec.type }}
-# After:  {{ has(audit.responseObject) ? audit.responseObject.spec.type : 'deleted' }}
+# After:  {{ has(audit.responseObject.spec.type) ? audit.responseObject.spec.type : 'deleted' }}
 ```
 
 Policy update triggers immediate retry of all failed events.


### PR DESCRIPTION
## What

Correct the `cel_summary` remediation in `docs/runbooks/dlq/policy-dlq-errors.md`.
The documented null check guarded only the root object
(`has(audit.responseObject)`), which does not prevent `no such key: name` when
`responseObject` is present but `metadata.name` is absent (DELETE, status
subresource, error/forbidden responses). Guard the full leaf path instead.

## Why

Surfaced by a prod `DLQSlowLeak` on `gateway.networking.k8s.io-gateway`
(~120 Gateway audit events/6h to the DLQ). The runbook's suggested fix would
not have resolved it. See #212 for the full investigation.

## Changes

- `has(audit.responseObject.metadata.name)` instead of `has(audit.responseObject)`
- Same leaf-path guard applied to the `spec.type` DELETE example

## Scope / does NOT fix prod

Docs only. The live leak is a standalone `ActivityPolicy` CR
(`gateway.networking.k8s.io-gateway`) that is **not** version-controlled in this
repo — see #212. Stopping the prod leak requires correcting that CR's rule 0
summary CEL; merging this PR does not do that on its own.

Refs #212
