### PR TITLE
feat(cel): reject unguarded responseObject/requestObject derefs (DLQ-leak guard)

### DIFF
--- a/internal/cel/policy.go
+++ b/internal/cel/policy.go
@@ -92,6 +92,11 @@ func validateMatchExpression(env *cel.Env, expression string) error {
 		return fmt.Errorf("match expression must return a boolean, got %v", ast.OutputType())
 	}
 
+	// Reject unguarded deep dereferences of audit.responseObject/requestObject.
+	if err := ValidateGuardedDerefs(ast); err != nil {
+		return fmt.Errorf("invalid match expression: %w", err)
+	}
+
 	return nil
 }
 
@@ -134,6 +139,11 @@ func validateSummaryExpression(env *cel.Env, expression string) error {
 		// The link() function returns a string, so check for string type
 		if !ast.OutputType().IsExactType(cel.StringType) && !ast.OutputType().IsExactType(cel.DynType) {
 			return fmt.Errorf("expression '{{ %s }}' in summary must return a string, got %v", embeddedExpr, ast.OutputType())
+		}
+
+		// Reject unguarded deep dereferences of audit.responseObject/requestObject.
+		if err := ValidateGuardedDerefs(ast); err != nil {
+			return fmt.Errorf("invalid summary expression '{{ %s }}': %w", embeddedExpr, err)
 		}
 	}
 

--- a/internal/cel/responseobject_guard.go
+++ b/internal/cel/responseobject_guard.go
@@ -1,0 +1,237 @@
+package cel
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+// guardedDerefRoots are the audit fields whose deep dereferences are unsafe at
+// runtime. These fields are absent (or replaced by a metav1.Status object) on
+// non-2xx responses, so dereferencing nested fields throws "no such key" and
+// sends the event to the dead-letter queue.
+var guardedDerefRoots = []string{
+	"audit.responseObject",
+	"audit.requestObject",
+}
+
+// ValidateGuardedDerefs inspects a compiled CEL AST and rejects expressions that
+// perform an UNGUARDED deep dereference of audit.responseObject or
+// audit.requestObject (e.g. audit.responseObject.metadata.name) without a
+// corresponding has() guard for that exact path.
+//
+// These roots are defaulted to empty maps at evaluation time, so reading the
+// root itself (audit.responseObject) or guarding only the root
+// (has(audit.responseObject)) is insufficient: any field beyond the root throws
+// "no such key" at runtime on non-2xx responses. Each indexed level must be
+// guarded with has().
+//
+// Validation only — it does not affect runtime defaulting or evaluation.
+func ValidateGuardedDerefs(ast *cel.Ast) error {
+	if ast == nil {
+		return nil
+	}
+
+	parsed, err := cel.AstToParsedExpr(ast)
+	if err != nil {
+		// If we cannot recover the AST we cannot statically analyze it; do not
+		// block the policy on an internal conversion failure.
+		return nil
+	}
+
+	root := parsed.GetExpr()
+	if root == nil {
+		return nil
+	}
+
+	// Pass 1: collect every has() guarded path.
+	guarded := make(map[string]bool)
+	collectGuardedPaths(root, guarded)
+
+	// Pass 2: collect unguarded deep dereferences rooted at the unsafe roots.
+	violations := make(map[string]bool)
+	collectViolations(root, guarded, violations)
+
+	if len(violations) == 0 {
+		return nil
+	}
+
+	// Keep only the deepest violating path per chain to reduce noise: drop any
+	// path that is a strict prefix of another violating path.
+	paths := make([]string, 0, len(violations))
+	for p := range violations {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	deepest := make([]string, 0, len(paths))
+	for _, p := range paths {
+		isPrefix := false
+		for _, other := range paths {
+			if other != p && strings.HasPrefix(other, p+".") {
+				isPrefix = true
+				break
+			}
+		}
+		if !isPrefix {
+			deepest = append(deepest, p)
+		}
+	}
+
+	errs := make([]error, 0, len(deepest))
+	for _, p := range deepest {
+		errs = append(errs, unguardedDerefError(p))
+	}
+	return errors.Join(errs...)
+}
+
+// unguardedDerefError builds the actionable error message for a single violation.
+func unguardedDerefError(path string) error {
+	// Build the guard suggestion for the example path: chain has() over every
+	// indexed level of the path beyond the root.
+	parent := path[:strings.LastIndex(path, ".")]
+	return fmt.Errorf(
+		"unguarded dereference of %q: responseObject/requestObject is absent or a "+
+			"metav1.Status on non-2xx responses, so this throws \"no such key\" at runtime "+
+			"and sends events to the DLQ. Guard each level with has() "+
+			"(e.g. has(%s) && has(%s) ? %s : \"\") or gate on audit.responseStatus.code < 300, "+
+			"or use a field present regardless of outcome such as audit.objectRef.name.",
+		path, parent, path, path,
+	)
+}
+
+// collectGuardedPaths walks the AST and records the dot-path of every has()
+// expression (a SelectExpr with TestOnly == true).
+func collectGuardedPaths(e *expr.Expr, guarded map[string]bool) {
+	if e == nil {
+		return
+	}
+
+	switch k := e.ExprKind.(type) {
+	case *expr.Expr_SelectExpr:
+		sel := k.SelectExpr
+		if sel.GetTestOnly() {
+			if p := selectPath(e); p != "" {
+				guarded[p] = true
+			}
+		}
+		// Continue walking the operand so nested has() inside larger
+		// expressions are still collected.
+		collectGuardedPaths(sel.GetOperand(), guarded)
+
+	case *expr.Expr_CallExpr:
+		call := k.CallExpr
+		collectGuardedPaths(call.GetTarget(), guarded)
+		for _, arg := range call.GetArgs() {
+			collectGuardedPaths(arg, guarded)
+		}
+
+	case *expr.Expr_ListExpr:
+		for _, elem := range k.ListExpr.GetElements() {
+			collectGuardedPaths(elem, guarded)
+		}
+
+	case *expr.Expr_StructExpr:
+		for _, entry := range k.StructExpr.GetEntries() {
+			collectGuardedPaths(entry.GetValue(), guarded)
+		}
+
+	case *expr.Expr_ComprehensionExpr:
+		comp := k.ComprehensionExpr
+		collectGuardedPaths(comp.GetIterRange(), guarded)
+		collectGuardedPaths(comp.GetAccuInit(), guarded)
+		collectGuardedPaths(comp.GetLoopCondition(), guarded)
+		collectGuardedPaths(comp.GetLoopStep(), guarded)
+		collectGuardedPaths(comp.GetResult(), guarded)
+	}
+}
+
+// collectViolations walks the AST and records unguarded deep dereferences rooted
+// at an unsafe root. TestOnly (has()) selects are skipped so that the guards
+// themselves are never flagged.
+func collectViolations(e *expr.Expr, guarded map[string]bool, violations map[string]bool) {
+	if e == nil {
+		return
+	}
+
+	switch k := e.ExprKind.(type) {
+	case *expr.Expr_SelectExpr:
+		sel := k.SelectExpr
+		if sel.GetTestOnly() {
+			// Do not descend into has() subtrees — those are guards, not reads.
+			return
+		}
+		if p := selectPath(e); p != "" {
+			if isUnsafeDeepPath(p) && !guarded[p] {
+				violations[p] = true
+			}
+		}
+		collectViolations(sel.GetOperand(), guarded, violations)
+
+	case *expr.Expr_CallExpr:
+		call := k.CallExpr
+		collectViolations(call.GetTarget(), guarded, violations)
+		for _, arg := range call.GetArgs() {
+			collectViolations(arg, guarded, violations)
+		}
+
+	case *expr.Expr_ListExpr:
+		for _, elem := range k.ListExpr.GetElements() {
+			collectViolations(elem, guarded, violations)
+		}
+
+	case *expr.Expr_StructExpr:
+		for _, entry := range k.StructExpr.GetEntries() {
+			collectViolations(entry.GetValue(), guarded, violations)
+		}
+
+	case *expr.Expr_ComprehensionExpr:
+		comp := k.ComprehensionExpr
+		collectViolations(comp.GetIterRange(), guarded, violations)
+		collectViolations(comp.GetAccuInit(), guarded, violations)
+		collectViolations(comp.GetLoopCondition(), guarded, violations)
+		collectViolations(comp.GetLoopStep(), guarded, violations)
+		collectViolations(comp.GetResult(), guarded, violations)
+	}
+}
+
+// isUnsafeDeepPath reports whether path is a dereference of an unsafe root with
+// at least one field beyond the root (e.g. audit.responseObject.metadata). Bare
+// roots (audit.responseObject) are safe because they are defaulted.
+func isUnsafeDeepPath(path string) bool {
+	for _, root := range guardedDerefRoots {
+		if strings.HasPrefix(path, root+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// selectPath builds the dot-path for a Select chain rooted at an identifier.
+// Returns "" when the chain is not a pure ident/select path (e.g. it indexes
+// into a call result), meaning it cannot be statically resolved and is skipped.
+func selectPath(e *expr.Expr) string {
+	if e == nil {
+		return ""
+	}
+
+	switch k := e.ExprKind.(type) {
+	case *expr.Expr_IdentExpr:
+		return k.IdentExpr.GetName()
+
+	case *expr.Expr_SelectExpr:
+		sel := k.SelectExpr
+		parent := selectPath(sel.GetOperand())
+		if parent == "" {
+			return ""
+		}
+		return parent + "." + sel.GetField()
+
+	default:
+		return ""
+	}
+}

--- a/internal/cel/responseobject_guard_test.go
+++ b/internal/cel/responseobject_guard_test.go
@@ -1,0 +1,138 @@
+package cel
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateGuardedDerefs_Match covers unguarded deep dereferences of
+// audit.responseObject / audit.requestObject in match expressions (issue #214).
+func TestValidateGuardedDerefs_Match(t *testing.T) {
+	tests := []struct {
+		name        string
+		expression  string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "VIOLATION: unguarded responseObject deep deref",
+			expression:  "audit.responseObject.spec.foo == 'x'",
+			wantErr:     true,
+			errContains: "unguarded dereference of \"audit.responseObject.spec.foo\"",
+		},
+		{
+			name:        "VIOLATION: root-only guard is insufficient",
+			expression:  "(has(audit.responseObject) ? audit.responseObject.metadata.name : '') == 'x'",
+			wantErr:     true,
+			errContains: "unguarded dereference of \"audit.responseObject.metadata.name\"",
+		},
+		{
+			name:        "VIOLATION: requestObject deep deref unguarded",
+			expression:  "audit.requestObject.spec.replicas == 3",
+			wantErr:     true,
+			errContains: "unguarded dereference of \"audit.requestObject.spec.replicas\"",
+		},
+		{
+			name:       "OK: fully guarded responseObject deref",
+			expression: "(has(audit.responseObject.metadata) && has(audit.responseObject.metadata.name) ? audit.responseObject.metadata.name : '') == 'x'",
+			wantErr:    false,
+		},
+		{
+			name:       "OK: different root objectRef",
+			expression: "audit.objectRef.name == 'foo'",
+			wantErr:    false,
+		},
+		{
+			name:       "OK: responseStatus code gate",
+			expression: "audit.responseStatus.code < 300",
+			wantErr:    false,
+		},
+		{
+			name:       "OK: bare has(audit.responseObject)",
+			expression: "has(audit.responseObject)",
+			wantErr:    false,
+		},
+		{
+			name:       "OK: bare audit.responseObject root read",
+			expression: "audit.responseObject == {}",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePolicyExpression(tt.expression, MatchExpression, AuditRule)
+			checkErr(t, err, tt.wantErr, tt.errContains)
+		})
+	}
+}
+
+// TestValidateGuardedDerefs_Summary covers the same rule for embedded {{ }} CEL
+// in summary templates, including the exact #215/#212 bug.
+func TestValidateGuardedDerefs_Summary(t *testing.T) {
+	tests := []struct {
+		name        string
+		expression  string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "VIOLATION: link with unguarded responseObject.metadata.name (#215/#212)",
+			expression:  "{{ link(audit.responseObject.metadata.name, audit.objectRef) }}",
+			wantErr:     true,
+			errContains: "unguarded dereference of \"audit.responseObject.metadata.name\"",
+		},
+		{
+			name:       "OK: guarded deref in summary",
+			expression: "{{ has(audit.responseObject.metadata) && has(audit.responseObject.metadata.name) ? audit.responseObject.metadata.name : '' }}",
+			wantErr:    false,
+		},
+		{
+			name:       "OK: objectRef.name in summary",
+			expression: "{{ link(audit.objectRef.name, audit.objectRef) }}",
+			wantErr:    false,
+		},
+		{
+			name:       "OK: static summary, no deref",
+			expression: "{{ actor }} created {{ kind }}",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePolicyExpression(tt.expression, SummaryExpression, AuditRule)
+			checkErr(t, err, tt.wantErr, tt.errContains)
+		})
+	}
+}
+
+// TestValidateGuardedDerefs_DeepestOnly verifies that only the deepest violating
+// path is reported per chain to keep errors actionable.
+func TestValidateGuardedDerefs_DeepestOnly(t *testing.T) {
+	err := ValidatePolicyExpression("audit.responseObject.metadata.name == 'x'", MatchExpression, AuditRule)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "audit.responseObject.metadata.name") {
+		t.Errorf("expected deepest path in error, got %q", err.Error())
+	}
+	// The intermediate path should not be reported as its own violation.
+	if strings.Contains(err.Error(), "of \"audit.responseObject.metadata\":") {
+		t.Errorf("intermediate path should not be reported separately: %q", err.Error())
+	}
+}
+
+func checkErr(t *testing.T, err error, wantErr bool, errContains string) {
+	t.Helper()
+	if wantErr {
+		if err == nil {
+			t.Fatalf("expected error containing %q, got nil", errContains)
+		}
+		if errContains != "" && !strings.Contains(err.Error(), errContains) {
+			t.Errorf("expected error containing %q, got %q", errContains, err.Error())
+		}
+	} else if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Systematic fix for the unguarded-`responseObject`-deref DLQ-leak class

Closes #214 (the systemic gate). This is **one fix for a class of bugs**, not a single policy patch — it prevents every future instance of the failure first seen in #212 and recurring in #215.

### The class of bug

An ActivityPolicy `match`/`summary` CEL expression that dereferences a deep path into `audit.responseObject` or `audit.requestObject` — e.g. `link(audit.responseObject.metadata.name, ...)` — throws `no such key` at runtime whenever the response is **not** a 2xx. On a 403/409/422/admission-deny the apiserver returns a `metav1.Status`, not the named object (and absent roots are defaulted to empty maps). The event is routed to the DLQ, retries fail identically → the steady `DLQSlowLeak`.

Concrete instances this would have stopped at apply time:
- #212 — `gateway.networking.k8s.io-gateway`
- #215 — `resourcemanager.miloapis.com-project`, `networking.datumapis.com-connector`
- Same latent pattern previously fixed by hand in sibling repos (NSO #230, milo #672, billing #69).

### Why existing validation missed it

`audit` is typed `map(string, dyn)` (`internal/cel/environment.go`), so `env.Compile()` accepts `audit.responseObject.metadata.name` with no error. `ValidatePolicyExpression` was compile-based — the failure is a runtime `no such key` on a specific event shape, not a type/syntax error. **Detection has to be structural (AST), not compile.**

### What this PR does

New `ValidateGuardedDerefs(ast *cel.Ast)` (`internal/cel/responseobject_guard.go`): a two-pass walk over the CEL protobuf AST.
1. Collect every `has()`-guarded path (`SelectExpr` with `TestOnly == true`).
2. Flag any normal read (`TestOnly == false`) rooted at `audit.responseObject`/`audit.requestObject`, one or more levels deep, whose full dot-path is **not** in the guarded set. Reports the deepest path per chain for actionable errors.

`has(audit.responseObject)` alone does **not** satisfy it — the root is always present (defaulted), so guarding only the root is meaningless. Each indexed level must be `has()`-guarded, e.g.:

```
has(audit.responseObject.metadata) && has(audit.responseObject.metadata.name)
  ? audit.responseObject.metadata.name : ""
```

…or gate on `audit.responseStatus.code < 300`, or use a field present regardless of outcome like `audit.objectRef.name`. The error message spells these out.

Wired into `ValidatePolicyExpression` (`internal/cel/policy.go`) for both `match` and each `{{ }}` summary block, so **both** enforcement layers inherit it:
- **Aggregated apiserver REST strategy** (`internal/registry/activity/policy/strategy.go`) — rejects bad specs **at apply**, including orphan CRs applied directly to a control plane (the #214 primary concern). No separate admission webhook needed: ActivityPolicy is served by our aggregated apiserver, whose strategy `Validate` *is* the admission point.
- **Controller** (`internal/controller/activitypolicy_controller.go`) — surfaces a status condition on reconcile.

Validation only — runtime defaulting/evaluation unchanged.

### Tests

`internal/cel/responseobject_guard_test.go`, table-driven:
- VIOLATION: `link(audit.responseObject.metadata.name, ...)` (the #215/#212 bug), unguarded `responseObject.spec`, `requestObject` deep deref, and root-only `has(audit.responseObject) ? ...metadata.name` (still rejected).
- OK: fully has()-guarded deref, `audit.objectRef.name`, `audit.responseStatus.code < 300`, bare `has(audit.responseObject)`, bare root read.

`go build ./...`, `go test ./internal/cel/...`, and `./internal/controller/... ./internal/registry/...` all pass. No existing ActivityPolicy manifest in `config/`/`examples/`/`docs/` is rejected by the new check.

### Known limitation

Bracket-index access (`audit.responseObject["metadata"]`) is a `_[_]` call expr, not a select, so it isn't statically resolved or flagged. The observed/dot-path pattern is fully covered. Tracked as follow-up if needed.

### Not in scope

The independent NATS-layer DLQ-retry bug (#216, `totalSucceeded: 0`, `filtered consumer not unique on workqueue stream`) is unrelated to CEL and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)