### PR TITLE
fix: convert timestamps to UTC before formatting (#221)

### DIFF
--- a/pkg/cmd/audit.go
+++ b/pkg/cmd/audit.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -379,9 +380,9 @@ func eventsToRows(events []auditv1.Event) []metav1.TableRow {
 	for i := range events {
 		timestamp := "<unknown>"
 		if !events[i].StageTimestamp.IsZero() {
-			timestamp = events[i].StageTimestamp.Format("2006-01-02T15:04:05Z")
+			timestamp = events[i].StageTimestamp.UTC().Format(time.RFC3339)
 		} else if !events[i].RequestReceivedTimestamp.IsZero() {
-			timestamp = events[i].RequestReceivedTimestamp.Format("2006-01-02T15:04:05Z")
+			timestamp = events[i].RequestReceivedTimestamp.UTC().Format(time.RFC3339)
 		}
 		verb := events[i].Verb
 		username := events[i].User.Username

--- a/pkg/cmd/audit_test.go
+++ b/pkg/cmd/audit_test.go
@@ -387,6 +387,29 @@ func TestEventsToRows(t *testing.T) {
 			},
 		},
 		{
+			name: "non-UTC timestamp converted to UTC for output",
+			events: []auditv1.Event{
+				{
+					Verb:           "delete",
+					StageTimestamp: metav1.NewMicroTime(time.Date(2026, 2, 21, 15, 30, 0, 0, time.FixedZone("AEST", 10*60*60))),
+					User: authnv1.UserInfo{
+						Username: "alice@example.com",
+					},
+					ObjectRef: &auditv1.ObjectReference{
+						Namespace: "production",
+						Resource:  "secrets",
+						Name:      "db-password",
+					},
+					ResponseStatus: &metav1.Status{
+						Code: 200,
+					},
+				},
+			},
+			wantCells: [][]interface{}{
+				{"2026-02-21T05:30:00Z", "delete", "alice@example.com", "production/secrets/db-password", "200"},
+			},
+		},
+		{
 			name: "event without response status",
 			events: []auditv1.Event{
 				{

--- a/pkg/cmd/events.go
+++ b/pkg/cmd/events.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	eventsv1 "k8s.io/api/events/v1"
@@ -398,7 +399,7 @@ func kubeEventsToRows(events []activityv1alpha1.EventRecord) []metav1.TableRow {
 
 		lastSeen := ""
 		if !ev.EventTime.IsZero() {
-			lastSeen = ev.EventTime.Format("2006-01-02T15:04:05Z")
+			lastSeen = ev.EventTime.UTC().Format(time.RFC3339)
 		}
 
 		eventType := ev.Type

--- a/pkg/cmd/events_test.go
+++ b/pkg/cmd/events_test.go
@@ -382,6 +382,19 @@ func TestKubeEventsToRows(t *testing.T) {
 			},
 		},
 		{
+			name: "non-UTC timestamp converted to UTC for output",
+			events: []activityv1alpha1.EventRecord{
+				makeEventRecord(metav1.NewMicroTime(time.Date(2026, 2, 21, 15, 30, 0, 0, time.FixedZone("EST", -5*60*60))), "Warning", "FailedMount", corev1.ObjectReference{
+					Kind:      "Pod",
+					Name:      "my-pod",
+					Namespace: "production",
+				}, "Unable to mount volume"),
+			},
+			wantCells: [][]interface{}{
+				{"2026-02-21T20:30:00Z", "Warning", "FailedMount", "production/Pod/my-pod", "Unable to mount volume"},
+			},
+		},
+		{
 			name: "event with long message truncated",
 			events: []activityv1alpha1.EventRecord{
 				makeEventRecord(now, "Warning", "LongMessage", corev1.ObjectReference{

--- a/pkg/cmd/feed.go
+++ b/pkg/cmd/feed.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -523,7 +524,7 @@ func activitiesToTable(activities []activityv1alpha1.Activity) *metav1.Table {
 func activitiesToRows(activities []activityv1alpha1.Activity) []metav1.TableRow {
 	rows := make([]metav1.TableRow, 0, len(activities))
 	for i := range activities {
-		timestamp := activities[i].CreationTimestamp.Format("2006-01-02T15:04:05Z")
+		timestamp := activities[i].CreationTimestamp.UTC().Format(time.RFC3339)
 		actor := activities[i].Spec.Actor.Name
 		source := activities[i].Spec.ChangeSource
 		summary := activities[i].Spec.Summary

--- a/pkg/cmd/feed_test.go
+++ b/pkg/cmd/feed_test.go
@@ -534,6 +534,26 @@ func TestActivitiesToRows(t *testing.T) {
 			},
 		},
 		{
+			name: "non-UTC timestamp converted to UTC for output",
+			activities: []activityv1alpha1.Activity{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(time.Date(2026, 2, 21, 15, 30, 0, 0, time.FixedZone("AEST", 10*60*60))),
+					},
+					Spec: activityv1alpha1.ActivitySpec{
+						Actor: activityv1alpha1.ActivityActor{
+							Name: "admin",
+						},
+						ChangeSource: "human",
+						Summary:      "created namespace prod",
+					},
+				},
+			},
+			wantCells: [][]interface{}{
+				{"2026-02-21T05:30:00Z", "admin", "human", "created namespace prod"},
+			},
+		},
+		{
 			name: "long summary truncated",
 			activities: []activityv1alpha1.Activity{
 				{

--- a/pkg/cmd/reindexjob/reindexjob.go
+++ b/pkg/cmd/reindexjob/reindexjob.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -485,10 +486,10 @@ func (o *StatusOptions) printDetail(job *activityv1alpha1.ReindexJob) error {
 	if job.Status.StartedAt != nil || job.Status.CompletedAt != nil {
 		fmt.Fprintf(o.Out, "\nTimestamps:\n")
 		if job.Status.StartedAt != nil {
-			fmt.Fprintf(o.Out, "  Started:   %s\n", job.Status.StartedAt.Format("2006-01-02T15:04:05Z"))
+			fmt.Fprintf(o.Out, "  Started:   %s\n", 		job.Status.StartedAt.UTC().Format(time.RFC3339))
 		}
 		if job.Status.CompletedAt != nil {
-			fmt.Fprintf(o.Out, "  Completed: %s\n", job.Status.CompletedAt.Format("2006-01-02T15:04:05Z"))
+			fmt.Fprintf(o.Out, "  Completed: %s\n", 		job.Status.CompletedAt.UTC().Format(time.RFC3339))
 		}
 	}
 
@@ -636,12 +637,12 @@ func reindexJobsToRows(jobs []activityv1alpha1.ReindexJob) []metav1.TableRow {
 
 		started := ""
 		if job.Status.StartedAt != nil {
-			started = job.Status.StartedAt.Format("2006-01-02T15:04:05Z")
+			started = 		job.Status.StartedAt.UTC().Format(time.RFC3339)
 		}
 
 		completed := ""
 		if job.Status.CompletedAt != nil {
-			completed = job.Status.CompletedAt.Format("2006-01-02T15:04:05Z")
+			completed = 		job.Status.CompletedAt.UTC().Format(time.RFC3339)
 		}
 
 		row := metav1.TableRow{

--- a/pkg/mcp/tools/tools.go
+++ b/pkg/mcp/tools/tools.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -389,7 +390,7 @@ func (p *ToolProvider) handleQueryActivities(ctx context.Context, req *mcp.CallT
 				"name":      activity.Spec.Resource.Name,
 				"namespace": activity.Spec.Resource.Namespace,
 			},
-			"timestamp": activity.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
+			"timestamp": activity.CreationTimestamp.UTC().Format(time.RFC3339),
 		}
 		activities = append(activities, activityMap)
 	}
@@ -586,7 +587,7 @@ func (p *ToolProvider) handleFindFailedOperations(ctx context.Context, req *mcp.
 		statusCodeCounts[code]++
 
 		failure := map[string]any{
-			"timestamp":  event.RequestReceivedTimestamp.Format("2006-01-02T15:04:05Z"),
+			"timestamp":  event.RequestReceivedTimestamp.UTC().Format(time.RFC3339),
 			"user":       event.User.Username,
 			"verb":       event.Verb,
 			"resource":   event.ObjectRef.Resource,
@@ -688,10 +689,10 @@ func (p *ToolProvider) handleGetResourceHistory(ctx context.Context, req *mcp.Ca
 		}
 
 		entry := map[string]any{
-			"timestamp":    activity.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
-			"actor":        activity.Spec.Actor.Name,
-			"summary":      activity.Spec.Summary,
-			"changeSource": activity.Spec.ChangeSource,
+		"timestamp":    activity.CreationTimestamp.UTC().Format(time.RFC3339),
+		"actor":        activity.Spec.Actor.Name,
+		"summary":      activity.Spec.Summary,
+		"changeSource": activity.Spec.ChangeSource,
 		}
 
 		history = append(history, entry)
@@ -788,7 +789,7 @@ func (p *ToolProvider) handleGetUserActivitySummary(ctx context.Context, req *mc
 
 		if args.IncludeDetails && i < 20 {
 			recentActivities = append(recentActivities, map[string]any{
-				"timestamp":    activity.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
+				"timestamp":    activity.CreationTimestamp.UTC().Format(time.RFC3339),
 				"summary":      activity.Spec.Summary,
 				"changeSource": activity.Spec.ChangeSource,
 				"resource": map[string]any{
@@ -1423,9 +1424,9 @@ func (p *ToolProvider) handleQueryEvents(ctx context.Context, req *mcp.CallToolR
 
 		// eventsv1 uses EventTime, or Series.LastObservedTime for recurring events
 		if event.Series != nil && !event.Series.LastObservedTime.IsZero() {
-			eventMap["timestamp"] = event.Series.LastObservedTime.Format("2006-01-02T15:04:05Z")
+			eventMap["timestamp"] = event.Series.LastObservedTime.UTC().Format(time.RFC3339)
 		} else if !event.EventTime.IsZero() {
-			eventMap["timestamp"] = event.EventTime.Format("2006-01-02T15:04:05Z")
+			eventMap["timestamp"] = event.EventTime.UTC().Format(time.RFC3339)
 		}
 
 		events = append(events, eventMap)


### PR DESCRIPTION
Closes #221

## Summary

- Each timestamp used `Format("2006-01-02T15:04:05Z")`. In Go this treats the trailing `Z` as a literal character, not a zone verb, so the output shows the local clock time regardless of timezone.
- `metav1.Time` and `metav1.MicroTime` store times in the local zone after JSON decoding (`UnmarshalJSON` calls `.Local()`), so the formatted output shows the wrong day/clock time while still printing `Z`.
- The fix converts to UTC first, then formats with `time.RFC3339`, which correctly emits `Z` only when the time is UTC.

## Changes

- **`ef1f5f9` test**: Add non-UTC timestamp test cases to `TestActivitiesToRows`, `TestEventsToRows`, and `TestKubeEventsToRows` that expect the correct UTC instant. These tests fail before the fix and pass after.
- **`70c8a18` fix**: Replace all 14 occurrences of `Format("2006-01-02T15:04:05Z")` with `.UTC().Format(time.RFC3339)` across 5 files in `pkg/cmd/`, `pkg/cmd/reindexjob/`, and `pkg/mcp/tools/`.