### PR TITLE
fix: name the SRE team by its current name

### DIFF
--- a/config/components/observability/alerts/dlq-alerts.yaml
+++ b/config/components/observability/alerts/dlq-alerts.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   groups:
     # =========================================================================
-    # DLQ Health Alerts - Platform SRE Ownership
+    # DLQ Health Alerts - SRE Ownership
     # =========================================================================
     - name: dlq-health
       interval: 30s
@@ -25,7 +25,7 @@ spec:
           labels:
             severity: warning
             component: activity-processor
-            team: platform-sre
+            team: sre
           annotations:
             summary: "DLQ is growing - messages not being processed"
             description: "DLQ is receiving {{ $value }} events/sec for 15+ minutes. Events are failing processing faster than retry can handle."
@@ -39,7 +39,7 @@ spec:
           labels:
             severity: warning
             component: activity-processor
-            team: platform-sre
+            team: sre
           annotations:
             summary: "Failed to publish events to DLQ"
             description: "{{ $value }} DLQ publish errors/sec. Events may be lost entirely."
@@ -54,7 +54,7 @@ spec:
           labels:
             severity: warning
             component: activity-processor
-            team: platform-sre
+            team: sre
           annotations:
             summary: "DLQ events with excessive retry attempts"
             description: "{{ $value }} events have exceeded the high retry threshold for {{ $labels.api_group }}/{{ $labels.kind }}."
@@ -69,7 +69,7 @@ spec:
           labels:
             severity: warning
             component: activity-processor
-            team: platform-sre
+            team: sre
           annotations:
             summary: "DLQ receiving events at a slow but steady rate"
             description: "{{ $value }} events sent to DLQ in the last 6 hours. A policy may be failing for specific event shapes."
@@ -94,7 +94,7 @@ spec:
           labels:
             severity: warning
             component: activity-processor
-            team: platform-sre
+            team: sre
           annotations:
             summary: "DLQ retry success rate is low"
             description: "{{ $value | humanizePercentage }} of retry attempts are failing. Events not recovering after retry."


### PR DESCRIPTION
Five dead-letter queue alerts name an owning team that no longer goes by that name.

They read as owned while matching nothing the alerting standard recognises, so anything they raise routes to nobody.

This renames the label to the team's current name, and the banner above the rules with it, from the ownership audit in datum-cloud/infra#3974

## Test plan

- [x] All five alerts render with the current team name, and no reference to the former name remains
- [x] The component builds and the rule file parses
- [x] No other alert, label, annotation or expression changed
- [ ] After release, production shows the new label on all five
